### PR TITLE
Added an API endpoint to make proxy regrades.

### DIFF
--- a/internal/api/courses/assignments/submissions/proxy/regrade.go
+++ b/internal/api/courses/assignments/submissions/proxy/regrade.go
@@ -1,0 +1,49 @@
+package proxy
+
+import (
+	"github.com/edulinq/autograder/internal/api/core"
+	"github.com/edulinq/autograder/internal/db"
+	"github.com/edulinq/autograder/internal/grader"
+	"github.com/edulinq/autograder/internal/model"
+)
+
+type RegradeRequest struct {
+	core.APIRequestAssignmentContext
+	core.MinCourseRoleGrader
+
+	// Filter results to only users with this role.
+	FilterRole model.CourseUserRole `json:"filter-role"`
+}
+
+type RegradeResponse struct {
+	SubmissionInfo map[string]*model.SubmissionHistoryItem `json:"submission-infos"`
+}
+
+// Regrade the most recent submissions for the course.
+func HandleRegrade(request *RegradeRequest) (*RegradeResponse, *core.APIError) {
+	response := RegradeResponse{}
+
+	role := model.GetCourseUserRoleString(request.FilterRole)
+	users, err := db.ResolveCourseUsers(request.Course, []string{role})
+	if err != nil {
+		return nil, core.NewInternalError("-635", request, "Unable to resolve course users.")
+	}
+
+	gradeOptions := grader.GetDefaultGradeOptions()
+	gradeOptions.ProxyUser = request.User.Email
+	gradeOptions.CheckRejection = false
+
+	regradeOptions := grader.RegradeOptions{
+		Options:    gradeOptions,
+		Context:    request.Context,
+		Assignment: request.Assignment,
+		Users:      users,
+	}
+
+	response.SubmissionInfo, err = grader.RegradeSubmissions(regradeOptions)
+	if err != nil {
+		return nil, core.NewInternalError("-636", request, "Unable to regrade subission contents.")
+	}
+
+	return &response, nil
+}

--- a/internal/api/courses/assignments/submissions/proxy/regrade_test.go
+++ b/internal/api/courses/assignments/submissions/proxy/regrade_test.go
@@ -1,0 +1,162 @@
+package proxy
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/edulinq/autograder/internal/api/core"
+	"github.com/edulinq/autograder/internal/db"
+	"github.com/edulinq/autograder/internal/grader"
+	"github.com/edulinq/autograder/internal/model"
+	"github.com/edulinq/autograder/internal/util"
+)
+
+func TestRegradeBase(test *testing.T) {
+	db.ResetForTesting()
+	defer db.ResetForTesting()
+
+	// Note that computation of these paths are deferred until test time.
+	studentGradingResults := map[string]*model.GradingResult{
+		"1697406272": model.MustLoadGradingResult(getTestSubmissionResultPath("1697406272")),
+	}
+
+	testCases := []struct {
+		role              string
+		proxyUser         string
+		waitForCompletion bool
+		expectedLocator   string
+		expected          RegradeResponse
+	}{
+		// Valid regrade submissions
+		// Student, wait for completion
+		{
+			"student",
+			"course-grader",
+			true,
+			"",
+			RegradeResponse{
+				Complete: true,
+				Users:    []string{"course-student@test.edulinq.org"},
+				Results: map[string]*model.SubmissionHistoryItem{
+					"course-student@test.edulinq.org": studentGradingResults["1697406272"].Info.ToHistoryItem(),
+				},
+			},
+		},
+
+		// Admin, wait for completion
+		{
+			"admin",
+			"course-grader",
+			true,
+			"",
+			RegradeResponse{
+				Complete: true,
+				Users:    []string{"course-admin@test.edulinq.org"},
+				Results: map[string]*model.SubmissionHistoryItem{
+					"course-admin@test.edulinq.org": nil,
+				},
+			},
+		},
+
+		// Student, no wait
+		{
+			"student",
+			"course-grader",
+			false,
+			"",
+			RegradeResponse{
+				Complete: false,
+				Users:    []string{"course-student@test.edulinq.org"},
+				Results:  map[string]*model.SubmissionHistoryItem{},
+			},
+		},
+
+		// Grader, no wait
+		{
+			"grader",
+			"course-grader",
+			false,
+			"",
+			RegradeResponse{
+				Complete: false,
+				Users:    []string{"course-grader@test.edulinq.org"},
+				Results:  map[string]*model.SubmissionHistoryItem{},
+			},
+		},
+
+		// Invalid regrade submissions
+		// Unknown role, wait
+		{
+			"ZZZ",
+			"course-admin",
+			true,
+			"-005",
+			RegradeResponse{},
+		},
+
+		// Unknown role, no wait
+		{
+			"ZZZ",
+			"course-admin",
+			false,
+			"-005",
+			RegradeResponse{},
+		},
+
+		// Perm errors
+		{
+			"student",
+			"course-student",
+			false,
+			"-020",
+			RegradeResponse{},
+		},
+		{
+			"student",
+			"course-other",
+			true,
+			"-020",
+			RegradeResponse{},
+		},
+	}
+
+	for i, testCase := range testCases {
+		fields := map[string]any{
+			"filter-role":         testCase.role,
+			"wait-for-completion": testCase.waitForCompletion,
+		}
+
+		response := core.SendTestAPIRequestFull(test, `courses/assignments/submissions/proxy/regrade`, fields, nil, testCase.proxyUser)
+		if !response.Success {
+			if testCase.expectedLocator != "" {
+				if response.Locator != testCase.expectedLocator {
+					test.Errorf("Case %d: Incorrect error returned. Expected '%s', found '%s'.",
+						i, testCase.expectedLocator, response.Locator)
+				}
+			} else {
+				test.Errorf("Case %d: Response is not a success when it should be: '%v'.", i, response)
+			}
+
+			continue
+		}
+
+		if testCase.expectedLocator != "" {
+			test.Errorf("Case %d: Did not get an expected permissions error.", i)
+			continue
+		}
+
+		var responseContent RegradeResponse
+		util.MustJSONFromString(util.MustToJSON(response.Content), &responseContent)
+
+		failed := grader.CheckAndClearIDs(test, i, testCase.expected.Results, responseContent.Results)
+		if failed {
+			continue
+		}
+
+		if !reflect.DeepEqual(testCase.expected, responseContent) {
+			test.Errorf("Case %d: Unexpected regrade result. Expected: '%s', actual: '%s'.",
+				i, util.MustToJSONIndent(testCase.expected), util.MustToJSONIndent(responseContent))
+			continue
+		}
+	}
+}

--- a/internal/api/courses/assignments/submissions/proxy/regrade_test.go
+++ b/internal/api/courses/assignments/submissions/proxy/regrade_test.go
@@ -93,6 +93,13 @@ func TestRegradeBase(test *testing.T) {
 			"-005",
 			RegradeResponse{},
 		},
+		{
+			"",
+			"course-admin",
+			true,
+			"-005",
+			RegradeResponse{},
+		},
 
 		// Unknown role, no wait
 		{

--- a/internal/api/courses/assignments/submissions/proxy/routes.go
+++ b/internal/api/courses/assignments/submissions/proxy/routes.go
@@ -7,6 +7,7 @@ import (
 )
 
 var baseRoutes []core.Route = []core.Route{
+	core.MustNewAPIRoute(`courses/assignments/submissions/proxy/regrade`, HandleRegrade),
 	core.MustNewAPIRoute(`courses/assignments/submissions/proxy/resubmit`, HandleResubmit),
 	core.MustNewAPIRoute(`courses/assignments/submissions/proxy/submit`, HandleSubmit),
 }

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -66,5 +66,8 @@ var (
 	ANALYSIS_INDIVIDUAL_COURSE_POOL_SIZE = MustNewIntOption("analysis.individual.poolsize", 1, "The number of parallel workers per course when computing individual analysis.")
 	ANALYSIS_PAIRWISE_COURSE_POOL_SIZE   = MustNewIntOption("analysis.pairwise.poolsize", 1, "The number of parallel workers per course when computing pairwise analysis.")
 
+	// Regrades
+	REGRADE_COURSE_POOL_SIZE = MustNewIntOption("regrade.poolsize", 4, "The number of parallel workers per course when regrading an assignment.")
+
 	STALELOCK_DURATION_SECS = MustNewIntOption("lockmanager.staleduration", 2*60*60, "Number of seconds a lock can be unused before getting removed.")
 )

--- a/internal/grader/regrade.go
+++ b/internal/grader/regrade.go
@@ -10,30 +10,54 @@ import (
 	"github.com/edulinq/autograder/internal/lockmanager"
 	"github.com/edulinq/autograder/internal/log"
 	"github.com/edulinq/autograder/internal/model"
-	"github.com/edulinq/autograder/internal/timestamp"
 	"github.com/edulinq/autograder/internal/util"
 )
 
 type RegradeOptions struct {
-	Options GradeOptions
+	Users []string `json:"users"`
 
-	Context    context.Context
-	Assignment *model.Assignment
+	// Wait for the entire regrade to complete and return all results.
+	WaitForCompletion bool `json:"wait-for-completion"`
 
-	Users []string
+	Options GradeOptions `json:"-"`
+
+	// A context that can be used to cancel the regrade.
+	Context    context.Context   `json:"-"`
+	Assignment *model.Assignment `json:"-"`
+
+	// If true, do not swap the context to the background context when running.
+	// By default (when this is false), the context will be swapped to the background context when !WaitForCompletion.
+	// The swap is so that regrade does not get canceled when an HTTP request is complete.
+	// Setting this true is useful for testing (as one round of regrade tests can be wrapped up).
+	RetainOriginalContext bool `json:"-"`
 }
 
-func RegradeSubmissions(options RegradeOptions) (map[string]*model.SubmissionHistoryItem, error) {
+func RegradeSubmissions(options RegradeOptions) (map[string]*model.SubmissionHistoryItem, int, error) {
 	if options.Context == nil {
 		options.Context = context.Background()
 	}
 
-	results, err := runRegradeSubmissions(options)
-	if err != nil {
-		return nil, err
+	if options.WaitForCompletion {
+		results, err := runRegradeSubmissions(options)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		return results, 0, nil
+	} else {
+		if !options.RetainOriginalContext {
+			options.Context = context.Background()
+		}
+
+		go func() {
+			_, err := runRegradeSubmissions(options)
+			if err != nil {
+				log.Error("Failure during asynchronous regrading.", err)
+			}
+		}()
 	}
 
-	return results, nil
+	return map[string]*model.SubmissionHistoryItem{}, len(options.Users), nil
 }
 
 func runRegradeSubmissions(options RegradeOptions) (map[string]*model.SubmissionHistoryItem, error) {
@@ -43,8 +67,7 @@ func runRegradeSubmissions(options RegradeOptions) (map[string]*model.Submission
 
 	// Lock based on the course to prevent multiple requests using up all the cores.
 	lockKey := fmt.Sprintf("regrade-course-%s", options.Assignment.GetCourse().GetID())
-	// TODO: May need noLockWait
-	_ = lockmanager.Lock(lockKey)
+	lockmanager.Lock(lockKey)
 	defer lockmanager.Unlock(lockKey)
 
 	// The context has been canceled while waiting for a lock, abandon this regrade.
@@ -56,21 +79,20 @@ func runRegradeSubmissions(options RegradeOptions) (map[string]*model.Submission
 
 	poolSize := config.REGRADE_COURSE_POOL_SIZE.Get()
 	type PoolResult struct {
-		User    string
-		Result  *model.SubmissionHistoryItem
-		RunTime int64
-		// TODO: Should we split into internal vs grading errors?
-		Error error
+		User   string
+		Result *model.SubmissionHistoryItem
+		Error  error
 	}
 
 	poolResults, _, err := util.RunParallelPoolMap(poolSize, options.Users, options.Context, func(user string) (PoolResult, error) {
-		result, runTime, err := runSingleRegrade(options, user)
+		result, err := runSingleRegrade(options, user)
 		if err != nil {
 			err = fmt.Errorf("Failed to perform individual regrade for user %s: '%w'.", user, err)
 		}
 
-		return PoolResult{user, result, runTime, err}, nil
+		return PoolResult{user, result, err}, nil
 	})
+
 	if err != nil {
 		return nil, fmt.Errorf("Failed to run parallel pool map: '%w'.", err)
 	}
@@ -81,43 +103,38 @@ func runRegradeSubmissions(options RegradeOptions) (map[string]*model.Submission
 	}
 
 	var errs error = nil
-	totalRunTime := int64(0)
 
 	for _, poolResult := range poolResults {
 		if poolResult.Error != nil {
 			errs = errors.Join(errs, poolResult.Error)
 		} else {
 			results[poolResult.User] = poolResult.Result
-			totalRunTime += poolResult.RunTime
 		}
 	}
-
-	// TODO: Look into this!
-	// collectIndividualStats(users, totalRunTime, options.ProxyUser)
 
 	return results, errs
 }
 
-func runSingleRegrade(options RegradeOptions, user string) (*model.SubmissionHistoryItem, int64, error) {
+func runSingleRegrade(options RegradeOptions, user string) (*model.SubmissionHistoryItem, error) {
 	previousResult, err := db.GetSubmissionContents(options.Assignment, user, "")
 	if err != nil {
-		return nil, 0, fmt.Errorf("Failed to get most recent grading result for '%s': '%w'.", user, err)
+		return nil, fmt.Errorf("Failed to get most recent grading result for '%s': '%w'.", user, err)
 	}
 
 	if previousResult == nil {
-		return nil, 0, nil
+		return nil, nil
 	}
 
 	dirName := fmt.Sprintf("regrade-%s-%s-%s-", options.Assignment.GetCourse().GetID(), options.Assignment.GetID(), user)
 	tempDir, err := util.MkDirTemp(dirName)
 	if err != nil {
-		return nil, 0, fmt.Errorf("Failed to create temp regrade dir: '%w'.", err)
+		return nil, fmt.Errorf("Failed to create temp regrade dir: '%w'.", err)
 	}
 	defer util.RemoveDirent(tempDir)
 
 	err = util.GzipBytesToDirectory(tempDir, previousResult.InputFilesGZip)
 	if err != nil {
-		return nil, 0, fmt.Errorf("Failed to write submission input to a temp dir: '%v'.", err)
+		return nil, fmt.Errorf("Failed to write submission input to a temp dir: '%v'.", err)
 	}
 
 	message := ""
@@ -126,11 +143,6 @@ func runSingleRegrade(options RegradeOptions, user string) (*model.SubmissionHis
 		options.Options.ProxyTime = &previousResult.Info.GradingStartTime
 	}
 
-	startTime := timestamp.Now()
-
-	// TODO: Continue handling different failure possibilities.
-	// Think about if we can give back partial information.
-	// If result.GradingInfo != nil, use ToHistoryItem().
 	gradingResult, reject, failureMessage, err := Grade(options.Context, options.Assignment, tempDir, user, message, options.Options)
 	if err != nil {
 		stdout := ""
@@ -143,22 +155,19 @@ func runSingleRegrade(options RegradeOptions, user string) (*model.SubmissionHis
 
 		log.Warn("Regrade submission failed internally.", err, log.NewAttr("stdout", stdout), log.NewAttr("stderr", stderr))
 
-		runTime := int64(timestamp.Now() - startTime)
-		return nil, runTime, fmt.Errorf("Submission failed internally. stdout: '%s', stderr: '%s': '%w'.", stdout, stderr, err)
+		return nil, nil
 	}
 
 	if reject != nil {
 		log.Debug("Regrade submission rejected.", log.NewAttr("reason", reject.String()))
 
-		runTime := int64(timestamp.Now() - startTime)
-		return nil, runTime, fmt.Errorf("Submission rejected: '%s'.", reject.String())
+		return nil, nil
 	}
 
 	if failureMessage != "" {
 		log.Debug("Regrade submission got a soft error.", log.NewAttr("message", failureMessage))
 
-		runTime := int64(timestamp.Now() - startTime)
-		return nil, runTime, fmt.Errorf("Submission got a soft error: '%s'.", failureMessage)
+		return nil, nil
 	}
 
 	var result *model.SubmissionHistoryItem = nil
@@ -166,6 +175,5 @@ func runSingleRegrade(options RegradeOptions, user string) (*model.SubmissionHis
 		result = (*gradingResult.Info).ToHistoryItem()
 	}
 
-	runTime := int64(timestamp.Now() - startTime)
-	return result, runTime, nil
+	return result, nil
 }

--- a/internal/grader/regrade.go
+++ b/internal/grader/regrade.go
@@ -1,0 +1,171 @@
+package grader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/edulinq/autograder/internal/config"
+	"github.com/edulinq/autograder/internal/db"
+	"github.com/edulinq/autograder/internal/lockmanager"
+	"github.com/edulinq/autograder/internal/log"
+	"github.com/edulinq/autograder/internal/model"
+	"github.com/edulinq/autograder/internal/timestamp"
+	"github.com/edulinq/autograder/internal/util"
+)
+
+type RegradeOptions struct {
+	Options GradeOptions
+
+	Context    context.Context
+	Assignment *model.Assignment
+
+	Users []string
+}
+
+func RegradeSubmissions(options RegradeOptions) (map[string]*model.SubmissionHistoryItem, error) {
+	if options.Context == nil {
+		options.Context = context.Background()
+	}
+
+	results, err := runRegradeSubmissions(options)
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+func runRegradeSubmissions(options RegradeOptions) (map[string]*model.SubmissionHistoryItem, error) {
+	if len(options.Users) == 0 {
+		return nil, nil
+	}
+
+	// Lock based on the course to prevent multiple requests using up all the cores.
+	lockKey := fmt.Sprintf("regrade-course-%s", options.Assignment.GetCourse().GetID())
+	// TODO: May need noLockWait
+	_ = lockmanager.Lock(lockKey)
+	defer lockmanager.Unlock(lockKey)
+
+	// The context has been canceled while waiting for a lock, abandon this regrade.
+	if options.Context.Err() != nil {
+		return nil, nil
+	}
+
+	results := make(map[string]*model.SubmissionHistoryItem, len(options.Users))
+
+	poolSize := config.REGRADE_COURSE_POOL_SIZE.Get()
+	type PoolResult struct {
+		User    string
+		Result  *model.SubmissionHistoryItem
+		RunTime int64
+		// TODO: Should we split into internal vs grading errors?
+		Error error
+	}
+
+	poolResults, _, err := util.RunParallelPoolMap(poolSize, options.Users, options.Context, func(user string) (PoolResult, error) {
+		result, runTime, err := runSingleRegrade(options, user)
+		if err != nil {
+			err = fmt.Errorf("Failed to perform individual regrade for user %s: '%w'.", user, err)
+		}
+
+		return PoolResult{user, result, runTime, err}, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Failed to run parallel pool map: '%w'.", err)
+	}
+
+	// If the regrade was canceled, exit right away.
+	if options.Context.Err() != nil {
+		return nil, nil
+	}
+
+	var errs error = nil
+	totalRunTime := int64(0)
+
+	for _, poolResult := range poolResults {
+		if poolResult.Error != nil {
+			errs = errors.Join(errs, poolResult.Error)
+		} else {
+			results[poolResult.User] = poolResult.Result
+			totalRunTime += poolResult.RunTime
+		}
+	}
+
+	// TODO: Look into this!
+	// collectIndividualStats(users, totalRunTime, options.ProxyUser)
+
+	return results, errs
+}
+
+func runSingleRegrade(options RegradeOptions, user string) (*model.SubmissionHistoryItem, int64, error) {
+	previousResult, err := db.GetSubmissionContents(options.Assignment, user, "")
+	if err != nil {
+		return nil, 0, fmt.Errorf("Failed to get most recent grading result for '%s': '%w'.", user, err)
+	}
+
+	if previousResult == nil {
+		return nil, 0, nil
+	}
+
+	dirName := fmt.Sprintf("regrade-%s-%s-%s-", options.Assignment.GetCourse().GetID(), options.Assignment.GetID(), user)
+	tempDir, err := util.MkDirTemp(dirName)
+	if err != nil {
+		return nil, 0, fmt.Errorf("Failed to create temp regrade dir: '%w'.", err)
+	}
+	defer util.RemoveDirent(tempDir)
+
+	err = util.GzipBytesToDirectory(tempDir, previousResult.InputFilesGZip)
+	if err != nil {
+		return nil, 0, fmt.Errorf("Failed to write submission input to a temp dir: '%v'.", err)
+	}
+
+	message := ""
+	if previousResult.Info != nil {
+		message = previousResult.Info.Message
+		options.Options.ProxyTime = &previousResult.Info.GradingStartTime
+	}
+
+	startTime := timestamp.Now()
+
+	// TODO: Continue handling different failure possibilities.
+	// Think about if we can give back partial information.
+	// If result.GradingInfo != nil, use ToHistoryItem().
+	gradingResult, reject, failureMessage, err := Grade(options.Context, options.Assignment, tempDir, user, message, options.Options)
+	if err != nil {
+		stdout := ""
+		stderr := ""
+
+		if (gradingResult != nil) && (gradingResult.HasTextOutput()) {
+			stdout = gradingResult.Stdout
+			stderr = gradingResult.Stderr
+		}
+
+		log.Warn("Regrade submission failed internally.", err, log.NewAttr("stdout", stdout), log.NewAttr("stderr", stderr))
+
+		runTime := int64(timestamp.Now() - startTime)
+		return nil, runTime, fmt.Errorf("Submission failed internally. stdout: '%s', stderr: '%s': '%w'.", stdout, stderr, err)
+	}
+
+	if reject != nil {
+		log.Debug("Regrade submission rejected.", log.NewAttr("reason", reject.String()))
+
+		runTime := int64(timestamp.Now() - startTime)
+		return nil, runTime, fmt.Errorf("Submission rejected: '%s'.", reject.String())
+	}
+
+	if failureMessage != "" {
+		log.Debug("Regrade submission got a soft error.", log.NewAttr("message", failureMessage))
+
+		runTime := int64(timestamp.Now() - startTime)
+		return nil, runTime, fmt.Errorf("Submission got a soft error: '%s'.", failureMessage)
+	}
+
+	var result *model.SubmissionHistoryItem = nil
+	if gradingResult.Info != nil {
+		result = (*gradingResult.Info).ToHistoryItem()
+	}
+
+	runTime := int64(timestamp.Now() - startTime)
+	return result, runTime, nil
+}

--- a/internal/grader/regrade.go
+++ b/internal/grader/regrade.go
@@ -62,7 +62,7 @@ func RegradeSubmissions(options RegradeOptions) (map[string]*model.SubmissionHis
 
 func runRegradeSubmissions(options RegradeOptions) (map[string]*model.SubmissionHistoryItem, error) {
 	if len(options.Users) == 0 {
-		return nil, nil
+		return map[string]*model.SubmissionHistoryItem{}, nil
 	}
 
 	// Lock based on the course to prevent multiple requests using up all the cores.

--- a/internal/grader/regrade_test.go
+++ b/internal/grader/regrade_test.go
@@ -1,0 +1,159 @@
+package grader
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/edulinq/autograder/internal/db"
+	"github.com/edulinq/autograder/internal/docker"
+	"github.com/edulinq/autograder/internal/model"
+	"github.com/edulinq/autograder/internal/util"
+)
+
+func TestRegradeBase(test *testing.T) {
+	docker.EnsureOrSkipForTest(test)
+
+	defer db.ResetForTesting()
+
+	// Note that computation of these paths are deferred until test time.
+	studentGradingResults := map[string]*model.GradingResult{
+		"1697406272": model.MustLoadGradingResult(getTestSubmissionResultPath("1697406272")),
+	}
+
+	testCases := []struct {
+		users             []string
+		waitForCompletion bool
+		numLeft           int
+		results           map[string]*model.SubmissionHistoryItem
+	}{
+		// User with submission, wait
+		{
+			[]string{"course-student@test.edulinq.org"},
+			true,
+			0,
+			map[string]*model.SubmissionHistoryItem{
+				"course-student@test.edulinq.org": studentGradingResults["1697406272"].Info.ToHistoryItem(),
+			},
+		},
+
+		// Empty users, wait
+		{
+			[]string{},
+			true,
+			0,
+			map[string]*model.SubmissionHistoryItem{},
+		},
+
+		// Empty submissions, wait
+		{
+			[]string{"course-admin@test.edulinq.org"},
+			true,
+			0,
+			map[string]*model.SubmissionHistoryItem{
+				"course-admin@test.edulinq.org": nil,
+			},
+		},
+
+		// User with submission, no wait
+		{
+			[]string{"course-student@test.edulinq.org"},
+			false,
+			1,
+			map[string]*model.SubmissionHistoryItem{},
+		},
+
+		// Empty users, no wait
+		{
+			[]string{},
+			false,
+			0,
+			map[string]*model.SubmissionHistoryItem{},
+		},
+
+		// Empty submission, no wait
+		{
+			[]string{"course-admin@test.edulinq.org"},
+			false,
+			1,
+			map[string]*model.SubmissionHistoryItem{},
+		},
+	}
+
+	assignment := db.MustGetTestAssignment()
+
+	for i, testCase := range testCases {
+		db.ResetForTesting()
+
+		options := RegradeOptions{
+			Users:             testCase.users,
+			Assignment:        assignment,
+			WaitForCompletion: testCase.waitForCompletion,
+		}
+
+		results, numLeft, err := RegradeSubmissions(options)
+		if err != nil {
+			test.Errorf("Case %d: Failed to regrade submissions: '%v'.", i, err)
+			continue
+		}
+
+		if testCase.numLeft != numLeft {
+			test.Errorf("Case %d: Unexpected number of regrades remaining. Expected: '%d', actual: '%d'.", i, testCase.numLeft, numLeft)
+			continue
+		}
+
+		failed := checkAndClearIDs(test, i, testCase.results, results)
+		if failed {
+			continue
+		}
+
+		if !reflect.DeepEqual(testCase.results, results) {
+			test.Errorf("Case %d: Unexpected regrade result. Expected: '%s', actual: '%s'.",
+				i, util.MustToJSONIndent(testCase.results), util.MustToJSONIndent(results))
+			continue
+		}
+	}
+}
+
+func checkAndClearIDs(test *testing.T, i int, expectedResults map[string]*model.SubmissionHistoryItem, actualResults map[string]*model.SubmissionHistoryItem) bool {
+	for user, expected := range expectedResults {
+		actual, ok := actualResults[user]
+		if !ok {
+			test.Errorf("Case %d: Unable to find result for user '%s'. Expected: '%v'.",
+				i, user, util.MustToJSONIndent(expected))
+			return true
+		}
+
+		if (expected == nil) && (actual == nil) {
+			return false
+		}
+
+		if expected == nil {
+			test.Errorf("Case %d: Unexpected result for user '%s'. Expected: '<nil>', actual: '%s'.",
+				i, user, util.MustToJSONIndent(actual))
+			return true
+		}
+
+		if actual == nil {
+			test.Errorf("Case %d: Unexpected result for user '%s'. Expected: '%s', actual: '<nil>'.",
+				i, user, util.MustToJSONIndent(expected))
+			return true
+		}
+
+		if expected.ShortID == actual.ShortID {
+			test.Errorf("Case %d: Regrade submission has the same short ID as the previous submission: '%s'.", i, expected.ShortID)
+			return true
+		}
+
+		if expected.ID == actual.ID {
+			test.Errorf("Case %d: Regrade submission has the same ID as the previous submission: '%s'.", i, expected.ID)
+			return true
+		}
+
+		actual.ShortID = ""
+		expected.ShortID = ""
+		actual.ID = ""
+		expected.ID = ""
+	}
+
+	return false
+}

--- a/internal/grader/regrade_test.go
+++ b/internal/grader/regrade_test.go
@@ -85,6 +85,7 @@ func TestRegradeBase(test *testing.T) {
 		db.ResetForTesting()
 
 		options := RegradeOptions{
+			Options:           GetDefaultGradeOptions(),
 			Users:             testCase.users,
 			Assignment:        assignment,
 			WaitForCompletion: testCase.waitForCompletion,
@@ -101,7 +102,7 @@ func TestRegradeBase(test *testing.T) {
 			continue
 		}
 
-		failed := checkAndClearIDs(test, i, testCase.results, results)
+		failed := CheckAndClearIDs(test, i, testCase.results, results)
 		if failed {
 			continue
 		}
@@ -112,48 +113,4 @@ func TestRegradeBase(test *testing.T) {
 			continue
 		}
 	}
-}
-
-func checkAndClearIDs(test *testing.T, i int, expectedResults map[string]*model.SubmissionHistoryItem, actualResults map[string]*model.SubmissionHistoryItem) bool {
-	for user, expected := range expectedResults {
-		actual, ok := actualResults[user]
-		if !ok {
-			test.Errorf("Case %d: Unable to find result for user '%s'. Expected: '%v'.",
-				i, user, util.MustToJSONIndent(expected))
-			return true
-		}
-
-		if (expected == nil) && (actual == nil) {
-			return false
-		}
-
-		if expected == nil {
-			test.Errorf("Case %d: Unexpected result for user '%s'. Expected: '<nil>', actual: '%s'.",
-				i, user, util.MustToJSONIndent(actual))
-			return true
-		}
-
-		if actual == nil {
-			test.Errorf("Case %d: Unexpected result for user '%s'. Expected: '%s', actual: '<nil>'.",
-				i, user, util.MustToJSONIndent(expected))
-			return true
-		}
-
-		if expected.ShortID == actual.ShortID {
-			test.Errorf("Case %d: Regrade submission has the same short ID as the previous submission: '%s'.", i, expected.ShortID)
-			return true
-		}
-
-		if expected.ID == actual.ID {
-			test.Errorf("Case %d: Regrade submission has the same ID as the previous submission: '%s'.", i, expected.ID)
-			return true
-		}
-
-		actual.ShortID = ""
-		expected.ShortID = ""
-		actual.ID = ""
-		expected.ID = ""
-	}
-
-	return false
 }

--- a/internal/grader/test.go
+++ b/internal/grader/test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"testing"
 
 	"github.com/edulinq/autograder/internal/config"
 	"github.com/edulinq/autograder/internal/db"
@@ -71,6 +72,50 @@ func GetTestSubmissions(baseDir string, useDocker bool) ([]*TestSubmissionInfo, 
 	}
 
 	return testSubmissions, nil
+}
+
+func CheckAndClearIDs(test *testing.T, i int, expectedResults map[string]*model.SubmissionHistoryItem, actualResults map[string]*model.SubmissionHistoryItem) bool {
+	for user, expected := range expectedResults {
+		actual, ok := actualResults[user]
+		if !ok {
+			test.Errorf("Case %d: Unable to find result for user '%s'. Expected: '%v'.",
+				i, user, util.MustToJSONIndent(expected))
+			return true
+		}
+
+		if (expected == nil) && (actual == nil) {
+			return false
+		}
+
+		if expected == nil {
+			test.Errorf("Case %d: Unexpected result for user '%s'. Expected: '<nil>', actual: '%s'.",
+				i, user, util.MustToJSONIndent(actual))
+			return true
+		}
+
+		if actual == nil {
+			test.Errorf("Case %d: Unexpected result for user '%s'. Expected: '%s', actual: '<nil>'.",
+				i, user, util.MustToJSONIndent(expected))
+			return true
+		}
+
+		if expected.ShortID == actual.ShortID {
+			test.Errorf("Case %d: Regrade submission has the same short ID as the previous submission: '%s'.", i, expected.ShortID)
+			return true
+		}
+
+		if expected.ID == actual.ID {
+			test.Errorf("Case %d: Regrade submission has the same ID as the previous submission: '%s'.", i, expected.ID)
+			return true
+		}
+
+		actual.ShortID = ""
+		expected.ShortID = ""
+		actual.ID = ""
+		expected.ID = ""
+	}
+
+	return false
 }
 
 // Test submission are within their assignment's directory,

--- a/internal/grader/test.go
+++ b/internal/grader/test.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/edulinq/autograder/internal/config"
 	"github.com/edulinq/autograder/internal/db"
 	"github.com/edulinq/autograder/internal/model"
 	"github.com/edulinq/autograder/internal/util"
@@ -99,4 +100,8 @@ func fetchTestSubmissionAssignment(testSubmissionPath string) (*model.Assignment
 	}
 
 	return db.GetAssignment(course.GetID(), assignment.GetID())
+}
+
+func getTestSubmissionResultPath(shortID string) string {
+	return filepath.Join(config.GetTestdataDir(), "course101", "submissions", "HW0", "course-student@test.edulinq.org", shortID, "submission-result.json")
 }

--- a/resources/api.json
+++ b/resources/api.json
@@ -175,7 +175,7 @@
             }
         },
         "courses/assignments/submissions/proxy/regrade": {
-            "description": "Regrade the most recent submissions for the course.",
+            "description": "Regrade the most recent submissions for users with the filtered role in the course.",
             "input": {
                 "assignment-id": "string",
                 "course-id": "string",
@@ -184,7 +184,9 @@
                 "user-pass": "string"
             },
             "output": {
-                "submission-infos": "map[string]*model.SubmissionHistoryItem"
+                "complete": "bool",
+                "options": "grader.RegradeOptions",
+                "results": "map[string]*model.SubmissionHistoryItem"
             }
         },
         "courses/assignments/submissions/proxy/resubmit": {
@@ -747,6 +749,13 @@
                 "html": "bool",
                 "subject": "string",
                 "to": "[]string"
+            }
+        },
+        "grader.RegradeOptions": {
+            "category": "struct",
+            "fields": {
+                "users": "[]string",
+                "wait-for-completion": "bool"
             }
         },
         "log.LogLevel": {

--- a/resources/api.json
+++ b/resources/api.json
@@ -174,6 +174,19 @@
                 "submission-result": "*model.GradingInfo"
             }
         },
+        "courses/assignments/submissions/proxy/regrade": {
+            "description": "Regrade the most recent submissions for the course.",
+            "input": {
+                "assignment-id": "string",
+                "course-id": "string",
+                "filter-role": "int",
+                "user-email": "string",
+                "user-pass": "string"
+            },
+            "output": {
+                "submission-infos": "map[string]*model.SubmissionHistoryItem"
+            }
+        },
         "courses/assignments/submissions/proxy/resubmit": {
             "description": "Proxy resubmit an assignment submission to the autograder.",
             "input": {

--- a/resources/api.json
+++ b/resources/api.json
@@ -181,12 +181,13 @@
                 "course-id": "string",
                 "filter-role": "int",
                 "user-email": "string",
-                "user-pass": "string"
+                "user-pass": "string",
+                "wait-for-completion": "bool"
             },
             "output": {
                 "complete": "bool",
-                "options": "grader.RegradeOptions",
-                "results": "map[string]*model.SubmissionHistoryItem"
+                "results": "map[string]*model.SubmissionHistoryItem",
+                "users": "[]string"
             }
         },
         "courses/assignments/submissions/proxy/resubmit": {
@@ -749,13 +750,6 @@
                 "html": "bool",
                 "subject": "string",
                 "to": "[]string"
-            }
-        },
-        "grader.RegradeOptions": {
-            "category": "struct",
-            "fields": {
-                "users": "[]string",
-                "wait-for-completion": "bool"
             }
         },
         "log.LogLevel": {


### PR DESCRIPTION
This PR adds a new API endpoint `courses/assignment/submissions/proxy/regrade` that allows course graders (or above) to make mass proxy regrades based on a given role.

Regrades take the most recent submission for every user with the filtered role and resubmit with a proxy time that is the same time as the original submission. This features allows course staff to easily regrade every students (or another role's) submissions.

As regrades may take a long time (as there could be many students), the endpoint gives the option to wait for completion. If the requesting user does not wait for completion, the results will be available by looking at the submission history.