### PR TITLE
Fix symlink handling for globs.

### DIFF
--- a/internal/util/fileop.go
+++ b/internal/util/fileop.go
@@ -263,7 +263,12 @@ func handleGlobFileOperation(sourceGlob string, dest string, baseDir string, ope
 	var errs error
 
 	for _, sourcePath := range sourcePaths {
-		if sourcePath == dest {
+		realSourcePath, err := filepath.EvalSymlinks(sourcePath)
+		if err != nil {
+			errs = errors.Join(errs, err)
+		}
+
+		if realSourcePath == dest {
 			continue
 		}
 

--- a/internal/util/fileop.go
+++ b/internal/util/fileop.go
@@ -265,7 +265,7 @@ func handleGlobFileOperation(sourceGlob string, dest string, baseDir string, ope
 	for _, sourcePath := range sourcePaths {
 		realSourcePath, err := filepath.EvalSymlinks(sourcePath)
 		if err != nil {
-			errs = errors.Join(errs, err)
+			return fmt.Errorf("Failed to eval symlinks for sourcePath '%s': '%w'.", sourcePath, err)
 		}
 
 		if realSourcePath == dest {


### PR DESCRIPTION
When executing file operations, evaluating symlinks in `ShouldNormalizePath()` doesn't work for glob patterns (on mac, the /tmp directory is symlinked to /private/tmp). This causes an issue when it compares each matched source path to the dest path (each matched source path isn't fully normalized but dest is fully normalized so checking for equality doesn't work). To make sure all matched source paths are fully normalized, symlink evaluation should be performed on each individual match inside of `handleGlobFileOperation()`.