### PR TITLE
Added an API endpoint for getting course users.

### DIFF
--- a/internal/api/courses/routes.go
+++ b/internal/api/courses/routes.go
@@ -7,6 +7,7 @@ import (
 	"github.com/edulinq/autograder/internal/api/courses/admin"
 	"github.com/edulinq/autograder/internal/api/courses/assignments"
 	"github.com/edulinq/autograder/internal/api/courses/assignments/submissions"
+	"github.com/edulinq/autograder/internal/api/courses/users"
 )
 
 func GetRoutes() *[]*core.Route {
@@ -15,6 +16,7 @@ func GetRoutes() *[]*core.Route {
 	routes = append(routes, *(admin.GetRoutes())...)
 	routes = append(routes, *(assignments.GetRoutes())...)
 	routes = append(routes, *(submissions.GetRoutes())...)
+	routes = append(routes, *(users.GetRoutes())...)
 
 	return &routes
 }

--- a/internal/api/courses/users/get.go
+++ b/internal/api/courses/users/get.go
@@ -1,0 +1,30 @@
+package users
+
+import (
+	"github.com/edulinq/autograder/internal/api/core"
+)
+
+type GetRequest struct {
+	core.APIRequestCourseUserContext
+	core.MinCourseRoleOther
+
+	TargetCourseUser core.TargetCourseUserSelfOrAdmin `json:"target-email"`
+}
+
+type GetResponse struct {
+	Found bool                 `json:"found"`
+	User  *core.CourseUserInfo `json:"user"`
+}
+
+func HandleGet(request *GetRequest) (*GetResponse, *core.APIError) {
+	response := GetResponse{}
+
+	if !request.TargetCourseUser.Found {
+		return &response, nil
+	}
+
+	response.Found = true
+	response.User = core.NewCourseUserInfo(request.TargetCourseUser.User)
+
+	return &response, nil
+}

--- a/internal/api/courses/users/get.go
+++ b/internal/api/courses/users/get.go
@@ -8,7 +8,7 @@ type GetRequest struct {
 	core.APIRequestCourseUserContext
 	core.MinCourseRoleOther
 
-	TargetCourseUser core.TargetCourseUserSelfOrAdmin `json:"target-email"`
+	TargetCourseUser core.TargetCourseUserSelfOrGrader `json:"target-email"`
 }
 
 type GetResponse struct {

--- a/internal/api/courses/users/get_test.go
+++ b/internal/api/courses/users/get_test.go
@@ -31,9 +31,9 @@ func TestGet(test *testing.T) {
 
 		// Other, bad permissions.
 		{"course-student", "couse-admin@test.edulinq.org", true, "-033", nil},
-		{"course-grader", "course-admin@test.edulinq.org", true, "-033", nil},
 
 		// Other, good permissions.
+		{"course-grader", "course-student@test.edulinq.org", false, "", users["course-student@test.edulinq.org"]},
 		{"course-admin", "course-student@test.edulinq.org", false, "", users["course-student@test.edulinq.org"]},
 		{"course-owner", "course-student@test.edulinq.org", false, "", users["course-student@test.edulinq.org"]},
 

--- a/internal/api/courses/users/get_test.go
+++ b/internal/api/courses/users/get_test.go
@@ -1,0 +1,93 @@
+package users
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/edulinq/autograder/internal/api/core"
+	"github.com/edulinq/autograder/internal/db"
+	"github.com/edulinq/autograder/internal/model"
+	"github.com/edulinq/autograder/internal/util"
+)
+
+func TestGet(test *testing.T) {
+	course := db.MustGetTestCourse()
+
+	users, err := db.GetCourseUsers(course)
+	if err != nil {
+		test.Fatalf("Failed to get course users: '%v'.", err)
+	}
+
+	testCases := []struct {
+		email     string
+		target    string
+		permError bool
+		locator   string
+		expected  *model.CourseUser
+	}{
+		// Self.
+		{"course-student", "", false, "", users["course-student@test.edulinq.org"]},
+		{"course-grader", "", false, "", users["course-grader@test.edulinq.org"]},
+
+		// Other, bad permissions.
+		{"course-student", "couse-admin@test.edulinq.org", true, "-033", nil},
+		{"course-grader", "course-admin@test.edulinq.org", true, "-033", nil},
+
+		// Other, good permissions.
+		{"course-admin", "course-student@test.edulinq.org", false, "", users["course-student@test.edulinq.org"]},
+		{"course-owner", "course-student@test.edulinq.org", false, "", users["course-student@test.edulinq.org"]},
+
+		// Other, good permissions, role escalation.
+		{"server-admin", "course-student@test.edulinq.org", false, "", users["course-student@test.edulinq.org"]},
+		{"server-owner", "course-student@test.edulinq.org", false, "", users["course-student@test.edulinq.org"]},
+
+		// Missing
+		{"course-admin", "ZZZ@test.edulinq.org", false, "", nil},
+		{"course-admin", "server-user@test.edulinq.org", false, "", nil},
+	}
+
+	for i, testCase := range testCases {
+		fields := map[string]any{
+			"target-email": testCase.target,
+		}
+
+		response := core.SendTestAPIRequestFull(test, core.NewEndpoint(`courses/users/get`), fields, nil, testCase.email)
+		if !response.Success {
+			if testCase.permError {
+				if testCase.locator != response.Locator {
+					test.Errorf("Case %d: Incorrect error returned. Expcted '%s', found '%s'.",
+						i, testCase.locator, response.Locator)
+				}
+			} else {
+				test.Errorf("Case %d: Response is not a success when it should be: '%v'.", i, response)
+			}
+
+			continue
+		}
+
+		if testCase.permError {
+			test.Errorf("Case %d: Did not get an expected permissions error.", i)
+			continue
+		}
+
+		var responseContent GetResponse
+		util.MustJSONFromString(util.MustToJSON(response.Content), &responseContent)
+
+		expectedFound := (testCase.expected != nil)
+		if expectedFound != responseContent.Found {
+			test.Errorf("Case %d: Found user does not match. Expected: '%v', actual: '%v'.", i, expectedFound, responseContent.Found)
+			continue
+		}
+
+		if testCase.expected == nil {
+			continue
+		}
+
+		expectedInfo := core.NewCourseUserInfo(testCase.expected)
+		if !reflect.DeepEqual(expectedInfo, responseContent.User) {
+			test.Errorf("Case %d: Unexpected user result. Expected: '%s', actual: '%s'.",
+				i, util.MustToJSONIndent(expectedInfo), util.MustToJSONIndent(responseContent.User))
+			continue
+		}
+	}
+}

--- a/internal/api/courses/users/main_test.go
+++ b/internal/api/courses/users/main_test.go
@@ -1,0 +1,12 @@
+package users
+
+import (
+	"testing"
+
+	"github.com/edulinq/autograder/internal/api/core"
+)
+
+// Use the common main for all tests in this package.
+func TestMain(suite *testing.M) {
+	core.APITestingMain(suite, GetRoutes())
+}

--- a/internal/api/courses/users/routes.go
+++ b/internal/api/courses/users/routes.go
@@ -1,0 +1,15 @@
+package users
+
+// All the API endpoints handled by this package.
+
+import (
+	"github.com/edulinq/autograder/internal/api/core"
+)
+
+var routes []*core.Route = []*core.Route{
+	core.NewAPIRoute(core.NewEndpoint(`courses/users/get`), HandleGet),
+}
+
+func GetRoutes() *[]*core.Route {
+	return &routes
+}


### PR DESCRIPTION
New API endpoint: courses/users/get.

This API endpoint allows users to get course information about themselves. Course admin or above can use the endpoint to get course information about other course users.

This PR must be reviewed with the associated python interface implementation, which can be found [here](https://github.com/edulinq/autograder-py/pull/31).