### PR TITLE
Require acknowledgment for late submissions

### DIFF
--- a/api/submission/submit.go
+++ b/api/submission/submit.go
@@ -10,7 +10,7 @@ import (
 type SubmitRequest struct {
     core.APIRequestAssignmentContext
     core.MinRoleStudent
-    LateAcknowledgment *bool `json:"late-acknowledgment"`
+    LateAcknowledgment bool `json:"late-acknowledgment"`
     Files core.POSTFiles
 
     Message string `json:"message"`
@@ -28,7 +28,7 @@ type SubmitResponse struct {
 func HandleSubmit(request *SubmitRequest) (*SubmitResponse, *core.APIError) {
     response := SubmitResponse{};
 
-    result, reject, err := grader.GradeDefault(request.Assignment, request.Files.TempDir, request.User.Email, request.Message);
+    result, reject, err := grader.GradeDefault(request.Assignment, request.Files.TempDir, request.User.Email, request.Message, request.LateAcknowledgment);
     if (err != nil) {
         stdout := "";
         stderr := "";

--- a/api/submission/submit.go
+++ b/api/submission/submit.go
@@ -52,6 +52,7 @@ func HandleSubmit(request *SubmitRequest) (*SubmitResponse, *core.APIError) {
         if _, ok := reject.(*grader.RejectMissingLateAcknowledgment); ok {
             response.RequireLateAcknowledgment = true;
         }
+        
         return &response, nil;
     }
 

--- a/api/submission/submit.go
+++ b/api/submission/submit.go
@@ -10,10 +10,10 @@ import (
 type SubmitRequest struct {
     core.APIRequestAssignmentContext
     core.MinRoleStudent
-    LateAcknowledgment bool `json:"late-acknowledgment"`
     Files core.POSTFiles
-
+    
     Message string `json:"message"`
+    LateAcknowledgment bool `json:"late-acknowledgment"`
 }
 
 type SubmitResponse struct {

--- a/cmd/grade/main.go
+++ b/cmd/grade/main.go
@@ -21,6 +21,7 @@ var args struct {
     User string `help:"User email for the submission." default:"testuser"`
     Message string `help:"Submission message." default:""`
     CheckRejection bool `help:"Check if this submission should be rejected (bypassed by default)." default:"false"`
+    LateAcknowledgment bool `help:"Acknowledge that the late penalty will be applied by making a submission." default:"false"`
 }
 
 func main() {
@@ -38,7 +39,7 @@ func main() {
 
     assignment := db.MustGetAssignment(args.Course, args.Assignment);
 
-    result, reject, err := grader.Grade(assignment, args.Submission, args.User, args.Message, args.CheckRejection, grader.GetDefaultGradeOptions());
+    result, reject, err := grader.Grade(assignment, args.Submission, args.User, args.Message, args.CheckRejection, args.LateAcknowledgment, grader.GetDefaultGradeOptions());
     if (err != nil) {
         if ((result != nil) && result.HasTextOutput()) {
             fmt.Println("Grading failed, but output was recovered:");

--- a/grader/grade.go
+++ b/grader/grade.go
@@ -27,9 +27,9 @@ func GetDefaultGradeOptions() GradeOptions {
 }
 
 // Grade with default options pulled from config.
-func GradeDefault(assignment *model.Assignment, submissionPath string, user string, message string) (
+func GradeDefault(assignment *model.Assignment, submissionPath string, user string, message string, lateAcknowledgment bool) (
         *model.GradingResult, RejectReason, error) {
-    return Grade(assignment, submissionPath, user, message, true, false, GetDefaultGradeOptions());
+    return Grade(assignment, submissionPath, user, message, true, lateAcknowledgment, GetDefaultGradeOptions());
 }
 
 // Grade with custom options.

--- a/grader/grade.go
+++ b/grader/grade.go
@@ -29,14 +29,14 @@ func GetDefaultGradeOptions() GradeOptions {
 // Grade with default options pulled from config.
 func GradeDefault(assignment *model.Assignment, submissionPath string, user string, message string) (
         *model.GradingResult, RejectReason, error) {
-    return Grade(assignment, submissionPath, user, message, true, GetDefaultGradeOptions());
+    return Grade(assignment, submissionPath, user, message, true, false, GetDefaultGradeOptions());
 }
 
 // Grade with custom options.
-func Grade(assignment *model.Assignment, submissionPath string, user string, message string, checkRejection bool, options GradeOptions) (
+func Grade(assignment *model.Assignment, submissionPath string, user string, message string, checkRejection bool, lateAcknowledgment bool, options GradeOptions) (
         *model.GradingResult, RejectReason, error) {
     if (checkRejection) {
-        reject, err := checkForRejection(assignment, submissionPath, user, message);
+        reject, err := checkForRejection(assignment, submissionPath, user, message, lateAcknowledgment);
         if (err != nil) {
             return nil, nil, fmt.Errorf("Failed to check for rejection: '%w'.", err);
         }

--- a/grader/grade_test.go
+++ b/grader/grade_test.go
@@ -73,7 +73,7 @@ func runSubmissionTests(test *testing.T, parallel bool, useDocker bool) {
                 test.Parallel();
             }
 
-            result, reject, err := Grade(testSubmission.Assignment, testSubmission.Dir, user, TEST_MESSAGE, false, gradeOptions);
+            result, reject, err := Grade(testSubmission.Assignment, testSubmission.Dir, user, TEST_MESSAGE, false, true, gradeOptions);
             if (err != nil) {
                 if (result != nil) {
                     fmt.Println("--- stdout ---");

--- a/grader/reject.go
+++ b/grader/reject.go
@@ -144,7 +144,7 @@ func checkLateAcknowledgment(assignment *model.Assignment, lateAcknowledgment bo
 
     policy := assignment.GetLatePolicy()
     
-    if policy.Type == model.EmptyPolicy {
+    if policy.Type == model.EmptyPolicy || policy.Type == model.BaselinePolicy {
         return nil, nil
     }
 

--- a/grader/reject.go
+++ b/grader/reject.go
@@ -45,9 +45,9 @@ func (this *RejectMissingLateAcknowledgment) String() string {
 }
 
 func checkForRejection(assignment *model.Assignment, submissionPath string, user string, message string, lateAcknowledgment bool) (RejectReason, error) {
-    reject := checkLateAcknowledgment(assignment, lateAcknowledgment)
-    if reject != nil {
-        return reject, nil
+    reject, err := checkLateAcknowledgment(assignment, lateAcknowledgment)
+    if reject != nil || err != nil {
+        return reject, err
     }
     return checkSubmissionLimit(assignment, user);
 }
@@ -136,27 +136,27 @@ func checkSubmissionLimitWindow(window *model.SubmittionLimitWindow,
     return nil, nil;
 }
 
-func checkLateAcknowledgment(assignment *model.Assignment, lateAcknowledgment bool) RejectReason {
+func checkLateAcknowledgment(assignment *model.Assignment, lateAcknowledgment bool) (RejectReason, error) {
     // If the user acknowledges that they are submitting late, do not reject the submission.
     if lateAcknowledgment {
-        return nil
+        return nil, nil
     }
 
     policy := assignment.GetLatePolicy()
     
     if policy.Type == model.EmptyPolicy || policy.Type == model.BaselinePolicy {
-        return nil
+        return nil, nil
     }
 
     dueDate := assignment.DueDate
 
     if dueDate.IsZero() {
-        return nil
+        return nil, nil
     }
 
     if common.NowTimestamp() >= dueDate {
-        return &RejectMissingLateAcknowledgment{}
+        return &RejectMissingLateAcknowledgment{}, nil
     }
 
-    return nil
+    return nil, nil
 }

--- a/grader/reject.go
+++ b/grader/reject.go
@@ -154,7 +154,13 @@ func checkLateAcknowledgment(assignment *model.Assignment, lateAcknowledgment bo
         return nil, nil
     }
 
-    if common.NowTimestamp() >= dueDate {
+    dueDateTime, err := dueDate.Time()
+
+    if err != nil {
+        return nil, err
+    }
+
+    if time.Now().After(dueDateTime) {
         return &RejectMissingLateAcknowledgment{}, nil
     }
 

--- a/grader/reject.go
+++ b/grader/reject.go
@@ -137,7 +137,7 @@ func checkSubmissionLimitWindow(window *model.SubmittionLimitWindow,
 }
 
 func checkLateAcknowledgment(assignment *model.Assignment, lateAcknowledgment bool) RejectReason {
-    // if the user acknowledges that they are submitting late, do not reject the submission
+    // If the user acknowledges that they are submitting late, do not reject the submission.
     if lateAcknowledgment {
         return nil
     }

--- a/grader/reject.go
+++ b/grader/reject.go
@@ -45,9 +45,9 @@ func (this *RejectMissingLateAcknowledgment) String() string {
 }
 
 func checkForRejection(assignment *model.Assignment, submissionPath string, user string, message string, lateAcknowledgment bool) (RejectReason, error) {
-    reject, err := checkLateAcknowledgment(assignment, lateAcknowledgment)
-    if reject != nil || err != nil {
-        return reject, err
+    reject := checkLateAcknowledgment(assignment, lateAcknowledgment)
+    if reject != nil {
+        return reject, nil
     }
     return checkSubmissionLimit(assignment, user);
 }
@@ -136,27 +136,27 @@ func checkSubmissionLimitWindow(window *model.SubmittionLimitWindow,
     return nil, nil;
 }
 
-func checkLateAcknowledgment(assignment *model.Assignment, lateAcknowledgment bool) (RejectReason, error) {
+func checkLateAcknowledgment(assignment *model.Assignment, lateAcknowledgment bool) RejectReason {
     // if the user acknowledges that they are submitting late, do not reject the submission
     if lateAcknowledgment {
-        return nil, nil
+        return nil
     }
 
     policy := assignment.GetLatePolicy()
     
     if policy.Type == model.EmptyPolicy || policy.Type == model.BaselinePolicy {
-        return nil, nil
+        return nil
     }
 
     dueDate := assignment.DueDate
 
     if dueDate.IsZero() {
-        return nil, nil
+        return nil
     }
 
     if common.NowTimestamp() >= dueDate {
-        return &RejectMissingLateAcknowledgment{}, nil
+        return &RejectMissingLateAcknowledgment{}
     }
 
-    return nil, nil
+    return nil
 }

--- a/grader/reject_test.go
+++ b/grader/reject_test.go
@@ -100,7 +100,7 @@ func submitForRejection(test *testing.T, assignment *model.Assignment, user stri
         test.Fatalf("Failed to validate submission limit: '%v'.", err);
     }
 
-    result, reject, err := GradeDefault(assignment, submissionPath, user, TEST_MESSAGE);
+    result, reject, err := GradeDefault(assignment, submissionPath, user, TEST_MESSAGE, true);
     if (err != nil) {
         test.Fatalf("Failed to grade assignment: '%v'.", err);
     }

--- a/grader/reject_test.go
+++ b/grader/reject_test.go
@@ -1,15 +1,15 @@
 package grader
 
 import (
-	"path/filepath"
-	"reflect"
-	"testing"
-	"time"
+    "path/filepath"
+    "reflect"
+    "testing"
+    "time"
 
-	"github.com/edulinq/autograder/common"
-	"github.com/edulinq/autograder/config"
-	"github.com/edulinq/autograder/db"
-	"github.com/edulinq/autograder/model"
+    "github.com/edulinq/autograder/common"
+    "github.com/edulinq/autograder/config"
+    "github.com/edulinq/autograder/db"
+    "github.com/edulinq/autograder/model"
 )
 
 var SUBMISSION_RELPATH string = filepath.Join("test-submissions", "solution");

--- a/grader/reject_test.go
+++ b/grader/reject_test.go
@@ -143,6 +143,17 @@ func TestRejectSubmissionLateAcknowledgmentNotOverdue(test *testing.T) {
     submitForRejection(test, assignment, "other@test.com", false, nil) // assignment is not overdue so can submit without acknowledgment
 }
 
+func TestRejectSubmissionLateAcknowledgmentNoDueDate(test *testing.T) {
+    db.ResetForTesting();
+    defer db.ResetForTesting();
+
+    assignment := db.MustGetTestAssignment();
+    assignment.SubmissionLimit = &model.SubmissionLimitInfo{};
+    assignment.LatePolicy = &model.LateGradingPolicy{Type: model.LateDays}
+
+    submitForRejection(test, assignment, "other@test.com", false, nil) // assignment does not have a due date
+}
+
 func submitForRejection(test *testing.T, assignment *model.Assignment, user string, lateAcknowledgment bool, expectedRejection RejectReason) (
         *model.GradingResult, RejectReason, error) {
     // Disable testing mode to check for rejection.

--- a/scoring/late.go
+++ b/scoring/late.go
@@ -333,23 +333,3 @@ func computeLateDays(dueDate time.Time, submissionTime time.Time) int {
 
     return int(math.Ceil(submissionTime.Sub(dueDate).Hours() / 24.0));
 }
-
-// Checks if late acknowledgment is necessary to accept a submission
-func RequireLateAcknowledgment(assignment *model.Assignment) bool {
-    policy := assignment.GetLatePolicy()
-
-    // Empty policy does not require an acknowledgment
-    if (policy.Type == model.EmptyPolicy) {
-        return false
-    }
-
-    dueDate := assignment.DueDate
-
-    // This assignment does not have a due date
-    if dueDate.IsZero() {
-        return false
-    }
-
-    // If the current timestamp is not smaller than the due date, the late policy will be applied
-    return common.NowTimestamp() >= dueDate
-}

--- a/scoring/late.go
+++ b/scoring/late.go
@@ -333,3 +333,23 @@ func computeLateDays(dueDate time.Time, submissionTime time.Time) int {
 
     return int(math.Ceil(submissionTime.Sub(dueDate).Hours() / 24.0));
 }
+
+// Checks if late acknowledgment is necessary to accept a submission
+func RequireLateAcknowledgment(assignment *model.Assignment) bool {
+    policy := assignment.GetLatePolicy()
+
+    // Empty policy does not require an acknowledgment
+    if (policy.Type == model.EmptyPolicy) {
+        return false
+    }
+
+    dueDate := assignment.DueDate
+
+    // This assignment does not have a due date
+    if dueDate.IsZero() {
+        return false
+    }
+
+    // If the current timestamp is not smaller than the due date, the late policy will be applied
+    return common.NowTimestamp() >= dueDate
+}


### PR DESCRIPTION
Note: please review this PR with https://github.com/edulinq/autograder-py/pull/12

Currently, students can make submissions to overdue assignments without any warnings/confirmations. Students may accidentally submit old assignments for various reasons (running the submit command in the wrong directory, reusing the old `config.json` file without changing the assignment ID, etc.), and it would be nice if we could prevent students from accidentally making submissions and getting late penalties.

This PR requires a _late acknowledgment_ when students submit late if there is a late penalty. The following summarizes the changes I made:

- The `submit` API receives `LateAcknowledgment`, which defaults to `false`
- If the assignment is overdue, the late policy is set, and `LateAcknowledgment` is `false`, we reject the submission with `RejectMissingLateAcknowledgment`
- If the submission is rejected with `RejectMissingLateAcknowledgment`, the `submit` API sets `RequireLateAcknowledgment` to `True`, indicating that the submission requires an acknowledgment to be accepted.
- The [CLI](https://github.com/edulinq/autograder-py/pull/12) checks `RequireLateAcknowledgment` in case of rejection, and if true, prompts the user if they acknowledge the fact that the late policy will be applied by making the submission.
- If the user selects "yes", the CLI makes a new submission with `LateAcknowledgment=true`. The server accepts the submission and applies the late policy.

[Here is the terminal recording of this feature](https://asciinema.org/a/kYgam99aqZpdwwiLDwQhVLfd1).
