### PR TITLE
Fix for TestCMDStartsOwnServer.

### DIFF
--- a/cmd/call-endpoint/main_test.go
+++ b/cmd/call-endpoint/main_test.go
@@ -271,7 +271,7 @@ func TestCallEndpoint(test *testing.T) {
 	for i, testCase := range testCases {
 		args := append([]string{testCase.endpoint}, testCase.parameters...)
 
-		cmd.RunCommonCMDTests(test, main, args, testCase.CommonCMDTestCase, fmt.Sprintf("Case %d: ", i))
+		cmd.RunCommonCMDTests(test, main, args, testCase.CommonCMDTestCase, fmt.Sprintf("Case %d: ", i), false)
 	}
 }
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -20,7 +20,7 @@ func main() {
 		log.Fatal("Could not load config options.", err)
 	}
 
-	err = server.RunAndBlockServer(common.PRIMARY_SERVER, false)
+	err = server.RunAndBlock(common.PRIMARY_SERVER, false)
 	if err != nil {
 		log.Fatal("Failed to start the server.", err)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -20,7 +20,7 @@ func main() {
 		log.Fatal("Could not load config options.", err)
 	}
 
-	err = server.Start(common.PRIMARY_SERVER)
+	err = server.RunAndBlockServer(common.PRIMARY_SERVER, false)
 	if err != nil {
 		log.Fatal("Failed to start the server.", err)
 	}

--- a/cmd/user-auth/main_test.go
+++ b/cmd/user-auth/main_test.go
@@ -24,7 +24,7 @@ func TestCMDStartsOwnServer(test *testing.T) {
 	}
 
 	// CMDs always succeed in user authentication, regardless of credentials, so only one test case needs to run.
-	cmd.RunCommonCMDTests(test, main, args, commonTestCase, "")
+	cmd.RunCommonCMDTests(test, main, args, commonTestCase, "", true)
 }
 
 const expected_auth_output = `{

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"os"
 	"os/signal"
-	"sync"
 	"syscall"
 
 	"github.com/edulinq/autograder/internal/api"
@@ -13,12 +12,20 @@ import (
 	"github.com/edulinq/autograder/internal/util"
 )
 
-// FinishCleanup ensures cleanup tasks execute before the server fully stops.
-// Add(1) to the WaitGroup for each defered cleanup task and call Done() when finished.
-var FinishCleanup sync.WaitGroup
+type APIServer struct {
+	errorsChan     chan error
+	shutdownSignal chan os.Signal
+}
+
+func NewAPIServer() *APIServer {
+	return &APIServer{
+		errorsChan:     make(chan error),
+		shutdownSignal: make(chan os.Signal),
+	}
+}
 
 // Run the autograder server and listen on an http and unix socket.
-func RunServer(initiator common.ServerInitiator) (err error) {
+func (this *APIServer) RunServer(initiator common.ServerInitiator) (err error) {
 	err = common.WriteAndHandleStatusFile(initiator)
 	if err != nil {
 		return err
@@ -31,50 +38,39 @@ func RunServer(initiator common.ServerInitiator) (err error) {
 
 	core.SetAPIDescription(*apiDescription)
 
-	FinishCleanup.Add(1)
 	defer func() {
 		err = errors.Join(err, util.RemoveDirent(common.GetStatusPath()))
-		FinishCleanup.Done()
-	}()
-
-	errorsChan := make(chan error, 2)
-
-	go func() {
-		errorsChan <- runAPIServer(api.GetRoutes())
 	}()
 
 	go func() {
-		errorsChan <- runUnixSocketServer()
+		this.errorsChan <- runAPIServer(api.GetRoutes())
+	}()
+
+	go func() {
+		this.errorsChan <- runUnixSocketServer()
 	}()
 
 	// Gracefully shutdown on Control-C (SIGINT).
-	shutdownSignal := make(chan os.Signal, 1)
-	signal.Notify(shutdownSignal, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(this.shutdownSignal, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
-		<-shutdownSignal
-		signal.Stop(shutdownSignal)
-		StopServer(true)
+		<-this.shutdownSignal
+		signal.Stop(this.shutdownSignal)
+		this.StopServer()
 	}()
 
 	// Wait for at least one error (or nil) to stop both servers,
 	// then wait for the next error (or nil).
-	err = errors.Join(err, <-errorsChan)
+	err = errors.Join(err, <-this.errorsChan)
 	// Stop server without waiting to ensure cleanup tasks get executed.
-	StopServer(false)
-	err = errors.Join(err, <-errorsChan)
+	this.StopServer()
+	err = errors.Join(err, <-this.errorsChan)
 
-	close(errorsChan)
+	close(this.errorsChan)
 
 	return err
 }
 
-// waitForCleanup should always be set to true when stopping a server
-// to ensure the server is fully cleaned up by the time it's stopped.
-func StopServer(waitForCleanup bool) {
+func (this *APIServer) StopServer() {
 	stopUnixSocketServer()
 	stopAPIServer()
-
-	if waitForCleanup {
-		FinishCleanup.Wait()
-	}
 }

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -25,7 +25,7 @@ func NewAPIServer() *APIServer {
 }
 
 // Run the autograder server and listen on an http and unix socket.
-func (this *APIServer) RunServer(initiator common.ServerInitiator) (err error) {
+func (this *APIServer) Run(initiator common.ServerInitiator) (err error) {
 	err = common.WriteAndHandleStatusFile(initiator)
 	if err != nil {
 		return err
@@ -55,14 +55,14 @@ func (this *APIServer) RunServer(initiator common.ServerInitiator) (err error) {
 	go func() {
 		<-this.shutdownSignal
 		signal.Stop(this.shutdownSignal)
-		this.StopServer()
+		this.Stop()
 	}()
 
 	// Wait for at least one error (or nil) to stop both servers,
 	// then wait for the next error (or nil).
 	err = errors.Join(err, <-this.errorsChan)
 	// Stop server without waiting to ensure cleanup tasks get executed.
-	this.StopServer()
+	this.Stop()
 	err = errors.Join(err, <-this.errorsChan)
 
 	close(this.errorsChan)
@@ -70,7 +70,7 @@ func (this *APIServer) RunServer(initiator common.ServerInitiator) (err error) {
 	return err
 }
 
-func (this *APIServer) StopServer() {
+func (this *APIServer) Stop() {
 	stopUnixSocketServer()
 	stopAPIServer()
 }

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 
 	"github.com/edulinq/autograder/internal/api"
@@ -11,6 +12,8 @@ import (
 	"github.com/edulinq/autograder/internal/common"
 	"github.com/edulinq/autograder/internal/util"
 )
+
+var FinishCleanup sync.WaitGroup
 
 // Run the autograder server and listen on an http and unix socket.
 func RunServer(initiator common.ServerInitiator) (err error) {

--- a/internal/cmd/request.go
+++ b/internal/cmd/request.go
@@ -36,7 +36,7 @@ func MustHandleCMDRequestAndExitFull(endpoint string, request any, responseType 
 		startedCMDServer, oldPort := mustEnsureServerIsRunning()
 		if startedCMDServer {
 			defer func() {
-				err := pserver.CleanupAndStopServer()
+				err := pserver.CleanupAndStop()
 				if err != nil {
 					log.Fatal("Failed to cleanup and stop the CMD server.", err)
 				}

--- a/internal/cmd/request.go
+++ b/internal/cmd/request.go
@@ -34,10 +34,7 @@ func MustHandleCMDRequestAndExitFull(endpoint string, request any, responseType 
 	func() {
 		startedCMDServer, oldPort := mustEnsureServerIsRunning()
 		if startedCMDServer {
-			// Wait for the server to finish cleaning up before this func finishes.
-			defer server.FinishCleanup.Wait()
-
-			defer server.StopServer()
+			defer server.StopServer(true)
 			defer config.WEB_PORT.Set(oldPort)
 		}
 

--- a/internal/cmd/request.go
+++ b/internal/cmd/request.go
@@ -34,6 +34,9 @@ func MustHandleCMDRequestAndExitFull(endpoint string, request any, responseType 
 	func() {
 		startedCMDServer, oldPort := mustEnsureServerIsRunning()
 		if startedCMDServer {
+			// Wait for the server to finish cleaning up before this func finishes.
+			defer server.FinishCleanup.Wait()
+
 			defer server.StopServer()
 			defer config.WEB_PORT.Set(oldPort)
 		}

--- a/internal/cmd/request.go
+++ b/internal/cmd/request.go
@@ -13,6 +13,7 @@ import (
 	"github.com/edulinq/autograder/internal/config"
 	"github.com/edulinq/autograder/internal/exit"
 	"github.com/edulinq/autograder/internal/log"
+	pserver "github.com/edulinq/autograder/internal/procedures/server"
 	"github.com/edulinq/autograder/internal/util"
 )
 
@@ -34,7 +35,12 @@ func MustHandleCMDRequestAndExitFull(endpoint string, request any, responseType 
 	func() {
 		startedCMDServer, oldPort := mustEnsureServerIsRunning()
 		if startedCMDServer {
-			defer server.StopServer(true)
+			defer func() {
+				err := pserver.CleanupAndStopServer()
+				if err != nil {
+					log.Fatal("Failed to cleanup and stop the CMD server.", err)
+				}
+			}()
 			defer config.WEB_PORT.Set(oldPort)
 		}
 

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -55,7 +55,7 @@ func mustEnsureServerIsRunning() (bool, int) {
 	serverStart.Wait()
 
 	// Small sleep to allow the server to start up.
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	return true, oldPort
 }

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -46,7 +46,7 @@ func mustEnsureServerIsRunning() (bool, int) {
 	go func() {
 		serverStart.Done()
 
-		err = server.RunAndBlockServer(common.CMD_SERVER, false)
+		err = server.RunAndBlock(common.CMD_SERVER, false)
 		if err != nil {
 			log.Fatal("Failed to start the server.", err)
 		}

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -46,7 +46,7 @@ func mustEnsureServerIsRunning() (bool, int) {
 	go func() {
 		serverStart.Done()
 
-		err = server.Start(common.CMD_SERVER)
+		err = server.RunAndBlockServer(common.CMD_SERVER, false)
 		if err != nil {
 			log.Fatal("Failed to start the server.", err)
 		}

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -55,7 +55,7 @@ func mustEnsureServerIsRunning() (bool, int) {
 	serverStart.Wait()
 
 	// Small sleep to allow the server to start up.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 
 	return true, oldPort
 }

--- a/internal/cmd/test.go
+++ b/internal/cmd/test.go
@@ -165,7 +165,6 @@ func runCMD(mainFunc func(), args []string) (err error) {
 
 func RunCommonCMDTests(test *testing.T, mainFunc func(), args []string, commonTestCase CommonCMDTestCase, prefix string) (string, string, int, bool) {
 	stdout, stderr, exitCode, err := RunCMDTest(test, mainFunc, args, commonTestCase.LogLevel)
-
 	if err != nil {
 		test.Errorf("%sCMD run returned an error: '%v'.", prefix, err)
 		logOutputs(test, stdout, stderr)

--- a/internal/cmd/test.go
+++ b/internal/cmd/test.go
@@ -34,7 +34,7 @@ type CommonCMDTestCase struct {
 
 // Common setup for all CMD tests that require a server.
 func CMDServerTestingMain(suite *testing.M) {
-	server.StopServer()
+	server.StopServer(true)
 
 	port, err := util.GetUnusedPort()
 	if err != nil {
@@ -61,7 +61,7 @@ func CMDServerTestingMain(suite *testing.M) {
 			}
 		}()
 
-		defer server.StopServer()
+		defer server.StopServer(true)
 
 		serverRun.Wait()
 
@@ -80,6 +80,11 @@ func RunCMDTest(test *testing.T, mainFunc func(), args []string, logLevel log.Lo
 	defer exit.SetShouldExitForTesting(true)
 
 	tempDir := util.MustMkDirTemp("autograder-testing-cmd-")
+	defer util.RemoveDirent(tempDir)
+
+	// Prevent the cmd testing dir from automatic cleanup to use during testing.
+	util.ClearRecordedTempDirs()
+
 	stdoutPath := filepath.Join(tempDir, STDOUT_FILENAME)
 	stderrPath := filepath.Join(tempDir, STDERR_FILENAME)
 
@@ -193,6 +198,10 @@ func RunCommonCMDTests(test *testing.T, mainFunc func(), args []string, commonTe
 }
 
 func logOutputs(test *testing.T, stdout string, stderr string) {
-	test.Logf("\n--- START OF STDOUT ---\n%s\n--- END OF STDOUT---", stdout)
-	test.Logf("\n--- START OF STDERR ---\n%s\n--- END OF STDERR ----", stderr)
+	test.Log("--- stdout ---")
+	test.Log(stdout)
+	test.Log("--------------")
+	test.Log("--- stderr ---")
+	test.Log(stderr)
+	test.Log("--------------")
 }

--- a/internal/cmd/test.go
+++ b/internal/cmd/test.go
@@ -165,23 +165,33 @@ func runCMD(mainFunc func(), args []string) (err error) {
 
 func RunCommonCMDTests(test *testing.T, mainFunc func(), args []string, commonTestCase CommonCMDTestCase, prefix string) (string, string, int, bool) {
 	stdout, stderr, exitCode, err := RunCMDTest(test, mainFunc, args, commonTestCase.LogLevel)
+
+	logOutputs := func() {
+		test.Logf("Stdout: '%s'.", stdout)
+		test.Logf("Stderr: '%s'.", stderr)
+	}
+
 	if err != nil {
 		test.Errorf("%sCMD run returned an error: '%v'.", prefix, err)
+		logOutputs()
 		return "", "", -1, false
 	}
 
 	if commonTestCase.ExpectedExitCode != exitCode {
 		test.Errorf("%sUnexpected exit code. Expected: '%d', Actual: '%d'.", prefix, commonTestCase.ExpectedExitCode, exitCode)
+		logOutputs()
 		return "", "", -1, false
 	}
 
 	if !strings.Contains(stderr, commonTestCase.ExpectedStderrSubstring) {
 		test.Errorf("%sUnexpected stderr substring. Expected stderr substring: '%s', Actual stderr: '%s'.", prefix, commonTestCase.ExpectedStderrSubstring, stderr)
+		logOutputs()
 		return "", "", -1, false
 	}
 
 	if !commonTestCase.IgnoreStdout && commonTestCase.ExpectedStdout != stdout {
 		test.Errorf("%sUnexpected output. Expected: \n'%s', \n Actual: \n'%s'.", prefix, commonTestCase.ExpectedStdout, stdout)
+		logOutputs()
 		return "", "", -1, false
 	}
 

--- a/internal/cmd/test.go
+++ b/internal/cmd/test.go
@@ -166,34 +166,34 @@ func runCMD(mainFunc func(), args []string) (err error) {
 func RunCommonCMDTests(test *testing.T, mainFunc func(), args []string, commonTestCase CommonCMDTestCase, prefix string) (string, string, int, bool) {
 	stdout, stderr, exitCode, err := RunCMDTest(test, mainFunc, args, commonTestCase.LogLevel)
 
-	logOutputs := func() {
-		test.Logf("Stdout: '%s'.", stdout)
-		test.Logf("Stderr: '%s'.", stderr)
-	}
-
 	if err != nil {
 		test.Errorf("%sCMD run returned an error: '%v'.", prefix, err)
-		logOutputs()
+		logOutputs(test, stdout, stderr)
 		return "", "", -1, false
 	}
 
 	if commonTestCase.ExpectedExitCode != exitCode {
 		test.Errorf("%sUnexpected exit code. Expected: '%d', Actual: '%d'.", prefix, commonTestCase.ExpectedExitCode, exitCode)
-		logOutputs()
+		logOutputs(test, stdout, stderr)
 		return "", "", -1, false
 	}
 
 	if !strings.Contains(stderr, commonTestCase.ExpectedStderrSubstring) {
 		test.Errorf("%sUnexpected stderr substring. Expected stderr substring: '%s', Actual stderr: '%s'.", prefix, commonTestCase.ExpectedStderrSubstring, stderr)
-		logOutputs()
+		logOutputs(test, stdout, stderr)
 		return "", "", -1, false
 	}
 
 	if !commonTestCase.IgnoreStdout && commonTestCase.ExpectedStdout != stdout {
 		test.Errorf("%sUnexpected output. Expected: \n'%s', \n Actual: \n'%s'.", prefix, commonTestCase.ExpectedStdout, stdout)
-		logOutputs()
+		logOutputs(test, stdout, stderr)
 		return "", "", -1, false
 	}
 
 	return stdout, stderr, exitCode, true
+}
+
+func logOutputs(test *testing.T, stdout string, stderr string) {
+	test.Logf("\n--- START OF STDOUT ---\n%s\n--- END OF STDOUT---", stdout)
+	test.Logf("\n--- START OF STDERR ---\n%s\n--- END OF STDERR ----", stderr)
 }

--- a/internal/procedures/server/start.go
+++ b/internal/procedures/server/start.go
@@ -50,8 +50,7 @@ func Start(initiator common.ServerInitiator) (err error) {
 		go startCourse(course)
 	}
 
-	// Don't remove temp dirs during unit testing
-	// since they contain data needed during tests after this function completes.
+	// Don't remove temp dirs during unit testing since they are needed after this function finishes.
 	if !config.UNIT_TESTING_MODE.Get() {
 		// Ensure temp dirs are removed before a CMD that started a server finishes its execution.
 		server.FinishCleanup.Add(1)

--- a/internal/procedures/server/start.go
+++ b/internal/procedures/server/start.go
@@ -63,6 +63,8 @@ func CleanupAndStop() (err error) {
 
 	apiServer = nil
 
+	log.Debug("Server closed.")
+
 	return err
 }
 
@@ -110,7 +112,6 @@ func startCourse(course *model.Course) {
 	root, err := db.GetRoot()
 	if err != nil {
 		log.Error("Failed to get root for course update.", err, course)
-		return
 	}
 
 	options := pcourses.CourseUpsertOptions{

--- a/internal/procedures/server/start.go
+++ b/internal/procedures/server/start.go
@@ -50,7 +50,7 @@ func Start(initiator common.ServerInitiator) (err error) {
 		go startCourse(course)
 	}
 
-	// Don't remove temporary directories during unit testing
+	// Don't remove temp dirs during unit testing
 	// since they contain data needed during tests after this function completes.
 	if !config.UNIT_TESTING_MODE.Get() {
 		// Ensure temp dirs are removed before a CMD that started a server finishes its execution.

--- a/internal/procedures/server/start.go
+++ b/internal/procedures/server/start.go
@@ -51,6 +51,7 @@ func Start(initiator common.ServerInitiator) (err error) {
 
 	server.FinishCleanup.Add(1)
 	defer func() {
+		// Cleanup any temp dirs.
 		util.RemoveRecordedTempDirs()
 		server.FinishCleanup.Done()
 	}()

--- a/internal/procedures/server/start.go
+++ b/internal/procedures/server/start.go
@@ -48,7 +48,9 @@ func Start(initiator common.ServerInitiator) (err error) {
 	}
 
 	// Cleanup any temp dirs.
-	defer util.RemoveRecordedTempDirs()
+	if !config.UNIT_TESTING_MODE.Get() {
+		defer util.RemoveRecordedTempDirs()
+	}
 
 	err = server.RunServer(initiator)
 	if err != nil {

--- a/internal/util/dir.go
+++ b/internal/util/dir.go
@@ -14,6 +14,7 @@ const DEFAULT_MKDIR_PERMS os.FileMode = 0755
 var tempDir string = filepath.Join("/", "tmp", "autograder-temp")
 var tempDirMutex sync.Mutex
 var createdTempDirs []string
+var shouldRemoveTempDirs bool = true
 
 func SetTempDirForTesting(newTempDir string) {
 	tempDir = newTempDir
@@ -53,7 +54,7 @@ func MkDirPerms(path string, perms os.FileMode) error {
 	return os.MkdirAll(path, perms)
 }
 
-func ClearRecordedTempDirs() {
+func clearRecordedTempDirs() {
 	createdTempDirs = nil
 }
 
@@ -62,14 +63,22 @@ func RemoveRecordedTempDirs() error {
 	tempDirMutex.Lock()
 	defer tempDirMutex.Unlock()
 
+	if !shouldRemoveTempDirs {
+		return nil
+	}
+
 	var errs error = nil
 	for _, dir := range createdTempDirs {
 		errs = errors.Join(errs, RemoveDirent(dir))
 	}
 
-	ClearRecordedTempDirs()
+	clearRecordedTempDirs()
 
 	return errs
+}
+
+func SetShouldRemoveTempDirs(shouldRemove bool) {
+	shouldRemoveTempDirs = shouldRemove
 }
 
 // If this dir has a single dirent, return its path.


### PR DESCRIPTION
It seems like procedures/server/start.go's defer of removing temp directories would occasionally get executed while another test would run. Since TestCMDStartsOwnServer already deals with removing temp dirs, procedures doesn't need to when unit testing.

I also noticed in ~1/100 tests that the server wouldn't have enough time to start up for the test, so I increased its sleep to 200 milliseconds.

After these changes, I ran TestCMDStartsOwnServer a few hundred times with no issues.