### PR TITLE
Users/Auth: New API Endpoint

### DIFF
--- a/internal/api/users/auth.go
+++ b/internal/api/users/auth.go
@@ -13,8 +13,7 @@ type AuthResponse struct {
 }
 
 func HandleAuth(request *AuthRequest) (*AuthResponse, *core.APIError) {
-	response := AuthResponse{}
-	response.Success = true
+	response := AuthResponse{true}
 
 	return &response, nil
 }

--- a/internal/api/users/auth.go
+++ b/internal/api/users/auth.go
@@ -1,0 +1,20 @@
+package users
+
+import (
+	"github.com/edulinq/autograder/internal/api/core"
+)
+
+type AuthRequest struct {
+	core.APIRequestUserContext
+}
+
+type AuthResponse struct {
+	Success bool `json:"success"`
+}
+
+func HandleAuth(request *AuthRequest) (*AuthResponse, *core.APIError) {
+	response := AuthResponse{}
+	response.Success = true
+
+	return &response, nil
+}

--- a/internal/api/users/auth_test.go
+++ b/internal/api/users/auth_test.go
@@ -1,0 +1,55 @@
+package users
+
+import (
+	"testing"
+
+	"github.com/edulinq/autograder/internal/api/core"
+	"github.com/edulinq/autograder/internal/util"
+)
+
+func TestUsersAuth(test *testing.T) {
+	testCases := []struct {
+		email    string
+		pass     string
+		success  bool
+		expected AuthResponse
+	}{
+		// Test cases for correct authorization.
+		{"other@test.com", "other", true, AuthResponse{true}},
+		{"student@test.com", "student", true, AuthResponse{true}},
+		{"grader@test.com", "grader", true, AuthResponse{true}},
+		{"admin@test.com", "admin", true, AuthResponse{true}},
+		{"owner@test.com", "owner", true, AuthResponse{true}},
+
+		// Ensure we fail on bad passwords.
+		{"other@test.com", "ZZZ", false, AuthResponse{false}},
+		{"student@test.com", "ZZZ", false, AuthResponse{false}},
+		{"grader@test.com", "ZZZ", false, AuthResponse{false}},
+		{"admin@test.com", "ZZZ", false, AuthResponse{false}},
+		{"owner@test.com", "ZZZ", false, AuthResponse{false}},
+
+		// Check we cannot find invalid users.
+		{"ZZZ", "Z", false, AuthResponse{false}},
+	}
+
+	for i, testCase := range testCases {
+		fields := map[string]any{
+			"user-email": testCase.email,
+			"user-pass":  util.Sha256HexFromString(testCase.pass),
+		}
+
+		response := core.SendTestAPIRequest(test, core.NewEndpoint("users/auth"), fields)
+		if testCase.success != response.Success {
+			test.Errorf("Case %d: Unexpected result. Expected: '%t', actual: '%t'.", i, testCase.success, response.Success)
+			continue
+		}
+
+		var responseContent AuthResponse
+		util.MustJSONFromString(util.MustToJSON(response.Content), &responseContent)
+
+		if testCase.expected != responseContent {
+			test.Errorf("Case %d: Unexpected result. Expected: '%+v', actual: '%+v'.", i, testCase.expected, responseContent)
+			continue
+		}
+	}
+}

--- a/internal/api/users/auth_test.go
+++ b/internal/api/users/auth_test.go
@@ -11,25 +11,24 @@ func TestUsersAuth(test *testing.T) {
 	testCases := []struct {
 		email    string
 		pass     string
-		success  bool
-		expected AuthResponse
+		expected bool
 	}{
 		// Test cases for correct authorization.
-		{"other@test.com", "other", true, AuthResponse{true}},
-		{"student@test.com", "student", true, AuthResponse{true}},
-		{"grader@test.com", "grader", true, AuthResponse{true}},
-		{"admin@test.com", "admin", true, AuthResponse{true}},
-		{"owner@test.com", "owner", true, AuthResponse{true}},
+		{"other@test.com", "other", true},
+		{"student@test.com", "student", true},
+		{"grader@test.com", "grader", true},
+		{"admin@test.com", "admin", true},
+		{"owner@test.com", "owner", true},
 
 		// Ensure we fail on bad passwords.
-		{"other@test.com", "ZZZ", false, AuthResponse{false}},
-		{"student@test.com", "ZZZ", false, AuthResponse{false}},
-		{"grader@test.com", "ZZZ", false, AuthResponse{false}},
-		{"admin@test.com", "ZZZ", false, AuthResponse{false}},
-		{"owner@test.com", "ZZZ", false, AuthResponse{false}},
+		{"other@test.com", "ZZZ", false},
+		{"student@test.com", "ZZZ", false},
+		{"grader@test.com", "ZZZ", false},
+		{"admin@test.com", "ZZZ", false},
+		{"owner@test.com", "ZZZ", false},
 
 		// Check we cannot find invalid users.
-		{"ZZZ", "Z", false, AuthResponse{false}},
+		{"ZZZ", "Z", false},
 	}
 
 	for i, testCase := range testCases {
@@ -39,16 +38,16 @@ func TestUsersAuth(test *testing.T) {
 		}
 
 		response := core.SendTestAPIRequest(test, core.NewEndpoint("users/auth"), fields)
-		if testCase.success != response.Success {
-			test.Errorf("Case %d: Unexpected result. Expected: '%t', actual: '%t'.", i, testCase.success, response.Success)
+		if testCase.expected != response.Success {
+			test.Errorf("Case %d: Unexpected result. Expected: '%t', actual: '%t'.", i, testCase.expected, response.Success)
 			continue
 		}
 
 		var responseContent AuthResponse
 		util.MustJSONFromString(util.MustToJSON(response.Content), &responseContent)
 
-		if testCase.expected != responseContent {
-			test.Errorf("Case %d: Unexpected result. Expected: '%+v', actual: '%+v'.", i, testCase.expected, responseContent)
+		if testCase.expected != responseContent.Success {
+			test.Errorf("Case %d: Unexpected result. Expected: '%t', actual: '%t'.", i, testCase.expected, responseContent.Success)
 			continue
 		}
 	}

--- a/internal/api/users/routes.go
+++ b/internal/api/users/routes.go
@@ -7,6 +7,7 @@ import (
 )
 
 var routes []*core.Route = []*core.Route{
+	core.NewAPIRoute(core.NewEndpoint(`users/auth`), HandleAuth),
 	core.NewAPIRoute(core.NewEndpoint(`users/tokens/create`), HandleTokensCreate),
 }
 


### PR DESCRIPTION
Added a new API endpoint for users/auth. The endpoint allows anyone to verify that the email, password pairing successfully authenticates with the server through a no-op.