### PR TITLE
Moved the API endpoint for updating a course to its new location.

### DIFF
--- a/internal/api/admin/logs_fetch.go
+++ b/internal/api/admin/logs_fetch.go
@@ -34,7 +34,7 @@ func HandleFetchLogs(request *FetchLogsRequest) (*FetchLogsResponse, *core.APIEr
 	if parsedQuery.UserID != "" {
 		fullUser, err := db.GetCourseUser(request.Course, parsedQuery.UserID)
 		if err != nil {
-			return nil, core.NewInternalError("-205", &request.APIRequestCourseUserContext, "Failed to get target user.").
+			return nil, core.NewInternalError("-201", &request.APIRequestCourseUserContext, "Failed to get target user.").
 				Add("target-user", parsedQuery.UserID).Err(err)
 		}
 
@@ -53,7 +53,7 @@ func HandleFetchLogs(request *FetchLogsRequest) (*FetchLogsResponse, *core.APIEr
 	response.Records, err = db.GetLogRecords(parsedQuery.Level, parsedQuery.After,
 		request.Course.GetID(), parsedQuery.AssignmentID, parsedQuery.UserID)
 	if err != nil {
-		return nil, core.NewInternalError("-206", &request.APIRequestCourseUserContext, "Failed to get log records.").Err(err)
+		return nil, core.NewInternalError("-202", &request.APIRequestCourseUserContext, "Failed to get log records.").Err(err)
 	}
 
 	response.Success = true

--- a/internal/api/courses/admin/main_test.go
+++ b/internal/api/courses/admin/main_test.go
@@ -1,0 +1,12 @@
+package admin
+
+import (
+	"testing"
+
+	"github.com/edulinq/autograder/internal/api/core"
+)
+
+// Use the common main for all tests in this package.
+func TestMain(suite *testing.M) {
+	core.APITestingMain(suite, GetRoutes())
+}

--- a/internal/api/courses/admin/routes.go
+++ b/internal/api/courses/admin/routes.go
@@ -7,7 +7,7 @@ import (
 )
 
 var routes []*core.Route = []*core.Route{
-	core.NewAPIRoute(core.NewEndpoint(`admin/logs/fetch`), HandleFetchLogs),
+	core.NewAPIRoute(core.NewEndpoint(`courses/admin/update`), HandleUpdate),
 }
 
 func GetRoutes() *[]*core.Route {

--- a/internal/api/courses/admin/update.go
+++ b/internal/api/courses/admin/update.go
@@ -7,7 +7,7 @@ import (
 	"github.com/edulinq/autograder/internal/procedures/courses"
 )
 
-type UpdateCourseRequest struct {
+type UpdateRequest struct {
 	core.APIRequestCourseUserContext
 	core.MinCourseRoleAdmin
 
@@ -15,15 +15,15 @@ type UpdateCourseRequest struct {
 	Clear  bool   `json:"clear"`
 }
 
-type UpdateCourseResponse struct {
+type UpdateResponse struct {
 	CourseUpdated bool `json:"course-updated"`
 }
 
-func HandleUpdateCourse(request *UpdateCourseRequest) (*UpdateCourseResponse, *core.APIError) {
+func HandleUpdate(request *UpdateRequest) (*UpdateResponse, *core.APIError) {
 	if request.Clear {
 		err := db.ClearCourse(request.Course)
 		if err != nil {
-			return nil, core.NewInternalError("-201", &request.APIRequestCourseUserContext,
+			return nil, core.NewInternalError("-608", &request.APIRequestCourseUserContext,
 				"Failed to clear course.").Err(err)
 		}
 	}
@@ -31,7 +31,7 @@ func HandleUpdateCourse(request *UpdateCourseRequest) (*UpdateCourseResponse, *c
 	if request.Source != "" {
 		spec, err := common.ParseFileSpec(request.Source)
 		if err != nil {
-			return nil, core.NewBadCourseRequestError("-202", &request.APIRequestCourseUserContext,
+			return nil, core.NewBadCourseRequestError("-609", &request.APIRequestCourseUserContext,
 				"Source FileSpec is not formatted properly.").Err(err)
 		}
 
@@ -39,16 +39,16 @@ func HandleUpdateCourse(request *UpdateCourseRequest) (*UpdateCourseResponse, *c
 
 		err = db.SaveCourse(request.Course)
 		if err != nil {
-			return nil, core.NewInternalError("-203", &request.APIRequestCourseUserContext,
+			return nil, core.NewInternalError("-610", &request.APIRequestCourseUserContext,
 				"Failed to save course.").Err(err)
 		}
 	}
 
 	updated, err := courses.UpdateCourse(request.Course, true)
 	if err != nil {
-		return nil, core.NewInternalError("-204", &request.APIRequestCourseUserContext,
+		return nil, core.NewInternalError("-611", &request.APIRequestCourseUserContext,
 			"Failed to update course.").Err(err)
 	}
 
-	return &UpdateCourseResponse{updated}, nil
+	return &UpdateResponse{updated}, nil
 }

--- a/internal/api/courses/admin/update_test.go
+++ b/internal/api/courses/admin/update_test.go
@@ -9,8 +9,6 @@ import (
 )
 
 func TestUpdateCourse(test *testing.T) {
-	db.MustOpen()
-	defer db.MustClose()
 	// Remove a user and ensure the user is back after a reload.
 
 	// Leave the course in a good state after the test.

--- a/internal/api/courses/admin/update_test.go
+++ b/internal/api/courses/admin/update_test.go
@@ -9,9 +9,12 @@ import (
 )
 
 func TestUpdateCourse(test *testing.T) {
+	db.MustOpen()
+	defer db.MustClose()
 	// Remove a user and ensure the user is back after a reload.
 
 	// Leave the course in a good state after the test.
+	db.ResetForTesting()
 	defer db.ResetForTesting()
 
 	course := db.MustGetTestCourse()
@@ -48,7 +51,7 @@ func TestUpdateCourse(test *testing.T) {
 }
 
 func reloadRequest(test *testing.T) {
-	response := core.SendTestAPIRequest(test, core.NewEndpoint(`admin/update/course`), nil)
+	response := core.SendTestAPIRequest(test, core.NewEndpoint(`courses/admin/update`), nil)
 	if !response.Success {
 		test.Errorf("Response is not a success when it should be: '%v'.", response)
 	}

--- a/internal/api/courses/routes.go
+++ b/internal/api/courses/routes.go
@@ -1,0 +1,20 @@
+package courses
+
+// All routes handled by this package.
+
+import (
+	"github.com/edulinq/autograder/internal/api/core"
+	"github.com/edulinq/autograder/internal/api/courses/admin"
+	"github.com/edulinq/autograder/internal/api/courses/assignments"
+	"github.com/edulinq/autograder/internal/api/courses/assignments/submissions"
+)
+
+func GetRoutes() *[]*core.Route {
+	routes := make([]*core.Route, 0)
+
+	routes = append(routes, *(admin.GetRoutes())...)
+	routes = append(routes, *(assignments.GetRoutes())...)
+	routes = append(routes, *(submissions.GetRoutes())...)
+
+	return &routes
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -5,8 +5,7 @@ package api
 import (
 	"github.com/edulinq/autograder/internal/api/admin"
 	"github.com/edulinq/autograder/internal/api/core"
-	"github.com/edulinq/autograder/internal/api/courses/assignments"
-	"github.com/edulinq/autograder/internal/api/courses/assignments/submissions"
+	"github.com/edulinq/autograder/internal/api/courses"
 	"github.com/edulinq/autograder/internal/api/lms"
 	"github.com/edulinq/autograder/internal/api/users"
 )
@@ -25,9 +24,8 @@ func GetRoutes() *[]*core.Route {
 
 	routes = append(routes, baseRoutes...)
 	routes = append(routes, *(admin.GetRoutes())...)
-	routes = append(routes, *(assignments.GetRoutes())...)
+	routes = append(routes, *(courses.GetRoutes())...)
 	routes = append(routes, *(lms.GetRoutes())...)
-	routes = append(routes, *(submissions.GetRoutes())...)
 	routes = append(routes, *(users.GetRoutes())...)
 
 	return &routes

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -31,7 +31,7 @@ var (
 	EMAIL_USER = MustNewStringOption("email.user", "", "SMTP username for emails sent from the autograder.")
 
 	// Docker
-	DOCKER_DISABLE = MustNewBoolOption("docker.disable", false, "Disable the use of docker (usually for testing).")
+	DOCKER_DISABLE = MustNewBoolOption("docker.disable", true, "Disable the use of docker (usually for testing).")
 
 	// Tasks
 	NO_TASKS           = MustNewBoolOption("tasks.disable", false, "Disable all scheduled tasks.")

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -31,7 +31,7 @@ var (
 	EMAIL_USER = MustNewStringOption("email.user", "", "SMTP username for emails sent from the autograder.")
 
 	// Docker
-	DOCKER_DISABLE = MustNewBoolOption("docker.disable", true, "Disable the use of docker (usually for testing).")
+	DOCKER_DISABLE = MustNewBoolOption("docker.disable", false, "Disable the use of docker (usually for testing).")
 
 	// Tasks
 	NO_TASKS           = MustNewBoolOption("tasks.disable", false, "Disable all scheduled tasks.")

--- a/internal/db/test.go
+++ b/internal/db/test.go
@@ -55,8 +55,6 @@ func CleanupTestingMain() {
 func AddTestUsers() error {
 	path := filepath.Join(config.GetCourseImportDir(), "testdata", model.USERS_FILENAME)
 
-    // TODO: Remove.
-    fmt.Printf("Path: '%v'.", path)
 	users, err := model.LoadServerUsersFile(path)
 	if err != nil {
 		return fmt.Errorf("Could not open test users file '%s': '%w'.", path, err)

--- a/internal/db/test.go
+++ b/internal/db/test.go
@@ -55,6 +55,8 @@ func CleanupTestingMain() {
 func AddTestUsers() error {
 	path := filepath.Join(config.GetCourseImportDir(), "testdata", model.USERS_FILENAME)
 
+    // TODO: Remove.
+    fmt.Printf("Path: '%v'.", path)
 	users, err := model.LoadServerUsersFile(path)
 	if err != nil {
 		return fmt.Errorf("Could not open test users file '%s': '%w'.", path, err)


### PR DESCRIPTION
This PR moves the course update API endpoint from admin/update-course to courses/admin/update.

The endpoint is responsible for updating a course from its source.

This PR must be reviewed with the corresponding [python interface PR](https://github.com/edulinq/autograder-py/pull/24).