### PR TITLE
Typo fix and deferral of container container removal.

### DIFF
--- a/internal/api/courses/assignments/submissions/fetch_course_attempts.go
+++ b/internal/api/courses/assignments/submissions/fetch_course_attempts.go
@@ -6,23 +6,23 @@ import (
 	"github.com/edulinq/autograder/internal/model"
 )
 
-type FetchCourseAttempsRequest struct {
+type FetchCourseAttemptsRequest struct {
 	core.APIRequestAssignmentContext
 	core.MinCourseRoleGrader
 
 	FilterRole model.CourseUserRole `json:"filter-role"`
 }
 
-type FetchCourseAttempsResponse struct {
+type FetchCourseAttemptsResponse struct {
 	GradingResults map[string]*model.GradingResult `json:"grading-results"`
 }
 
-func HandleFetchCourseAttemps(request *FetchCourseAttempsRequest) (*FetchCourseAttempsResponse, *core.APIError) {
+func HandleFetchCourseAttempts(request *FetchCourseAttemptsRequest) (*FetchCourseAttemptsResponse, *core.APIError) {
 	results, err := db.GetRecentSubmissionContents(request.Assignment, request.FilterRole)
 	if err != nil {
 		return nil, core.NewInternalError("-605", &request.APIRequestCourseUserContext, "Failed to get submissions.").
 			Err(err).Assignment(request.Assignment.GetID())
 	}
 
-	return &FetchCourseAttempsResponse{results}, nil
+	return &FetchCourseAttemptsResponse{results}, nil
 }

--- a/internal/api/courses/assignments/submissions/fetch_course_attempts_test.go
+++ b/internal/api/courses/assignments/submissions/fetch_course_attempts_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/edulinq/autograder/internal/util"
 )
 
-func TestFetchCourseAttemps(test *testing.T) {
+func TestFetchCourseAttempts(test *testing.T) {
 	testCases := []struct {
 		email     string
 		permError bool
@@ -42,7 +42,7 @@ func TestFetchCourseAttemps(test *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		response := core.SendTestAPIRequestFull(test, core.NewEndpoint(`courses/assignments/submissions/fetch/course/attemps`), nil, nil, testCase.email)
+		response := core.SendTestAPIRequestFull(test, core.NewEndpoint(`courses/assignments/submissions/fetch/course/attempts`), nil, nil, testCase.email)
 		if !response.Success {
 			if testCase.permError {
 				if response.Locator != testCase.locator {
@@ -56,7 +56,7 @@ func TestFetchCourseAttemps(test *testing.T) {
 			continue
 		}
 
-		var responseContent FetchCourseAttempsResponse
+		var responseContent FetchCourseAttemptsResponse
 		util.MustJSONFromString(util.MustToJSON(response.Content), &responseContent)
 
 		if !reflect.DeepEqual(submissions, responseContent.GradingResults) {

--- a/internal/api/courses/assignments/submissions/routes.go
+++ b/internal/api/courses/assignments/submissions/routes.go
@@ -7,7 +7,7 @@ import (
 )
 
 var routes []*core.Route = []*core.Route{
-	core.NewAPIRoute(core.NewEndpoint(`courses/assignments/submissions/fetch/course/attemps`), HandleFetchCourseAttemps),
+	core.NewAPIRoute(core.NewEndpoint(`courses/assignments/submissions/fetch/course/attempts`), HandleFetchCourseAttempts),
 	core.NewAPIRoute(core.NewEndpoint(`courses/assignments/submissions/fetch/course/scores`), HandleFetchCourseScores),
 
 	core.NewAPIRoute(core.NewEndpoint(`courses/assignments/submissions/fetch/user/attempt`), HandleFetchUserAttempt),

--- a/internal/grader/reject_test.go
+++ b/internal/grader/reject_test.go
@@ -52,11 +52,11 @@ func TestRejectSubmissionMaxAttemptsInfinite(test *testing.T) {
 }
 
 func TestRejectSubmissionMaxWindowAttempts(test *testing.T) {
-	testMaxWindowAttemps(test, "course-other@test.edulinq.org", true)
+	testMaxWindowAttempts(test, "course-other@test.edulinq.org", true)
 }
 
 func TestRejectSubmissionMaxWindowAttemptsAdmin(test *testing.T) {
-	testMaxWindowAttemps(test, "course-grader@test.edulinq.org", false)
+	testMaxWindowAttempts(test, "course-grader@test.edulinq.org", false)
 }
 
 func TestRejectWindowMaxMessage(test *testing.T) {
@@ -85,7 +85,7 @@ func TestRejectWindowMaxMessage(test *testing.T) {
 	}
 }
 
-func testMaxWindowAttemps(test *testing.T, user string, expectReject bool) {
+func testMaxWindowAttempts(test *testing.T, user string, expectReject bool) {
 	db.ResetForTesting()
 	defer db.ResetForTesting()
 


### PR DESCRIPTION
This PR fixes the typos "attemps" and updates it to be "attempts". Since it updates an endpoint name, this PR must be reviewed with the associated python interface PR, which can be found [here](https://github.com/edulinq/autograder-py/pull/34).

Additionally, this PR defers the removal of docker containers until after we finish reading the output.