### PR TITLE
Added descriptions of structs to the API type descriptions.

### DIFF
--- a/internal/api/core/describe.go
+++ b/internal/api/core/describe.go
@@ -21,21 +21,26 @@ var apiDescription APIDescription
 
 type APIDescription struct {
 	Endpoints map[string]EndpointDescription `json:"endpoints"`
-	Types     map[string]TypeDescription     `json:"types"`
+	Types     map[string]FullTypeDescription `json:"types"`
 }
 
 type EndpointDescription struct {
 	Description  string            `json:"description"`
 	RequestType  string            `json:"-"`
 	ResponseType string            `json:"-"`
-	Input        map[string]string `json:"input"`
-	Output       map[string]string `json:"output"`
+	Input        []TypeDescription `json:"input"`
+	Output       []TypeDescription `json:"output"`
 }
 
 type TypeDescription struct {
+	FieldName string `json:"field-name"`
+	FieldType string `json:"field-type"`
+}
+
+type FullTypeDescription struct {
 	Category    string            `json:"category"`
 	AliasType   string            `json:"alias-type,omitempty"`
-	Fields      map[string]string `json:"fields,omitempty"`
+	Fields      []TypeDescription `json:"fields,omitempty"`
 	ElementType string            `json:"element-type,omitempty"`
 	KeyType     string            `json:"-"`
 	ValueType   string            `json:"-"`
@@ -47,6 +52,26 @@ func SetAPIDescription(description APIDescription) {
 
 func GetAPIDescription() APIDescription {
 	return apiDescription
+}
+
+func CompareTypeDescriptionPointer(a *TypeDescription, b *TypeDescription) int {
+	if a == b {
+		return 0
+	}
+
+	if a == nil {
+		return 1
+	}
+
+	if b == nil {
+		return -1
+	}
+
+	return CompareTypeDescription(*a, *b)
+}
+
+func CompareTypeDescription(a TypeDescription, b TypeDescription) int {
+	return strings.Compare(a.FieldName, b.FieldName)
 }
 
 func GetDescriptionFromHandler(basePath string) (string, error) {

--- a/internal/api/core/describe.go
+++ b/internal/api/core/describe.go
@@ -33,9 +33,8 @@ type EndpointDescription struct {
 }
 
 type FieldDescription struct {
-	FieldName string `json:"field-name"`
-	FieldType string `json:"field-type"`
-	// FieldDescription string `json:"field-description"`
+	Name string `json:"name"`
+	Type string `json:"type"`
 }
 
 type TypeDescription struct {
@@ -56,24 +55,8 @@ func GetAPIDescription() APIDescription {
 	return apiDescription
 }
 
-func CompareFieldDescriptionPointer(a *FieldDescription, b *FieldDescription) int {
-	if a == b {
-		return 0
-	}
-
-	if a == nil {
-		return 1
-	}
-
-	if b == nil {
-		return -1
-	}
-
-	return CompareFieldDescription(*a, *b)
-}
-
 func CompareFieldDescription(a FieldDescription, b FieldDescription) int {
-	return strings.Compare(a.FieldName, b.FieldName)
+	return strings.Compare(a.Name, b.Name)
 }
 
 func GetDescriptionFromHandler(basePath string) (string, error) {

--- a/internal/api/core/describe.go
+++ b/internal/api/core/describe.go
@@ -21,31 +21,31 @@ var apiDescription APIDescription
 
 type APIDescription struct {
 	Endpoints map[string]EndpointDescription `json:"endpoints"`
-	Types     map[string]FullTypeDescription `json:"types"`
+	Types     map[string]TypeDescription     `json:"types"`
 }
 
 type EndpointDescription struct {
-	Description  string            `json:"description"`
-	RequestType  string            `json:"-"`
-	ResponseType string            `json:"-"`
-	Input        []TypeDescription `json:"input"`
-	Output       []TypeDescription `json:"output"`
+	Description  string             `json:"description"`
+	RequestType  string             `json:"-"`
+	ResponseType string             `json:"-"`
+	Input        []FieldDescription `json:"input"`
+	Output       []FieldDescription `json:"output"`
 }
 
-type TypeDescription struct {
+type FieldDescription struct {
 	FieldName string `json:"field-name"`
 	FieldType string `json:"field-type"`
 	// FieldDescription string `json:"field-description"`
 }
 
-type FullTypeDescription struct {
-	Category    string            `json:"category"`
-	Description string            `json:"description,omitempty"`
-	AliasType   string            `json:"alias-type,omitempty"`
-	Fields      []TypeDescription `json:"fields,omitempty"`
-	ElementType string            `json:"element-type,omitempty"`
-	KeyType     string            `json:"-"`
-	ValueType   string            `json:"-"`
+type TypeDescription struct {
+	Category    string             `json:"category"`
+	Description string             `json:"description,omitempty"`
+	AliasType   string             `json:"alias-type,omitempty"`
+	Fields      []FieldDescription `json:"fields,omitempty"`
+	ElementType string             `json:"element-type,omitempty"`
+	KeyType     string             `json:"-"`
+	ValueType   string             `json:"-"`
 }
 
 func SetAPIDescription(description APIDescription) {
@@ -56,7 +56,7 @@ func GetAPIDescription() APIDescription {
 	return apiDescription
 }
 
-func CompareTypeDescriptionPointer(a *TypeDescription, b *TypeDescription) int {
+func CompareFieldDescriptionPointer(a *FieldDescription, b *FieldDescription) int {
 	if a == b {
 		return 0
 	}
@@ -69,10 +69,10 @@ func CompareTypeDescriptionPointer(a *TypeDescription, b *TypeDescription) int {
 		return -1
 	}
 
-	return CompareTypeDescription(*a, *b)
+	return CompareFieldDescription(*a, *b)
 }
 
-func CompareTypeDescription(a TypeDescription, b TypeDescription) int {
+func CompareFieldDescription(a FieldDescription, b FieldDescription) int {
 	return strings.Compare(a.FieldName, b.FieldName)
 }
 

--- a/internal/api/core/describe.go
+++ b/internal/api/core/describe.go
@@ -35,10 +35,12 @@ type EndpointDescription struct {
 type TypeDescription struct {
 	FieldName string `json:"field-name"`
 	FieldType string `json:"field-type"`
+	// FieldDescription string `json:"field-description"`
 }
 
 type FullTypeDescription struct {
 	Category    string            `json:"category"`
+	Description string            `json:"description,omitempty"`
 	AliasType   string            `json:"alias-type,omitempty"`
 	Fields      []TypeDescription `json:"fields,omitempty"`
 	ElementType string            `json:"element-type,omitempty"`

--- a/internal/api/describe.go
+++ b/internal/api/describe.go
@@ -199,7 +199,6 @@ func describeType(customType reflect.Type, addType bool, typeMap map[string]core
 			break
 		}
 
-		// TODO: Should we log an error or just assume people look at resources/api.json bc of test?
 		if customType.Name() == "" {
 			break
 		}
@@ -260,7 +259,7 @@ func describeStructFields(customType reflect.Type, typeMap map[string]core.TypeD
 			// If the embedded type is a struct, merge its fields into the current struct.
 			if len(fieldDescription.Fields) > 0 {
 				for _, description := range fieldDescription.Fields {
-					if skipField(description.FieldName) {
+					if skipField(description.Name) {
 						continue
 					}
 
@@ -269,16 +268,16 @@ func describeStructFields(customType reflect.Type, typeMap map[string]core.TypeD
 			} else if fieldDescription.Category == core.AliasType {
 				// Store basic embedded types under the current JSON tag.
 				description := core.FieldDescription{
-					FieldName: jsonTag,
-					FieldType: fieldDescription.AliasType,
+					Name: jsonTag,
+					Type: fieldDescription.AliasType,
 				}
 
 				fieldDescriptions = append(fieldDescriptions, description)
 			} else {
 				// Store non-basic embedded types under the current JSON tag using the typeID.
 				description := core.FieldDescription{
-					FieldName: jsonTag,
-					FieldType: fieldTypeID,
+					Name: jsonTag,
+					Type: fieldTypeID,
 				}
 
 				fieldDescriptions = append(fieldDescriptions, description)
@@ -300,15 +299,15 @@ func describeStructFields(customType reflect.Type, typeMap map[string]core.TypeD
 
 		if typeDescription.Category == core.AliasType {
 			fieldDescription := core.FieldDescription{
-				FieldName: jsonTag,
-				FieldType: typeDescription.AliasType,
+				Name: jsonTag,
+				Type: typeDescription.AliasType,
 			}
 
 			fieldDescriptions = append(fieldDescriptions, fieldDescription)
 		} else {
 			fieldDescription := core.FieldDescription{
-				FieldName: jsonTag,
-				FieldType: typeID,
+				Name: jsonTag,
+				Type: typeID,
 			}
 
 			fieldDescriptions = append(fieldDescriptions, fieldDescription)

--- a/internal/api/describe.go
+++ b/internal/api/describe.go
@@ -194,6 +194,26 @@ func describeType(customType reflect.Type, addType bool, typeMap map[string]core
 		if err != nil {
 			return core.FullTypeDescription{}, "", map[string]core.FullTypeDescription{}, map[string]string{}, err
 		}
+
+		if !addType {
+			break
+		}
+
+		// TODO: Should we log an error or just assume people look at resources/api.json bc of test?
+		if customType.Name() == "" {
+			break
+		}
+
+		if customType.PkgPath() == "" {
+			break
+		}
+
+		description, err := util.GetDescriptionFromType(customType.PkgPath(), customType.Name())
+		if err != nil {
+			return core.FullTypeDescription{}, "", map[string]core.FullTypeDescription{}, map[string]string{}, err
+		}
+
+		typeDescription.Description = description
 	default:
 		// Handle built-in types.
 		typeDescription.Category = core.AliasType

--- a/internal/api/describe.go
+++ b/internal/api/describe.go
@@ -208,12 +208,15 @@ func describeType(customType reflect.Type, addType bool, typeMap map[string]core
 			break
 		}
 
-		description, err := util.GetDescriptionFromType(customType.PkgPath(), customType.Name())
+		descriptions, err := util.GetAllTypeDescriptionsFromPackage(customType.PkgPath())
 		if err != nil {
 			return core.TypeDescription{}, "", map[string]core.TypeDescription{}, map[string]string{}, err
 		}
 
-		typeDescription.Description = description
+		description, ok := descriptions[customType.Name()]
+		if ok {
+			typeDescription.Description = description
+		}
 	default:
 		// Handle built-in types.
 		typeDescription.Category = core.AliasType

--- a/internal/api/describe_test.go
+++ b/internal/api/describe_test.go
@@ -157,52 +157,52 @@ func TestDescribeEmptyRoutes(test *testing.T) {
 func TestDescribeType(test *testing.T) {
 	testCases := []struct {
 		customType      reflect.Type
-		expectedDesc    core.TypeDescription
-		expectedTypeMap map[string]core.TypeDescription
+		expectedDesc    core.FullTypeDescription
+		expectedTypeMap map[string]core.FullTypeDescription
 	}{
 		// Base types to alias (no JSON tags).
 		{
 			reflect.TypeOf((*string)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category:  core.AliasType,
 				AliasType: "string",
 			},
-			map[string]core.TypeDescription{},
+			map[string]core.FullTypeDescription{},
 		},
 		{
 			reflect.TypeOf((*int)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category:  core.AliasType,
 				AliasType: "int",
 			},
-			map[string]core.TypeDescription{},
+			map[string]core.FullTypeDescription{},
 		},
 		{
 			reflect.TypeOf((*int64)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category:  core.AliasType,
 				AliasType: "int64",
 			},
-			map[string]core.TypeDescription{},
+			map[string]core.FullTypeDescription{},
 		},
 		{
 			reflect.TypeOf((*bool)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category:  core.AliasType,
 				AliasType: "bool",
 			},
-			map[string]core.TypeDescription{},
+			map[string]core.FullTypeDescription{},
 		},
 
 		// Simple wrapper types.
 		{
 			reflect.TypeOf((*stringWrapper)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category:  core.AliasType,
 				AliasType: "string",
 			},
-			map[string]core.TypeDescription{
-				mustGetTypeID(reflect.TypeOf((*stringWrapper)(nil)).Elem(), nil): core.TypeDescription{
+			map[string]core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*stringWrapper)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category:  core.AliasType,
 					AliasType: "string",
 				},
@@ -210,12 +210,12 @@ func TestDescribeType(test *testing.T) {
 		},
 		{
 			reflect.TypeOf((*core.MinServerRoleAdmin)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category:  core.AliasType,
 				AliasType: "bool",
 			},
-			map[string]core.TypeDescription{
-				mustGetTypeID(reflect.TypeOf((*core.MinServerRoleAdmin)(nil)).Elem(), nil): core.TypeDescription{
+			map[string]core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*core.MinServerRoleAdmin)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category:  core.AliasType,
 					AliasType: "bool",
 				},
@@ -225,32 +225,32 @@ func TestDescribeType(test *testing.T) {
 		// Simple maps and arrays.
 		{
 			reflect.TypeOf((*map[string]string)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category:  core.MapType,
 				KeyType:   "string",
 				ValueType: "string",
 			},
-			map[string]core.TypeDescription{},
+			map[string]core.FullTypeDescription{},
 		},
 		{
 			reflect.TypeOf((*[]string)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category:    core.ArrayType,
 				ElementType: "string",
 			},
-			map[string]core.TypeDescription{},
+			map[string]core.FullTypeDescription{},
 		},
 
 		// Wrapped maps and arrays.
 		{
 			reflect.TypeOf((*simpleMapWrapper)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category:  core.MapType,
 				KeyType:   "string",
 				ValueType: "int",
 			},
-			map[string]core.TypeDescription{
-				mustGetTypeID(reflect.TypeOf((*simpleMapWrapper)(nil)).Elem(), nil): core.TypeDescription{
+			map[string]core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleMapWrapper)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category:  core.MapType,
 					KeyType:   "string",
 					ValueType: "int",
@@ -259,12 +259,12 @@ func TestDescribeType(test *testing.T) {
 		},
 		{
 			reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category:    core.ArrayType,
 				ElementType: "bool",
 			},
-			map[string]core.TypeDescription{
-				mustGetTypeID(reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(), nil): core.TypeDescription{
+			map[string]core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category:    core.ArrayType,
 					ElementType: "bool",
 				},
@@ -274,27 +274,27 @@ func TestDescribeType(test *testing.T) {
 		// Fields without JSON tags are ignored.
 		{
 			reflect.TypeOf((*simpleStruct)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category: core.StructType,
-				Fields:   map[string]string{},
+				Fields:   []core.TypeDescription{},
 			},
-			map[string]core.TypeDescription{
-				mustGetTypeID(reflect.TypeOf((*simpleStruct)(nil)).Elem(), nil): core.TypeDescription{
+			map[string]core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleStruct)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category: core.StructType,
-					Fields:   map[string]string{},
+					Fields:   []core.TypeDescription{},
 				},
 			},
 		},
 		{
 			reflect.TypeOf((*wrappedStruct)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category: core.StructType,
-				Fields:   map[string]string{},
+				Fields:   []core.TypeDescription{},
 			},
-			map[string]core.TypeDescription{
-				mustGetTypeID(reflect.TypeOf((*wrappedStruct)(nil)).Elem(), nil): core.TypeDescription{
+			map[string]core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*wrappedStruct)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category: core.StructType,
-					Fields:   map[string]string{},
+					Fields:   []core.TypeDescription{},
 				},
 			},
 		},
@@ -302,19 +302,19 @@ func TestDescribeType(test *testing.T) {
 		// Simple JSON tags.
 		{
 			reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category: core.StructType,
-				Fields: map[string]string{
-					"email":    "string",
-					"job-code": "int",
+				Fields: []core.TypeDescription{
+					core.TypeDescription{"email", "string"},
+					core.TypeDescription{"job-code", "int"},
 				},
 			},
-			map[string]core.TypeDescription{
-				mustGetTypeID(reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
+			map[string]core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category: core.StructType,
-					Fields: map[string]string{
-						"email":    "string",
-						"job-code": "int",
+					Fields: []core.TypeDescription{
+						core.TypeDescription{"email", "string"},
+						core.TypeDescription{"job-code", "int"},
 					},
 				},
 			},
@@ -323,19 +323,19 @@ func TestDescribeType(test *testing.T) {
 		// Hidden JSON tags (-).
 		{
 			reflect.TypeOf((*secureJSONStruct)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category: core.StructType,
-				Fields: map[string]string{
-					"first-name": "string",
-					"last-name":  "string",
+				Fields: []core.TypeDescription{
+					core.TypeDescription{"first-name", "string"},
+					core.TypeDescription{"last-name", "string"},
 				},
 			},
-			map[string]core.TypeDescription{
-				mustGetTypeID(reflect.TypeOf((*secureJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
+			map[string]core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*secureJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category: core.StructType,
-					Fields: map[string]string{
-						"first-name": "string",
-						"last-name":  "string",
+					Fields: []core.TypeDescription{
+						core.TypeDescription{"first-name", "string"},
+						core.TypeDescription{"last-name", "string"},
 					},
 				},
 			},
@@ -344,37 +344,37 @@ func TestDescribeType(test *testing.T) {
 		// Embedded fields.
 		{
 			reflect.TypeOf((*embeddedJSONStruct)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category: core.StructType,
-				Fields: map[string]string{
-					"email":      "string",
-					"job-code":   "int",
-					"first-name": "string",
-					"last-name":  "string",
+				Fields: []core.TypeDescription{
+					core.TypeDescription{"email", "string"},
+					core.TypeDescription{"first-name", "string"},
+					core.TypeDescription{"job-code", "int"},
+					core.TypeDescription{"last-name", "string"},
 				},
 			},
-			map[string]core.TypeDescription{
-				mustGetTypeID(reflect.TypeOf((*embeddedJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
+			map[string]core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*embeddedJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category: core.StructType,
-					Fields: map[string]string{
-						"email":      "string",
-						"first-name": "string",
-						"job-code":   "int",
-						"last-name":  "string",
+					Fields: []core.TypeDescription{
+						core.TypeDescription{"email", "string"},
+						core.TypeDescription{"first-name", "string"},
+						core.TypeDescription{"job-code", "int"},
+						core.TypeDescription{"last-name", "string"},
 					},
 				},
-				mustGetTypeID(reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category: core.StructType,
-					Fields: map[string]string{
-						"email":    "string",
-						"job-code": "int",
+					Fields: []core.TypeDescription{
+						core.TypeDescription{"email", "string"},
+						core.TypeDescription{"job-code", "int"},
 					},
 				},
-				mustGetTypeID(reflect.TypeOf((*secureJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*secureJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category: core.StructType,
-					Fields: map[string]string{
-						"first-name": "string",
-						"last-name":  "string",
+					Fields: []core.TypeDescription{
+						core.TypeDescription{"first-name", "string"},
+						core.TypeDescription{"last-name", "string"},
 					},
 				},
 			},
@@ -383,51 +383,51 @@ func TestDescribeType(test *testing.T) {
 		// Complex fields.
 		{
 			reflect.TypeOf((*complexJSONStruct)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category: core.StructType,
-				Fields: map[string]string{
-					"coin-value": "api.simpleMapWrapper",
-					"good-index": "api.simpleArrayWrapper",
-					"personnel":  "api.embeddedJSONStruct",
+				Fields: []core.TypeDescription{
+					core.TypeDescription{"coin-value", "api.simpleMapWrapper"},
+					core.TypeDescription{"good-index", "api.simpleArrayWrapper"},
+					core.TypeDescription{"personnel", "api.embeddedJSONStruct"},
 				},
 			},
-			map[string]core.TypeDescription{
-				mustGetTypeID(reflect.TypeOf((*complexJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
+			map[string]core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*complexJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category: core.StructType,
-					Fields: map[string]string{
-						"coin-value": "api.simpleMapWrapper",
-						"good-index": "api.simpleArrayWrapper",
-						"personnel":  "api.embeddedJSONStruct",
+					Fields: []core.TypeDescription{
+						core.TypeDescription{"coin-value", "api.simpleMapWrapper"},
+						core.TypeDescription{"good-index", "api.simpleArrayWrapper"},
+						core.TypeDescription{"personnel", "api.embeddedJSONStruct"},
 					},
 				},
-				mustGetTypeID(reflect.TypeOf((*embeddedJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*embeddedJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category: core.StructType,
-					Fields: map[string]string{
-						"email":      "string",
-						"first-name": "string",
-						"job-code":   "int",
-						"last-name":  "string",
+					Fields: []core.TypeDescription{
+						core.TypeDescription{"email", "string"},
+						core.TypeDescription{"first-name", "string"},
+						core.TypeDescription{"job-code", "int"},
+						core.TypeDescription{"last-name", "string"},
 					},
 				},
-				mustGetTypeID(reflect.TypeOf((*secureJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*secureJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category: core.StructType,
-					Fields: map[string]string{
-						"first-name": "string",
-						"last-name":  "string",
+					Fields: []core.TypeDescription{
+						core.TypeDescription{"first-name", "string"},
+						core.TypeDescription{"last-name", "string"},
 					},
 				},
-				mustGetTypeID(reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(), nil): core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category:    core.ArrayType,
 					ElementType: "bool",
 				},
-				mustGetTypeID(reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category: core.StructType,
-					Fields: map[string]string{
-						"email":    "string",
-						"job-code": "int",
+					Fields: []core.TypeDescription{
+						core.TypeDescription{"email", "string"},
+						core.TypeDescription{"job-code", "int"},
 					},
 				},
-				mustGetTypeID(reflect.TypeOf((*simpleMapWrapper)(nil)).Elem(), nil): core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleMapWrapper)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category:  core.MapType,
 					KeyType:   "string",
 					ValueType: "int",
@@ -438,80 +438,80 @@ func TestDescribeType(test *testing.T) {
 		// Pointers to various types.
 		{
 			reflect.TypeOf((**string)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category:  core.AliasType,
 				AliasType: "string",
 			},
-			map[string]core.TypeDescription{},
+			map[string]core.FullTypeDescription{},
 		},
 		{
 			reflect.TypeOf((**map[string]string)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category:  core.MapType,
 				KeyType:   "string",
 				ValueType: "string",
 			},
-			map[string]core.TypeDescription{},
+			map[string]core.FullTypeDescription{},
 		},
 
 		// Pointers inside of fields.
 		{
 			reflect.TypeOf((*simplePointerWrapper)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category:  core.AliasType,
 				AliasType: "string",
 			},
-			map[string]core.TypeDescription{},
+			map[string]core.FullTypeDescription{},
 		},
 		{
 			reflect.TypeOf((*complexPointerStruct)(nil)).Elem(),
-			core.TypeDescription{
+			core.FullTypeDescription{
 				Category: core.StructType,
-				Fields: map[string]string{
-					"coin-value": "*api.simpleMapWrapper",
-					"good-index": "*api.simpleArrayWrapper",
-					"personnel":  "*api.embeddedJSONStruct",
+				Fields: []core.TypeDescription{
+					core.TypeDescription{"coin-value", "*api.simpleMapWrapper"},
+					core.TypeDescription{"good-index", "*api.simpleArrayWrapper"},
+					core.TypeDescription{"personnel", "*api.embeddedJSONStruct"},
 				},
 			},
-			map[string]core.TypeDescription{
-				mustGetTypeID(reflect.TypeOf((*complexPointerStruct)(nil)).Elem(), nil): core.TypeDescription{
+			map[string]core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*complexPointerStruct)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category: core.StructType,
-					Fields: map[string]string{
-						"coin-value": "*api.simpleMapWrapper",
-						"good-index": "*api.simpleArrayWrapper",
-						"personnel":  "*api.embeddedJSONStruct",
+					Fields: []core.TypeDescription{
+						core.TypeDescription{"coin-value", "*api.simpleMapWrapper"},
+						core.TypeDescription{"good-index", "*api.simpleArrayWrapper"},
+						core.TypeDescription{"personnel", "*api.embeddedJSONStruct"},
 					},
 				},
 				// Note that the keys in typeMap do not include the pointer.
 				// TypeMap stores 'api/api.embeddedJSONStruct' instead of 'api/*api.embeddedJSONStruct'.
-				mustGetTypeID(reflect.TypeOf((*embeddedJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*embeddedJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category: core.StructType,
-					Fields: map[string]string{
-						"email":      "string",
-						"first-name": "string",
-						"job-code":   "int",
-						"last-name":  "string",
+					Fields: []core.TypeDescription{
+						core.TypeDescription{"email", "string"},
+						core.TypeDescription{"first-name", "string"},
+						core.TypeDescription{"job-code", "int"},
+						core.TypeDescription{"last-name", "string"},
 					},
 				},
-				mustGetTypeID(reflect.TypeOf((*secureJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*secureJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category: core.StructType,
-					Fields: map[string]string{
-						"first-name": "string",
-						"last-name":  "string",
+					Fields: []core.TypeDescription{
+						core.TypeDescription{"first-name", "string"},
+						core.TypeDescription{"last-name", "string"},
 					},
 				},
-				mustGetTypeID(reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(), nil): core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category:    core.ArrayType,
 					ElementType: "bool",
 				},
-				mustGetTypeID(reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category: core.StructType,
-					Fields: map[string]string{
-						"email":    "string",
-						"job-code": "int",
+					Fields: []core.TypeDescription{
+						core.TypeDescription{"email", "string"},
+						core.TypeDescription{"job-code", "int"},
 					},
 				},
-				mustGetTypeID(reflect.TypeOf((*simpleMapWrapper)(nil)).Elem(), nil): core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleMapWrapper)(nil)).Elem(), nil): core.FullTypeDescription{
 					Category:  core.MapType,
 					KeyType:   "string",
 					ValueType: "int",
@@ -521,7 +521,7 @@ func TestDescribeType(test *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		typeMap := make(map[string]core.TypeDescription)
+		typeMap := make(map[string]core.FullTypeDescription)
 
 		actual, _, _, _, err := describeType(testCase.customType, true, typeMap, nil)
 		if err != nil {
@@ -543,7 +543,7 @@ func TestDescribeType(test *testing.T) {
 }
 
 func TestDescribeConflictingTypes(test *testing.T) {
-	typeMap := make(map[string]core.TypeDescription)
+	typeMap := make(map[string]core.FullTypeDescription)
 	typeDescriptions := make(map[string]string)
 
 	// Add in the first users.ListRequest which will work.

--- a/internal/api/describe_test.go
+++ b/internal/api/describe_test.go
@@ -157,52 +157,52 @@ func TestDescribeEmptyRoutes(test *testing.T) {
 func TestDescribeType(test *testing.T) {
 	testCases := []struct {
 		customType      reflect.Type
-		expectedDesc    core.FullTypeDescription
-		expectedTypeMap map[string]core.FullTypeDescription
+		expectedDesc    core.TypeDescription
+		expectedTypeMap map[string]core.TypeDescription
 	}{
 		// Base types to alias (no JSON tags).
 		{
 			reflect.TypeOf((*string)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category:  core.AliasType,
 				AliasType: "string",
 			},
-			map[string]core.FullTypeDescription{},
+			map[string]core.TypeDescription{},
 		},
 		{
 			reflect.TypeOf((*int)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category:  core.AliasType,
 				AliasType: "int",
 			},
-			map[string]core.FullTypeDescription{},
+			map[string]core.TypeDescription{},
 		},
 		{
 			reflect.TypeOf((*int64)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category:  core.AliasType,
 				AliasType: "int64",
 			},
-			map[string]core.FullTypeDescription{},
+			map[string]core.TypeDescription{},
 		},
 		{
 			reflect.TypeOf((*bool)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category:  core.AliasType,
 				AliasType: "bool",
 			},
-			map[string]core.FullTypeDescription{},
+			map[string]core.TypeDescription{},
 		},
 
 		// Simple wrapper types.
 		{
 			reflect.TypeOf((*stringWrapper)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category:  core.AliasType,
 				AliasType: "string",
 			},
-			map[string]core.FullTypeDescription{
-				mustGetTypeID(reflect.TypeOf((*stringWrapper)(nil)).Elem(), nil): core.FullTypeDescription{
+			map[string]core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*stringWrapper)(nil)).Elem(), nil): core.TypeDescription{
 					Category:  core.AliasType,
 					AliasType: "string",
 				},
@@ -210,12 +210,12 @@ func TestDescribeType(test *testing.T) {
 		},
 		{
 			reflect.TypeOf((*core.MinServerRoleAdmin)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category:  core.AliasType,
 				AliasType: "bool",
 			},
-			map[string]core.FullTypeDescription{
-				mustGetTypeID(reflect.TypeOf((*core.MinServerRoleAdmin)(nil)).Elem(), nil): core.FullTypeDescription{
+			map[string]core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*core.MinServerRoleAdmin)(nil)).Elem(), nil): core.TypeDescription{
 					Category:  core.AliasType,
 					AliasType: "bool",
 				},
@@ -225,32 +225,32 @@ func TestDescribeType(test *testing.T) {
 		// Simple maps and arrays.
 		{
 			reflect.TypeOf((*map[string]string)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category:  core.MapType,
 				KeyType:   "string",
 				ValueType: "string",
 			},
-			map[string]core.FullTypeDescription{},
+			map[string]core.TypeDescription{},
 		},
 		{
 			reflect.TypeOf((*[]string)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category:    core.ArrayType,
 				ElementType: "string",
 			},
-			map[string]core.FullTypeDescription{},
+			map[string]core.TypeDescription{},
 		},
 
 		// Wrapped maps and arrays.
 		{
 			reflect.TypeOf((*simpleMapWrapper)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category:  core.MapType,
 				KeyType:   "string",
 				ValueType: "int",
 			},
-			map[string]core.FullTypeDescription{
-				mustGetTypeID(reflect.TypeOf((*simpleMapWrapper)(nil)).Elem(), nil): core.FullTypeDescription{
+			map[string]core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleMapWrapper)(nil)).Elem(), nil): core.TypeDescription{
 					Category:  core.MapType,
 					KeyType:   "string",
 					ValueType: "int",
@@ -259,12 +259,12 @@ func TestDescribeType(test *testing.T) {
 		},
 		{
 			reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category:    core.ArrayType,
 				ElementType: "bool",
 			},
-			map[string]core.FullTypeDescription{
-				mustGetTypeID(reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(), nil): core.FullTypeDescription{
+			map[string]core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(), nil): core.TypeDescription{
 					Category:    core.ArrayType,
 					ElementType: "bool",
 				},
@@ -274,27 +274,27 @@ func TestDescribeType(test *testing.T) {
 		// Fields without JSON tags are ignored.
 		{
 			reflect.TypeOf((*simpleStruct)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category: core.StructType,
-				Fields:   []core.TypeDescription{},
+				Fields:   []core.FieldDescription{},
 			},
-			map[string]core.FullTypeDescription{
-				mustGetTypeID(reflect.TypeOf((*simpleStruct)(nil)).Elem(), nil): core.FullTypeDescription{
+			map[string]core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleStruct)(nil)).Elem(), nil): core.TypeDescription{
 					Category: core.StructType,
-					Fields:   []core.TypeDescription{},
+					Fields:   []core.FieldDescription{},
 				},
 			},
 		},
 		{
 			reflect.TypeOf((*wrappedStruct)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category: core.StructType,
-				Fields:   []core.TypeDescription{},
+				Fields:   []core.FieldDescription{},
 			},
-			map[string]core.FullTypeDescription{
-				mustGetTypeID(reflect.TypeOf((*wrappedStruct)(nil)).Elem(), nil): core.FullTypeDescription{
+			map[string]core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*wrappedStruct)(nil)).Elem(), nil): core.TypeDescription{
 					Category: core.StructType,
-					Fields:   []core.TypeDescription{},
+					Fields:   []core.FieldDescription{},
 				},
 			},
 		},
@@ -302,19 +302,19 @@ func TestDescribeType(test *testing.T) {
 		// Simple JSON tags.
 		{
 			reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category: core.StructType,
-				Fields: []core.TypeDescription{
-					core.TypeDescription{"email", "string"},
-					core.TypeDescription{"job-code", "int"},
+				Fields: []core.FieldDescription{
+					core.FieldDescription{"email", "string"},
+					core.FieldDescription{"job-code", "int"},
 				},
 			},
-			map[string]core.FullTypeDescription{
-				mustGetTypeID(reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
+			map[string]core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
 					Category: core.StructType,
-					Fields: []core.TypeDescription{
-						core.TypeDescription{"email", "string"},
-						core.TypeDescription{"job-code", "int"},
+					Fields: []core.FieldDescription{
+						core.FieldDescription{"email", "string"},
+						core.FieldDescription{"job-code", "int"},
 					},
 				},
 			},
@@ -323,19 +323,19 @@ func TestDescribeType(test *testing.T) {
 		// Hidden JSON tags (-).
 		{
 			reflect.TypeOf((*secureJSONStruct)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category: core.StructType,
-				Fields: []core.TypeDescription{
-					core.TypeDescription{"first-name", "string"},
-					core.TypeDescription{"last-name", "string"},
+				Fields: []core.FieldDescription{
+					core.FieldDescription{"first-name", "string"},
+					core.FieldDescription{"last-name", "string"},
 				},
 			},
-			map[string]core.FullTypeDescription{
-				mustGetTypeID(reflect.TypeOf((*secureJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
+			map[string]core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*secureJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
 					Category: core.StructType,
-					Fields: []core.TypeDescription{
-						core.TypeDescription{"first-name", "string"},
-						core.TypeDescription{"last-name", "string"},
+					Fields: []core.FieldDescription{
+						core.FieldDescription{"first-name", "string"},
+						core.FieldDescription{"last-name", "string"},
 					},
 				},
 			},
@@ -344,37 +344,37 @@ func TestDescribeType(test *testing.T) {
 		// Embedded fields.
 		{
 			reflect.TypeOf((*embeddedJSONStruct)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category: core.StructType,
-				Fields: []core.TypeDescription{
-					core.TypeDescription{"email", "string"},
-					core.TypeDescription{"first-name", "string"},
-					core.TypeDescription{"job-code", "int"},
-					core.TypeDescription{"last-name", "string"},
+				Fields: []core.FieldDescription{
+					core.FieldDescription{"email", "string"},
+					core.FieldDescription{"first-name", "string"},
+					core.FieldDescription{"job-code", "int"},
+					core.FieldDescription{"last-name", "string"},
 				},
 			},
-			map[string]core.FullTypeDescription{
-				mustGetTypeID(reflect.TypeOf((*embeddedJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
+			map[string]core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*embeddedJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
 					Category: core.StructType,
-					Fields: []core.TypeDescription{
-						core.TypeDescription{"email", "string"},
-						core.TypeDescription{"first-name", "string"},
-						core.TypeDescription{"job-code", "int"},
-						core.TypeDescription{"last-name", "string"},
+					Fields: []core.FieldDescription{
+						core.FieldDescription{"email", "string"},
+						core.FieldDescription{"first-name", "string"},
+						core.FieldDescription{"job-code", "int"},
+						core.FieldDescription{"last-name", "string"},
 					},
 				},
-				mustGetTypeID(reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
 					Category: core.StructType,
-					Fields: []core.TypeDescription{
-						core.TypeDescription{"email", "string"},
-						core.TypeDescription{"job-code", "int"},
+					Fields: []core.FieldDescription{
+						core.FieldDescription{"email", "string"},
+						core.FieldDescription{"job-code", "int"},
 					},
 				},
-				mustGetTypeID(reflect.TypeOf((*secureJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*secureJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
 					Category: core.StructType,
-					Fields: []core.TypeDescription{
-						core.TypeDescription{"first-name", "string"},
-						core.TypeDescription{"last-name", "string"},
+					Fields: []core.FieldDescription{
+						core.FieldDescription{"first-name", "string"},
+						core.FieldDescription{"last-name", "string"},
 					},
 				},
 			},
@@ -383,51 +383,51 @@ func TestDescribeType(test *testing.T) {
 		// Complex fields.
 		{
 			reflect.TypeOf((*complexJSONStruct)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category: core.StructType,
-				Fields: []core.TypeDescription{
-					core.TypeDescription{"coin-value", "api.simpleMapWrapper"},
-					core.TypeDescription{"good-index", "api.simpleArrayWrapper"},
-					core.TypeDescription{"personnel", "api.embeddedJSONStruct"},
+				Fields: []core.FieldDescription{
+					core.FieldDescription{"coin-value", "api.simpleMapWrapper"},
+					core.FieldDescription{"good-index", "api.simpleArrayWrapper"},
+					core.FieldDescription{"personnel", "api.embeddedJSONStruct"},
 				},
 			},
-			map[string]core.FullTypeDescription{
-				mustGetTypeID(reflect.TypeOf((*complexJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
+			map[string]core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*complexJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
 					Category: core.StructType,
-					Fields: []core.TypeDescription{
-						core.TypeDescription{"coin-value", "api.simpleMapWrapper"},
-						core.TypeDescription{"good-index", "api.simpleArrayWrapper"},
-						core.TypeDescription{"personnel", "api.embeddedJSONStruct"},
+					Fields: []core.FieldDescription{
+						core.FieldDescription{"coin-value", "api.simpleMapWrapper"},
+						core.FieldDescription{"good-index", "api.simpleArrayWrapper"},
+						core.FieldDescription{"personnel", "api.embeddedJSONStruct"},
 					},
 				},
-				mustGetTypeID(reflect.TypeOf((*embeddedJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*embeddedJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
 					Category: core.StructType,
-					Fields: []core.TypeDescription{
-						core.TypeDescription{"email", "string"},
-						core.TypeDescription{"first-name", "string"},
-						core.TypeDescription{"job-code", "int"},
-						core.TypeDescription{"last-name", "string"},
+					Fields: []core.FieldDescription{
+						core.FieldDescription{"email", "string"},
+						core.FieldDescription{"first-name", "string"},
+						core.FieldDescription{"job-code", "int"},
+						core.FieldDescription{"last-name", "string"},
 					},
 				},
-				mustGetTypeID(reflect.TypeOf((*secureJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*secureJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
 					Category: core.StructType,
-					Fields: []core.TypeDescription{
-						core.TypeDescription{"first-name", "string"},
-						core.TypeDescription{"last-name", "string"},
+					Fields: []core.FieldDescription{
+						core.FieldDescription{"first-name", "string"},
+						core.FieldDescription{"last-name", "string"},
 					},
 				},
-				mustGetTypeID(reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(), nil): core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(), nil): core.TypeDescription{
 					Category:    core.ArrayType,
 					ElementType: "bool",
 				},
-				mustGetTypeID(reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
 					Category: core.StructType,
-					Fields: []core.TypeDescription{
-						core.TypeDescription{"email", "string"},
-						core.TypeDescription{"job-code", "int"},
+					Fields: []core.FieldDescription{
+						core.FieldDescription{"email", "string"},
+						core.FieldDescription{"job-code", "int"},
 					},
 				},
-				mustGetTypeID(reflect.TypeOf((*simpleMapWrapper)(nil)).Elem(), nil): core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleMapWrapper)(nil)).Elem(), nil): core.TypeDescription{
 					Category:  core.MapType,
 					KeyType:   "string",
 					ValueType: "int",
@@ -438,80 +438,80 @@ func TestDescribeType(test *testing.T) {
 		// Pointers to various types.
 		{
 			reflect.TypeOf((**string)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category:  core.AliasType,
 				AliasType: "string",
 			},
-			map[string]core.FullTypeDescription{},
+			map[string]core.TypeDescription{},
 		},
 		{
 			reflect.TypeOf((**map[string]string)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category:  core.MapType,
 				KeyType:   "string",
 				ValueType: "string",
 			},
-			map[string]core.FullTypeDescription{},
+			map[string]core.TypeDescription{},
 		},
 
 		// Pointers inside of fields.
 		{
 			reflect.TypeOf((*simplePointerWrapper)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category:  core.AliasType,
 				AliasType: "string",
 			},
-			map[string]core.FullTypeDescription{},
+			map[string]core.TypeDescription{},
 		},
 		{
 			reflect.TypeOf((*complexPointerStruct)(nil)).Elem(),
-			core.FullTypeDescription{
+			core.TypeDescription{
 				Category: core.StructType,
-				Fields: []core.TypeDescription{
-					core.TypeDescription{"coin-value", "*api.simpleMapWrapper"},
-					core.TypeDescription{"good-index", "*api.simpleArrayWrapper"},
-					core.TypeDescription{"personnel", "*api.embeddedJSONStruct"},
+				Fields: []core.FieldDescription{
+					core.FieldDescription{"coin-value", "*api.simpleMapWrapper"},
+					core.FieldDescription{"good-index", "*api.simpleArrayWrapper"},
+					core.FieldDescription{"personnel", "*api.embeddedJSONStruct"},
 				},
 			},
-			map[string]core.FullTypeDescription{
-				mustGetTypeID(reflect.TypeOf((*complexPointerStruct)(nil)).Elem(), nil): core.FullTypeDescription{
+			map[string]core.TypeDescription{
+				mustGetTypeID(reflect.TypeOf((*complexPointerStruct)(nil)).Elem(), nil): core.TypeDescription{
 					Category: core.StructType,
-					Fields: []core.TypeDescription{
-						core.TypeDescription{"coin-value", "*api.simpleMapWrapper"},
-						core.TypeDescription{"good-index", "*api.simpleArrayWrapper"},
-						core.TypeDescription{"personnel", "*api.embeddedJSONStruct"},
+					Fields: []core.FieldDescription{
+						core.FieldDescription{"coin-value", "*api.simpleMapWrapper"},
+						core.FieldDescription{"good-index", "*api.simpleArrayWrapper"},
+						core.FieldDescription{"personnel", "*api.embeddedJSONStruct"},
 					},
 				},
 				// Note that the keys in typeMap do not include the pointer.
 				// TypeMap stores 'api/api.embeddedJSONStruct' instead of 'api/*api.embeddedJSONStruct'.
-				mustGetTypeID(reflect.TypeOf((*embeddedJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*embeddedJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
 					Category: core.StructType,
-					Fields: []core.TypeDescription{
-						core.TypeDescription{"email", "string"},
-						core.TypeDescription{"first-name", "string"},
-						core.TypeDescription{"job-code", "int"},
-						core.TypeDescription{"last-name", "string"},
+					Fields: []core.FieldDescription{
+						core.FieldDescription{"email", "string"},
+						core.FieldDescription{"first-name", "string"},
+						core.FieldDescription{"job-code", "int"},
+						core.FieldDescription{"last-name", "string"},
 					},
 				},
-				mustGetTypeID(reflect.TypeOf((*secureJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*secureJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
 					Category: core.StructType,
-					Fields: []core.TypeDescription{
-						core.TypeDescription{"first-name", "string"},
-						core.TypeDescription{"last-name", "string"},
+					Fields: []core.FieldDescription{
+						core.FieldDescription{"first-name", "string"},
+						core.FieldDescription{"last-name", "string"},
 					},
 				},
-				mustGetTypeID(reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(), nil): core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(), nil): core.TypeDescription{
 					Category:    core.ArrayType,
 					ElementType: "bool",
 				},
-				mustGetTypeID(reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(), nil): core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(), nil): core.TypeDescription{
 					Category: core.StructType,
-					Fields: []core.TypeDescription{
-						core.TypeDescription{"email", "string"},
-						core.TypeDescription{"job-code", "int"},
+					Fields: []core.FieldDescription{
+						core.FieldDescription{"email", "string"},
+						core.FieldDescription{"job-code", "int"},
 					},
 				},
-				mustGetTypeID(reflect.TypeOf((*simpleMapWrapper)(nil)).Elem(), nil): core.FullTypeDescription{
+				mustGetTypeID(reflect.TypeOf((*simpleMapWrapper)(nil)).Elem(), nil): core.TypeDescription{
 					Category:  core.MapType,
 					KeyType:   "string",
 					ValueType: "int",
@@ -521,7 +521,7 @@ func TestDescribeType(test *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		typeMap := make(map[string]core.FullTypeDescription)
+		typeMap := make(map[string]core.TypeDescription)
 
 		actual, _, _, _, err := describeType(testCase.customType, true, typeMap, nil)
 		if err != nil {
@@ -543,7 +543,7 @@ func TestDescribeType(test *testing.T) {
 }
 
 func TestDescribeConflictingTypes(test *testing.T) {
-	typeMap := make(map[string]core.FullTypeDescription)
+	typeMap := make(map[string]core.TypeDescription)
 	typeDescriptions := make(map[string]string)
 
 	// Add in the first users.ListRequest which will work.

--- a/internal/api/server/server_test.go
+++ b/internal/api/server/server_test.go
@@ -172,7 +172,7 @@ func runServerTestBase(test *testing.T) {
 	}()
 
 	// Wait for the server to start.
-	time.Sleep(time.Duration(TEST_SHORT_WAIT_MS) * time.Millisecond)
+	time.Sleep(time.Duration(TEST_SHORT_WAIT_MS) * time.Millisecond * 10)
 
 	// Send a request.
 	response := core.SendTestAPIRequest(test, "courses/users/list", nil)

--- a/internal/api/server/server_test.go
+++ b/internal/api/server/server_test.go
@@ -172,7 +172,7 @@ func runServerTestBase(test *testing.T) {
 	}()
 
 	// Wait for the server to start.
-	time.Sleep(time.Duration(TEST_SHORT_WAIT_MS) * time.Millisecond * 10)
+	time.Sleep(time.Duration(TEST_SHORT_WAIT_MS) * time.Millisecond)
 
 	// Send a request.
 	response := core.SendTestAPIRequest(test, "courses/users/list", nil)

--- a/internal/util/path.go
+++ b/internal/util/path.go
@@ -298,7 +298,9 @@ func ShouldNormalizePath(path string) string {
 	return realPath
 }
 
-func getDirPathFromPackagePath(packagePath string) string {
+// Best effort attempt to determine the absolute path to the directory that holds a custom package path.
+// The package path is expected to be an internal path of the form `github.com/edulinq/autograder/`.
+func getDirPathFromCustomPackagePath(packagePath string) string {
 	if strings.HasPrefix(packagePath, "github.com/edulinq/autograder/") {
 		packagePath = strings.TrimPrefix(packagePath, "github.com/edulinq/autograder/")
 	}

--- a/internal/util/path.go
+++ b/internal/util/path.go
@@ -297,3 +297,11 @@ func ShouldNormalizePath(path string) string {
 
 	return realPath
 }
+
+func getDirPathFromPackagePath(packagePath string) string {
+	if strings.HasPrefix(packagePath, "github.com/edulinq/autograder/") {
+		packagePath = strings.TrimPrefix(packagePath, "github.com/edulinq/autograder/")
+	}
+
+	return ShouldAbs(filepath.Join(ShouldGetThisDir(), "..", "..", packagePath))
+}

--- a/resources/api.json
+++ b/resources/api.json
@@ -1075,7 +1075,7 @@
                 },
                 {
                     "field-name": "types",
-                    "field-type": "map[string]core.FullTypeDescription"
+                    "field-type": "map[string]core.TypeDescription"
                 }
             ]
         },
@@ -1395,7 +1395,7 @@
                 },
                 {
                     "field-name": "types",
-                    "field-type": "map[string]core.FullTypeDescription"
+                    "field-type": "map[string]core.TypeDescription"
                 }
             ]
         },
@@ -1565,11 +1565,11 @@
                 },
                 {
                     "field-name": "input",
-                    "field-type": "[]core.TypeDescription"
+                    "field-type": "[]core.FieldDescription"
                 },
                 {
                     "field-name": "output",
-                    "field-type": "[]core.TypeDescription"
+                    "field-type": "[]core.FieldDescription"
                 }
             ]
         },
@@ -1587,28 +1587,16 @@
                 }
             ]
         },
-        "core.FullTypeDescription": {
+        "core.FieldDescription": {
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "alias-type",
+                    "field-name": "field-name",
                     "field-type": "string"
                 },
                 {
-                    "field-name": "category",
+                    "field-name": "field-type",
                     "field-type": "string"
-                },
-                {
-                    "field-name": "description",
-                    "field-type": "string"
-                },
-                {
-                    "field-name": "element-type",
-                    "field-type": "string"
-                },
-                {
-                    "field-name": "fields",
-                    "field-type": "[]core.TypeDescription"
                 }
             ]
         },
@@ -1674,12 +1662,24 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "field-name",
+                    "field-name": "alias-type",
                     "field-type": "string"
                 },
                 {
-                    "field-name": "field-type",
+                    "field-name": "category",
                     "field-type": "string"
+                },
+                {
+                    "field-name": "description",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "element-type",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "fields",
+                    "field-type": "[]core.FieldDescription"
                 }
             ]
         },

--- a/resources/api.json
+++ b/resources/api.json
@@ -1401,6 +1401,7 @@
         },
         "core.APIRequestAssignmentContext": {
             "category": "struct",
+            "description": "Context for requests that need an assignment on top of a user/course.",
             "fields": [
                 {
                     "field-name": "assignment-id",
@@ -1422,6 +1423,7 @@
         },
         "core.APIRequestCourseUserContext": {
             "category": "struct",
+            "description": "Context for a request that has a course and user from that course.",
             "fields": [
                 {
                     "field-name": "course-id",
@@ -1439,6 +1441,7 @@
         },
         "core.APIRequestUserContext": {
             "category": "struct",
+            "description": "Context for a request that has a user (pretty much the lowest level of request).",
             "fields": [
                 {
                     "field-name": "user-email",
@@ -1494,6 +1497,7 @@
         },
         "core.BaseUserInfo": {
             "category": "struct",
+            "description": "This type must be embedded into any API-safe representation of a user.",
             "fields": [
                 {
                     "field-name": "email",
@@ -1528,6 +1532,7 @@
         },
         "core.CourseUserInfo": {
             "category": "struct",
+            "description": "An API-safe representation of a course user.\nEmbed the BaseUserInfo and use CourseUserInfoType as the type.",
             "fields": [
                 {
                     "field-name": "email",
@@ -1570,6 +1575,7 @@
         },
         "core.EnrollmentInfo": {
             "category": "struct",
+            "description": "An API-safe representation of enrollment information.",
             "fields": [
                 {
                     "field-name": "id",
@@ -1593,6 +1599,10 @@
                     "field-type": "string"
                 },
                 {
+                    "field-name": "description",
+                    "field-type": "string"
+                },
+                {
                     "field-name": "element-type",
                     "field-type": "string"
                 },
@@ -1608,6 +1618,7 @@
         },
         "core.ServerUserInfo": {
             "category": "struct",
+            "description": "An API-safe representation of a server user.\nEmbed the BaseUserInfo and use ServerUserInfoType as the type.",
             "fields": [
                 {
                     "field-name": "courses",
@@ -1632,10 +1643,12 @@
             ]
         },
         "core.TargetCourseUser": {
-            "category": "struct"
+            "category": "struct",
+            "description": "A request having a field of this type indicates that the request is targeting a specific course user.\nThis type serializes to/from a string.\nA user's email must be specified, but no error is generated if the user is not found.\nThe existence of this type in a struct also indicates that the request is at least a APIRequestCourseUserContext."
         },
         "core.TargetCourseUserSelfOrGrader": {
             "category": "struct",
+            "description": "Same as TargetServerUserSelfOrAdmin, but in the context of a course user and a grader context user.\nTherefore, the context user only has to be a grader in the context course (or the target user themself).\nWhen targeting yourself, the user can be a server admin (and will be escalated to course owner for the request).\nThe existence of this type in a struct also indicates that the request is at least a APIRequestCourseUserContext.",
             "fields": [
                 {
                     "field-name": "TargetCourseUser",
@@ -1644,10 +1657,12 @@
             ]
         },
         "core.TargetServerUser": {
-            "category": "struct"
+            "category": "struct",
+            "description": "A request having a field of this type indicates that the request is targeting a specific server user.\nThis type serializes to/from a string.\nA user's email must be specified, but no error is generated if the user is not found.\nThe existence of this type in a struct also indicates that the request is at least a APIRequestUserContext."
         },
         "core.TargetServerUserSelfOrAdmin": {
             "category": "struct",
+            "description": "A request having a field of this type indicates that the request is targeting a specific user.\nThis type serializes to/from a string.\nIf no user is specified, then the context user is the target.\nIf a user is specified, then the context user must be a server admin\n(any user can access their own resources, but higher permissions are required to access another user's resources).\nNo error is generated if the user is not found.\nThe existence of this type in a struct also indicates that the request is at least a APIRequestUserContext.",
             "fields": [
                 {
                     "field-name": "TargetServerUser",
@@ -1802,6 +1817,7 @@
         },
         "log.RawLogQuery": {
             "category": "struct",
+            "description": "A representation of a query for server log records.\nA raw query can be processed (validated for structure and permissions)\nby the internal/procedures/log package.\nBecause of some assumptions we make, log times before UNIX epoch are not supported.\nHowever, since this code was created well past that only time travelers should be concerned.",
             "fields": [
                 {
                     "field-name": "after",
@@ -1977,6 +1993,7 @@
         },
         "model.BaseUserOpResult": {
             "category": "struct",
+            "description": "A general representation of the result of operations that modify a user in any way (add, remove, enroll, drop, etc).",
             "fields": [
                 {
                     "field-name": "added",
@@ -2022,6 +2039,7 @@
         },
         "model.ExternalLocatableError": {
             "category": "struct",
+            "description": "A user safe version of locatable errors.\nAll LocatableErrors must be converted to ExternalLocatableErrors\nif it is to be given to a user.",
             "fields": [
                 {
                     "field-name": "locator",
@@ -2035,6 +2053,7 @@
         },
         "model.ExternalScoringInfo": {
             "category": "struct",
+            "description": "A trimmed-down version of ScoringInfo meant for external usage.",
             "fields": [
                 {
                     "field-name": "assignment",
@@ -2068,6 +2087,7 @@
         },
         "model.ExternalUserOpResult": {
             "category": "struct",
+            "description": "A user safe representation of the UserOpResult struct.\nNotably all errors will be converted to responses and the cleartext password field is removed.\nFor descriptions of shared fields, see UserOpResult above.",
             "fields": [
                 {
                     "field-name": "added",
@@ -2443,7 +2463,8 @@
             ]
         },
         "model.LocatableError": {
-            "category": "struct"
+            "category": "struct",
+            "description": "A general representation of errors that have a definite source location."
         },
         "model.PairwiseAnalysis": {
             "category": "struct",
@@ -2533,6 +2554,7 @@
         },
         "model.RawCourseUserData": {
             "category": "struct",
+            "description": "Raw/dirty data for a course user.\nThis struct is used for raw data coming from a single course.",
             "fields": [
                 {
                     "field-name": "course-lms-id",
@@ -2554,6 +2576,7 @@
         },
         "model.RawServerUserData": {
             "category": "struct",
+            "description": "Raw/dirty data for a user.\nThis struct can be directly embedded for Kong arguments.",
             "fields": [
                 {
                     "field-name": "course",
@@ -2632,6 +2655,7 @@
         },
         "model.UserOpResult": {
             "category": "struct",
+            "description": "A general representation of the result of operations that modify a user in any way (add, remove, enroll, drop, etc).\nAll user-facing functions (essentially non-db functions) should return an instance or collection of these objects.",
             "fields": [
                 {
                     "field-name": "added",
@@ -2718,6 +2742,7 @@
         },
         "stats.Query": {
             "category": "struct",
+            "description": "The query for stats.\nNote that the semantics of this struct mean that times before UNIX epoch (negative times)\nmust be offset by at least one MS (as a zero value is treated as the end of time).",
             "fields": [
                 {
                     "field-name": "after",
@@ -2777,6 +2802,7 @@
         },
         "users.UpsertUsersOptions": {
             "category": "struct",
+            "description": "Data for upserting users.\nUpserting should only be done by server or course admins,\nit should not be used for self creation.",
             "fields": [
                 {
                     "field-name": "dry-run",

--- a/resources/api.json
+++ b/resources/api.json
@@ -4,58 +4,58 @@
             "description": "Send an email to course users.",
             "input": [
                 {
-                    "field-name": "bcc",
-                    "field-type": "[]string"
+                    "name": "bcc",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "body",
-                    "field-type": "string"
+                    "name": "body",
+                    "type": "string"
                 },
                 {
-                    "field-name": "cc",
-                    "field-type": "[]string"
+                    "name": "cc",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "dry-run",
-                    "field-type": "bool"
+                    "name": "dry-run",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "html",
-                    "field-type": "bool"
+                    "name": "html",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "subject",
-                    "field-type": "string"
+                    "name": "subject",
+                    "type": "string"
                 },
                 {
-                    "field-name": "to",
-                    "field-type": "[]string"
+                    "name": "to",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "bcc",
-                    "field-type": "[]string"
+                    "name": "bcc",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "cc",
-                    "field-type": "[]string"
+                    "name": "cc",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "to",
-                    "field-type": "[]string"
+                    "name": "to",
+                    "type": "[]string"
                 }
             ]
         },
@@ -63,22 +63,22 @@
             "description": "Update an existing course.",
             "input": [
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "result",
-                    "field-type": "*courses.CourseUpsertResult"
+                    "name": "result",
+                    "type": "*courses.CourseUpsertResult"
                 }
             ]
         },
@@ -86,26 +86,26 @@
             "description": "Get the information for a course assignment.",
             "input": [
                 {
-                    "field-name": "assignment-id",
-                    "field-type": "string"
+                    "name": "assignment-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "assignment",
-                    "field-type": "*core.AssignmentInfo"
+                    "name": "assignment",
+                    "type": "*core.AssignmentInfo"
                 }
             ]
         },
@@ -113,22 +113,22 @@
             "description": "List the assignments in the course.",
             "input": [
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "assignments",
-                    "field-type": "[]*core.AssignmentInfo"
+                    "name": "assignments",
+                    "type": "[]*core.AssignmentInfo"
                 }
             ]
         },
@@ -136,46 +136,46 @@
             "description": "Get the result of a individual analysis for the specified submissions.",
             "input": [
                 {
-                    "field-name": "dry-run",
-                    "field-type": "bool"
+                    "name": "dry-run",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "overwrite-cache",
-                    "field-type": "bool"
+                    "name": "overwrite-cache",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "submissions",
-                    "field-type": "[]string"
+                    "name": "submissions",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 },
                 {
-                    "field-name": "wait-for-completion",
-                    "field-type": "bool"
+                    "name": "wait-for-completion",
+                    "type": "bool"
                 }
             ],
             "output": [
                 {
-                    "field-name": "complete",
-                    "field-type": "bool"
+                    "name": "complete",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "options",
-                    "field-type": "analysis.AnalysisOptions"
+                    "name": "options",
+                    "type": "analysis.AnalysisOptions"
                 },
                 {
-                    "field-name": "results",
-                    "field-type": "[]*model.IndividualAnalysis"
+                    "name": "results",
+                    "type": "[]*model.IndividualAnalysis"
                 },
                 {
-                    "field-name": "summary",
-                    "field-type": "*model.IndividualAnalysisSummary"
+                    "name": "summary",
+                    "type": "*model.IndividualAnalysisSummary"
                 }
             ]
         },
@@ -183,46 +183,46 @@
             "description": "Get the result of a pairwise analysis for the specified submissions.",
             "input": [
                 {
-                    "field-name": "dry-run",
-                    "field-type": "bool"
+                    "name": "dry-run",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "overwrite-cache",
-                    "field-type": "bool"
+                    "name": "overwrite-cache",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "submissions",
-                    "field-type": "[]string"
+                    "name": "submissions",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 },
                 {
-                    "field-name": "wait-for-completion",
-                    "field-type": "bool"
+                    "name": "wait-for-completion",
+                    "type": "bool"
                 }
             ],
             "output": [
                 {
-                    "field-name": "complete",
-                    "field-type": "bool"
+                    "name": "complete",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "options",
-                    "field-type": "analysis.AnalysisOptions"
+                    "name": "options",
+                    "type": "analysis.AnalysisOptions"
                 },
                 {
-                    "field-name": "results",
-                    "field-type": "[]*model.PairwiseAnalysis"
+                    "name": "results",
+                    "type": "[]*model.PairwiseAnalysis"
                 },
                 {
-                    "field-name": "summary",
-                    "field-type": "*model.PairwiseAnalysisSummary"
+                    "name": "summary",
+                    "type": "*model.PairwiseAnalysisSummary"
                 }
             ]
         },
@@ -230,30 +230,30 @@
             "description": "Get all recent submissions and grading information for this assignment.",
             "input": [
                 {
-                    "field-name": "assignment-id",
-                    "field-type": "string"
+                    "name": "assignment-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "filter-role",
-                    "field-type": "int"
+                    "name": "filter-role",
+                    "type": "int"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "grading-results",
-                    "field-type": "map[string]*model.GradingResult"
+                    "name": "grading-results",
+                    "type": "map[string]*model.GradingResult"
                 }
             ]
         },
@@ -261,30 +261,30 @@
             "description": "Get a summary of the most recent scores for this assignment.",
             "input": [
                 {
-                    "field-name": "assignment-id",
-                    "field-type": "string"
+                    "name": "assignment-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "filter-role",
-                    "field-type": "int"
+                    "name": "filter-role",
+                    "type": "int"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "submission-infos",
-                    "field-type": "map[string]*model.SubmissionHistoryItem"
+                    "name": "submission-infos",
+                    "type": "map[string]*model.SubmissionHistoryItem"
                 }
             ]
         },
@@ -292,42 +292,42 @@
             "description": "Get a submission along with all grading information.",
             "input": [
                 {
-                    "field-name": "assignment-id",
-                    "field-type": "string"
+                    "name": "assignment-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "target-email",
-                    "field-type": "core.TargetCourseUserSelfOrGrader"
+                    "name": "target-email",
+                    "type": "core.TargetCourseUserSelfOrGrader"
                 },
                 {
-                    "field-name": "target-submission",
-                    "field-type": "string"
+                    "name": "target-submission",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "found-submission",
-                    "field-type": "bool"
+                    "name": "found-submission",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "found-user",
-                    "field-type": "bool"
+                    "name": "found-user",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "grading-result",
-                    "field-type": "*model.GradingResult"
+                    "name": "grading-result",
+                    "type": "*model.GradingResult"
                 }
             ]
         },
@@ -335,34 +335,34 @@
             "description": "Get all submission attempts made by a user along with all grading information.",
             "input": [
                 {
-                    "field-name": "assignment-id",
-                    "field-type": "string"
+                    "name": "assignment-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "target-email",
-                    "field-type": "core.TargetCourseUserSelfOrGrader"
+                    "name": "target-email",
+                    "type": "core.TargetCourseUserSelfOrGrader"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "found-user",
-                    "field-type": "bool"
+                    "name": "found-user",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "grading-results",
-                    "field-type": "[]*model.GradingResult"
+                    "name": "grading-results",
+                    "type": "[]*model.GradingResult"
                 }
             ]
         },
@@ -370,34 +370,34 @@
             "description": "Get a summary of the submissions for this assignment.",
             "input": [
                 {
-                    "field-name": "assignment-id",
-                    "field-type": "string"
+                    "name": "assignment-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "target-email",
-                    "field-type": "core.TargetCourseUserSelfOrGrader"
+                    "name": "target-email",
+                    "type": "core.TargetCourseUserSelfOrGrader"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "found-user",
-                    "field-type": "bool"
+                    "name": "found-user",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "history",
-                    "field-type": "[]*model.SubmissionHistoryItem"
+                    "name": "history",
+                    "type": "[]*model.SubmissionHistoryItem"
                 }
             ]
         },
@@ -405,42 +405,42 @@
             "description": "Get a copy of the grading report for the specified submission. Does not submit a new submission.",
             "input": [
                 {
-                    "field-name": "assignment-id",
-                    "field-type": "string"
+                    "name": "assignment-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "target-email",
-                    "field-type": "core.TargetCourseUserSelfOrGrader"
+                    "name": "target-email",
+                    "type": "core.TargetCourseUserSelfOrGrader"
                 },
                 {
-                    "field-name": "target-submission",
-                    "field-type": "string"
+                    "name": "target-submission",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "found-submission",
-                    "field-type": "bool"
+                    "name": "found-submission",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "found-user",
-                    "field-type": "bool"
+                    "name": "found-user",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "submission-result",
-                    "field-type": "*model.GradingInfo"
+                    "name": "submission-result",
+                    "type": "*model.GradingInfo"
                 }
             ]
         },
@@ -448,58 +448,58 @@
             "description": "Proxy resubmit an assignment submission to the autograder.",
             "input": [
                 {
-                    "field-name": "assignment-id",
-                    "field-type": "string"
+                    "name": "assignment-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "proxy-email",
-                    "field-type": "core.TargetCourseUser"
+                    "name": "proxy-email",
+                    "type": "core.TargetCourseUser"
                 },
                 {
-                    "field-name": "proxy-time",
-                    "field-type": "int64"
+                    "name": "proxy-time",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "target-submission",
-                    "field-type": "string"
+                    "name": "target-submission",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "found-submission",
-                    "field-type": "bool"
+                    "name": "found-submission",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "found-user",
-                    "field-type": "bool"
+                    "name": "found-user",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "grading-success",
-                    "field-type": "bool"
+                    "name": "grading-success",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "message",
-                    "field-type": "string"
+                    "name": "message",
+                    "type": "string"
                 },
                 {
-                    "field-name": "rejected",
-                    "field-type": "bool"
+                    "name": "rejected",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "result",
-                    "field-type": "*model.GradingInfo"
+                    "name": "result",
+                    "type": "*model.GradingInfo"
                 }
             ]
         },
@@ -507,54 +507,54 @@
             "description": "Proxy submit an assignment submission to the autograder.",
             "input": [
                 {
-                    "field-name": "assignment-id",
-                    "field-type": "string"
+                    "name": "assignment-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "message",
-                    "field-type": "string"
+                    "name": "message",
+                    "type": "string"
                 },
                 {
-                    "field-name": "proxy-email",
-                    "field-type": "core.TargetCourseUser"
+                    "name": "proxy-email",
+                    "type": "core.TargetCourseUser"
                 },
                 {
-                    "field-name": "proxy-time",
-                    "field-type": "int64"
+                    "name": "proxy-time",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "found-user",
-                    "field-type": "bool"
+                    "name": "found-user",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "grading-success",
-                    "field-type": "bool"
+                    "name": "grading-success",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "message",
-                    "field-type": "string"
+                    "name": "message",
+                    "type": "string"
                 },
                 {
-                    "field-name": "rejected",
-                    "field-type": "bool"
+                    "name": "rejected",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "result",
-                    "field-type": "*model.GradingInfo"
+                    "name": "result",
+                    "type": "*model.GradingInfo"
                 }
             ]
         },
@@ -562,38 +562,38 @@
             "description": "Remove a specified submission. Defaults to the most recent submission.",
             "input": [
                 {
-                    "field-name": "assignment-id",
-                    "field-type": "string"
+                    "name": "assignment-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "target-email",
-                    "field-type": "core.TargetCourseUserSelfOrGrader"
+                    "name": "target-email",
+                    "type": "core.TargetCourseUserSelfOrGrader"
                 },
                 {
-                    "field-name": "target-submission",
-                    "field-type": "string"
+                    "name": "target-submission",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "found-submission",
-                    "field-type": "bool"
+                    "name": "found-submission",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "found-user",
-                    "field-type": "bool"
+                    "name": "found-user",
+                    "type": "bool"
                 }
             ]
         },
@@ -601,46 +601,46 @@
             "description": "Submit an assignment submission to the autograder.",
             "input": [
                 {
-                    "field-name": "allow-late",
-                    "field-type": "bool"
+                    "name": "allow-late",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "assignment-id",
-                    "field-type": "string"
+                    "name": "assignment-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "message",
-                    "field-type": "string"
+                    "name": "message",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "grading-success",
-                    "field-type": "bool"
+                    "name": "grading-success",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "message",
-                    "field-type": "string"
+                    "name": "message",
+                    "type": "string"
                 },
                 {
-                    "field-name": "rejected",
-                    "field-type": "bool"
+                    "name": "rejected",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "result",
-                    "field-type": "*model.GradingInfo"
+                    "name": "result",
+                    "type": "*model.GradingInfo"
                 }
             ]
         },
@@ -648,30 +648,30 @@
             "description": "Perform a full scoring and upload scores to the course's LMS.",
             "input": [
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "dry-run",
-                    "field-type": "bool"
+                    "name": "dry-run",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "dry-run",
-                    "field-type": "bool"
+                    "name": "dry-run",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "results",
-                    "field-type": "[]*model.ExternalScoringInfo"
+                    "name": "results",
+                    "type": "[]*model.ExternalScoringInfo"
                 }
             ]
         },
@@ -679,46 +679,46 @@
             "description": "Query metrics for a specific course.\nOnly the context course can be queried for, the target-course field will be ignored for this endpoint.",
             "input": [
                 {
-                    "field-name": "after",
-                    "field-type": "int64"
+                    "name": "after",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "before",
-                    "field-type": "int64"
+                    "name": "before",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "limit",
-                    "field-type": "int"
+                    "name": "limit",
+                    "type": "int"
                 },
                 {
-                    "field-name": "sort",
-                    "field-type": "int"
+                    "name": "sort",
+                    "type": "int"
                 },
                 {
-                    "field-name": "type",
-                    "field-type": "string"
+                    "name": "type",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 },
                 {
-                    "field-name": "where",
-                    "field-type": "map[stats.MetricAttribute]interface {}"
+                    "name": "where",
+                    "type": "map[stats.MetricAttribute]interface {}"
                 }
             ],
             "output": [
                 {
-                    "field-name": "results",
-                    "field-type": "[]*stats.Metric"
+                    "name": "results",
+                    "type": "[]*stats.Metric"
                 }
             ]
         },
@@ -726,46 +726,46 @@
             "description": "Upsert a course using a filespec.",
             "input": [
                 {
-                    "field-name": "dry-run",
-                    "field-type": "bool"
+                    "name": "dry-run",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "filespec",
-                    "field-type": "util.FileSpec"
+                    "name": "filespec",
+                    "type": "util.FileSpec"
                 },
                 {
-                    "field-name": "skip-build-images",
-                    "field-type": "bool"
+                    "name": "skip-build-images",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-emails",
-                    "field-type": "bool"
+                    "name": "skip-emails",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-lms-sync",
-                    "field-type": "bool"
+                    "name": "skip-lms-sync",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-source-sync",
-                    "field-type": "bool"
+                    "name": "skip-source-sync",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-template-files",
-                    "field-type": "bool"
+                    "name": "skip-template-files",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "results",
-                    "field-type": "[]courses.CourseUpsertResult"
+                    "name": "results",
+                    "type": "[]courses.CourseUpsertResult"
                 }
             ]
         },
@@ -773,42 +773,42 @@
             "description": "Upsert a course using a zip file.",
             "input": [
                 {
-                    "field-name": "dry-run",
-                    "field-type": "bool"
+                    "name": "dry-run",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-build-images",
-                    "field-type": "bool"
+                    "name": "skip-build-images",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-emails",
-                    "field-type": "bool"
+                    "name": "skip-emails",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-lms-sync",
-                    "field-type": "bool"
+                    "name": "skip-lms-sync",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-source-sync",
-                    "field-type": "bool"
+                    "name": "skip-source-sync",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-template-files",
-                    "field-type": "bool"
+                    "name": "skip-template-files",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "results",
-                    "field-type": "[]courses.CourseUpsertResult"
+                    "name": "results",
+                    "type": "[]courses.CourseUpsertResult"
                 }
             ]
         },
@@ -816,26 +816,26 @@
             "description": "Drop a user from the course.",
             "input": [
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "target-email",
-                    "field-type": "core.TargetCourseUser"
+                    "name": "target-email",
+                    "type": "core.TargetCourseUser"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "found-user",
-                    "field-type": "bool"
+                    "name": "found-user",
+                    "type": "bool"
                 }
             ]
         },
@@ -843,42 +843,42 @@
             "description": "Enroll one or more users to the course.",
             "input": [
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "dry-run",
-                    "field-type": "bool"
+                    "name": "dry-run",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "raw-course-users",
-                    "field-type": "[]*model.RawCourseUserData"
+                    "name": "raw-course-users",
+                    "type": "[]*model.RawCourseUserData"
                 },
                 {
-                    "field-name": "send-emails",
-                    "field-type": "bool"
+                    "name": "send-emails",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-inserts",
-                    "field-type": "bool"
+                    "name": "skip-inserts",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-updates",
-                    "field-type": "bool"
+                    "name": "skip-updates",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "results",
-                    "field-type": "[]*model.ExternalUserOpResult"
+                    "name": "results",
+                    "type": "[]*model.ExternalUserOpResult"
                 }
             ]
         },
@@ -886,30 +886,30 @@
             "description": "Get the information for a course user.",
             "input": [
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "target-email",
-                    "field-type": "core.TargetCourseUserSelfOrGrader"
+                    "name": "target-email",
+                    "type": "core.TargetCourseUserSelfOrGrader"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "found",
-                    "field-type": "bool"
+                    "name": "found",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "user",
-                    "field-type": "*core.CourseUserInfo"
+                    "name": "user",
+                    "type": "*core.CourseUserInfo"
                 }
             ]
         },
@@ -917,22 +917,22 @@
             "description": "List the users in the course.",
             "input": [
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "users",
-                    "field-type": "[]*core.CourseUserInfo"
+                    "name": "users",
+                    "type": "[]*core.CourseUserInfo"
                 }
             ]
         },
@@ -940,42 +940,42 @@
             "description": "Upload scores from a tab-separated file to the course's LMS.\nThe file should not have headers, and should have two columns: email and score.",
             "input": [
                 {
-                    "field-name": "assignment-lms-id",
-                    "field-type": "string"
+                    "name": "assignment-lms-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "scores",
-                    "field-type": "[]upload.ScoreEntry"
+                    "name": "scores",
+                    "type": "[]upload.ScoreEntry"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "count",
-                    "field-type": "int"
+                    "name": "count",
+                    "type": "int"
                 },
                 {
-                    "field-name": "error-count",
-                    "field-type": "int"
+                    "name": "error-count",
+                    "type": "int"
                 },
                 {
-                    "field-name": "no-lms-id-users",
-                    "field-type": "[]upload.RowEntry"
+                    "name": "no-lms-id-users",
+                    "type": "[]upload.RowEntry"
                 },
                 {
-                    "field-name": "unrecognized-users",
-                    "field-type": "[]upload.RowEntry"
+                    "name": "unrecognized-users",
+                    "type": "[]upload.RowEntry"
                 }
             ]
         },
@@ -983,34 +983,34 @@
             "description": "Get information for an LMS user.",
             "input": [
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "target-email",
-                    "field-type": "core.TargetCourseUser"
+                    "name": "target-email",
+                    "type": "core.TargetCourseUser"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "found-autograder-user",
-                    "field-type": "bool"
+                    "name": "found-autograder-user",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "found-lms-user",
-                    "field-type": "bool"
+                    "name": "found-lms-user",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "user",
-                    "field-type": "*core.CourseUserInfo"
+                    "name": "user",
+                    "type": "*core.CourseUserInfo"
                 }
             ]
         },
@@ -1018,50 +1018,50 @@
             "description": "Query log entries from the autograder server.",
             "input": [
                 {
-                    "field-name": "after",
-                    "field-type": "string"
+                    "name": "after",
+                    "type": "string"
                 },
                 {
-                    "field-name": "level",
-                    "field-type": "string"
+                    "name": "level",
+                    "type": "string"
                 },
                 {
-                    "field-name": "past",
-                    "field-type": "string"
+                    "name": "past",
+                    "type": "string"
                 },
                 {
-                    "field-name": "target-assignment",
-                    "field-type": "string"
+                    "name": "target-assignment",
+                    "type": "string"
                 },
                 {
-                    "field-name": "target-course",
-                    "field-type": "string"
+                    "name": "target-course",
+                    "type": "string"
                 },
                 {
-                    "field-name": "target-email",
-                    "field-type": "string"
+                    "name": "target-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "error",
-                    "field-type": "*model.ExternalLocatableError"
+                    "name": "error",
+                    "type": "*model.ExternalLocatableError"
                 },
                 {
-                    "field-name": "results",
-                    "field-type": "[]*log.Record"
+                    "name": "results",
+                    "type": "[]*log.Record"
                 },
                 {
-                    "field-name": "success",
-                    "field-type": "bool"
+                    "name": "success",
+                    "type": "bool"
                 }
             ]
         },
@@ -1070,12 +1070,12 @@
             "input": [],
             "output": [
                 {
-                    "field-name": "endpoints",
-                    "field-type": "map[string]core.EndpointDescription"
+                    "name": "endpoints",
+                    "type": "map[string]core.EndpointDescription"
                 },
                 {
-                    "field-name": "types",
-                    "field-type": "map[string]core.TypeDescription"
+                    "name": "types",
+                    "type": "map[string]core.TypeDescription"
                 }
             ]
         },
@@ -1083,42 +1083,42 @@
             "description": "Query stats for the server.",
             "input": [
                 {
-                    "field-name": "after",
-                    "field-type": "int64"
+                    "name": "after",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "before",
-                    "field-type": "int64"
+                    "name": "before",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "limit",
-                    "field-type": "int"
+                    "name": "limit",
+                    "type": "int"
                 },
                 {
-                    "field-name": "sort",
-                    "field-type": "int"
+                    "name": "sort",
+                    "type": "int"
                 },
                 {
-                    "field-name": "type",
-                    "field-type": "string"
+                    "name": "type",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 },
                 {
-                    "field-name": "where",
-                    "field-type": "map[stats.MetricAttribute]interface {}"
+                    "name": "where",
+                    "type": "map[stats.MetricAttribute]interface {}"
                 }
             ],
             "output": [
                 {
-                    "field-name": "results",
-                    "field-type": "[]*stats.Metric"
+                    "name": "results",
+                    "type": "[]*stats.Metric"
                 }
             ]
         },
@@ -1126,22 +1126,22 @@
             "description": "Get stack traces for all the currently running routines (threads) on the server.",
             "input": [
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "count",
-                    "field-type": "int"
+                    "name": "count",
+                    "type": "int"
                 },
                 {
-                    "field-name": "stacks",
-                    "field-type": "[]*util.CallStack"
+                    "name": "stacks",
+                    "type": "[]*util.CallStack"
                 }
             ]
         },
@@ -1149,18 +1149,18 @@
             "description": "Authenticate as a user.",
             "input": [
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "success",
-                    "field-type": "bool"
+                    "name": "success",
+                    "type": "bool"
                 }
             ]
         },
@@ -1168,30 +1168,30 @@
             "description": "Get the information for a server user.",
             "input": [
                 {
-                    "field-name": "target-email",
-                    "field-type": "core.TargetServerUserSelfOrAdmin"
+                    "name": "target-email",
+                    "type": "core.TargetServerUserSelfOrAdmin"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "courses",
-                    "field-type": "map[string]*core.CourseInfo"
+                    "name": "courses",
+                    "type": "map[string]*core.CourseInfo"
                 },
                 {
-                    "field-name": "found",
-                    "field-type": "bool"
+                    "name": "found",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "user",
-                    "field-type": "*core.ServerUserInfo"
+                    "name": "user",
+                    "type": "*core.ServerUserInfo"
                 }
             ]
         },
@@ -1199,18 +1199,18 @@
             "description": "List the users on the server.",
             "input": [
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "users",
-                    "field-type": "[]*core.ServerUserInfo"
+                    "name": "users",
+                    "type": "[]*core.ServerUserInfo"
                 }
             ]
         },
@@ -1218,26 +1218,26 @@
             "description": "Change your password to the one provided.",
             "input": [
                 {
-                    "field-name": "new-pass",
-                    "field-type": "string"
+                    "name": "new-pass",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "duplicate",
-                    "field-type": "bool"
+                    "name": "duplicate",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "success",
-                    "field-type": "bool"
+                    "name": "success",
+                    "type": "bool"
                 }
             ]
         },
@@ -1245,8 +1245,8 @@
             "description": "Reset to a random password that will be emailed to you.",
             "input": [
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 }
             ],
             "output": []
@@ -1255,22 +1255,22 @@
             "description": "Remove a user from the server.",
             "input": [
                 {
-                    "field-name": "target-email",
-                    "field-type": "core.TargetServerUser"
+                    "name": "target-email",
+                    "type": "core.TargetServerUser"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "found-user",
-                    "field-type": "bool"
+                    "name": "found-user",
+                    "type": "bool"
                 }
             ]
         },
@@ -1278,26 +1278,26 @@
             "description": "Create a new authentication token.",
             "input": [
                 {
-                    "field-name": "name",
-                    "field-type": "string"
+                    "name": "name",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "token-cleartext",
-                    "field-type": "string"
+                    "name": "token-cleartext",
+                    "type": "string"
                 },
                 {
-                    "field-name": "token-id",
-                    "field-type": "string"
+                    "name": "token-id",
+                    "type": "string"
                 }
             ]
         },
@@ -1305,22 +1305,22 @@
             "description": "Delete an authentication token.",
             "input": [
                 {
-                    "field-name": "token-id",
-                    "field-type": "string"
+                    "name": "token-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "found",
-                    "field-type": "bool"
+                    "name": "found",
+                    "type": "bool"
                 }
             ]
         },
@@ -1328,38 +1328,38 @@
             "description": "Upsert one or more users to the server (update if exists, insert otherwise).",
             "input": [
                 {
-                    "field-name": "dry-run",
-                    "field-type": "bool"
+                    "name": "dry-run",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "raw-users",
-                    "field-type": "[]*model.RawServerUserData"
+                    "name": "raw-users",
+                    "type": "[]*model.RawServerUserData"
                 },
                 {
-                    "field-name": "send-emails",
-                    "field-type": "bool"
+                    "name": "send-emails",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-inserts",
-                    "field-type": "bool"
+                    "name": "skip-inserts",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-updates",
-                    "field-type": "bool"
+                    "name": "skip-updates",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ],
             "output": [
                 {
-                    "field-name": "results",
-                    "field-type": "[]*model.ExternalUserOpResult"
+                    "name": "results",
+                    "type": "[]*model.ExternalUserOpResult"
                 }
             ]
         }
@@ -1369,20 +1369,20 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "dry-run",
-                    "field-type": "bool"
+                    "name": "dry-run",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "overwrite-cache",
-                    "field-type": "bool"
+                    "name": "overwrite-cache",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "submissions",
-                    "field-type": "[]string"
+                    "name": "submissions",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "wait-for-completion",
-                    "field-type": "bool"
+                    "name": "wait-for-completion",
+                    "type": "bool"
                 }
             ]
         },
@@ -1390,12 +1390,12 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "endpoints",
-                    "field-type": "map[string]core.EndpointDescription"
+                    "name": "endpoints",
+                    "type": "map[string]core.EndpointDescription"
                 },
                 {
-                    "field-name": "types",
-                    "field-type": "map[string]core.TypeDescription"
+                    "name": "types",
+                    "type": "map[string]core.TypeDescription"
                 }
             ]
         },
@@ -1404,20 +1404,20 @@
             "description": "Context for requests that need an assignment on top of a user/course.",
             "fields": [
                 {
-                    "field-name": "assignment-id",
-                    "field-type": "string"
+                    "name": "assignment-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ]
         },
@@ -1426,16 +1426,16 @@
             "description": "Context for a request that has a course and user from that course.",
             "fields": [
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ]
         },
@@ -1444,12 +1444,12 @@
             "description": "Context for a request that has a user (pretty much the lowest level of request).",
             "fields": [
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user-pass",
-                    "field-type": "string"
+                    "name": "user-pass",
+                    "type": "string"
                 }
             ]
         },
@@ -1457,20 +1457,20 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "due-date",
-                    "field-type": "int64"
+                    "name": "due-date",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "id",
-                    "field-type": "string"
+                    "name": "id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "max-points",
-                    "field-type": "float64"
+                    "name": "max-points",
+                    "type": "float64"
                 },
                 {
-                    "field-name": "name",
-                    "field-type": "string"
+                    "name": "name",
+                    "type": "string"
                 }
             ]
         },
@@ -1478,20 +1478,20 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "grading-success",
-                    "field-type": "bool"
+                    "name": "grading-success",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "message",
-                    "field-type": "string"
+                    "name": "message",
+                    "type": "string"
                 },
                 {
-                    "field-name": "rejected",
-                    "field-type": "bool"
+                    "name": "rejected",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "result",
-                    "field-type": "*model.GradingInfo"
+                    "name": "result",
+                    "type": "*model.GradingInfo"
                 }
             ]
         },
@@ -1500,16 +1500,16 @@
             "description": "This type must be embedded into any API-safe representation of a user.",
             "fields": [
                 {
-                    "field-name": "email",
-                    "field-type": "string"
+                    "name": "email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "name",
-                    "field-type": "string"
+                    "name": "name",
+                    "type": "string"
                 },
                 {
-                    "field-name": "type",
-                    "field-type": "string"
+                    "name": "type",
+                    "type": "string"
                 }
             ]
         },
@@ -1517,16 +1517,16 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "assignments",
-                    "field-type": "map[string]*core.AssignmentInfo"
+                    "name": "assignments",
+                    "type": "map[string]*core.AssignmentInfo"
                 },
                 {
-                    "field-name": "id",
-                    "field-type": "string"
+                    "name": "id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "name",
-                    "field-type": "string"
+                    "name": "name",
+                    "type": "string"
                 }
             ]
         },
@@ -1535,24 +1535,24 @@
             "description": "An API-safe representation of a course user.\nEmbed the BaseUserInfo and use CourseUserInfoType as the type.",
             "fields": [
                 {
-                    "field-name": "email",
-                    "field-type": "string"
+                    "name": "email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "lms-id",
-                    "field-type": "string"
+                    "name": "lms-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "name",
-                    "field-type": "string"
+                    "name": "name",
+                    "type": "string"
                 },
                 {
-                    "field-name": "role",
-                    "field-type": "int"
+                    "name": "role",
+                    "type": "int"
                 },
                 {
-                    "field-name": "type",
-                    "field-type": "string"
+                    "name": "type",
+                    "type": "string"
                 }
             ]
         },
@@ -1560,16 +1560,16 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "description",
-                    "field-type": "string"
+                    "name": "description",
+                    "type": "string"
                 },
                 {
-                    "field-name": "input",
-                    "field-type": "[]core.FieldDescription"
+                    "name": "input",
+                    "type": "[]core.FieldDescription"
                 },
                 {
-                    "field-name": "output",
-                    "field-type": "[]core.FieldDescription"
+                    "name": "output",
+                    "type": "[]core.FieldDescription"
                 }
             ]
         },
@@ -1578,12 +1578,12 @@
             "description": "An API-safe representation of enrollment information.",
             "fields": [
                 {
-                    "field-name": "id",
-                    "field-type": "string"
+                    "name": "id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "role",
-                    "field-type": "int"
+                    "name": "role",
+                    "type": "int"
                 }
             ]
         },
@@ -1591,12 +1591,12 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "field-name",
-                    "field-type": "string"
+                    "name": "name",
+                    "type": "string"
                 },
                 {
-                    "field-name": "field-type",
-                    "field-type": "string"
+                    "name": "type",
+                    "type": "string"
                 }
             ]
         },
@@ -1609,24 +1609,24 @@
             "description": "An API-safe representation of a server user.\nEmbed the BaseUserInfo and use ServerUserInfoType as the type.",
             "fields": [
                 {
-                    "field-name": "courses",
-                    "field-type": "map[string]core.EnrollmentInfo"
+                    "name": "courses",
+                    "type": "map[string]core.EnrollmentInfo"
                 },
                 {
-                    "field-name": "email",
-                    "field-type": "string"
+                    "name": "email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "name",
-                    "field-type": "string"
+                    "name": "name",
+                    "type": "string"
                 },
                 {
-                    "field-name": "role",
-                    "field-type": "int"
+                    "name": "role",
+                    "type": "int"
                 },
                 {
-                    "field-name": "type",
-                    "field-type": "string"
+                    "name": "type",
+                    "type": "string"
                 }
             ]
         },
@@ -1639,8 +1639,8 @@
             "description": "Same as TargetServerUserSelfOrAdmin, but in the context of a course user and a grader context user.\nTherefore, the context user only has to be a grader in the context course (or the target user themself).\nWhen targeting yourself, the user can be a server admin (and will be escalated to course owner for the request).\nThe existence of this type in a struct also indicates that the request is at least a APIRequestCourseUserContext.",
             "fields": [
                 {
-                    "field-name": "TargetCourseUser",
-                    "field-type": "core.TargetCourseUser"
+                    "name": "TargetCourseUser",
+                    "type": "core.TargetCourseUser"
                 }
             ]
         },
@@ -1653,8 +1653,8 @@
             "description": "A request having a field of this type indicates that the request is targeting a specific user.\nThis type serializes to/from a string.\nIf no user is specified, then the context user is the target.\nIf a user is specified, then the context user must be a server admin\n(any user can access their own resources, but higher permissions are required to access another user's resources).\nNo error is generated if the user is not found.\nThe existence of this type in a struct also indicates that the request is at least a APIRequestUserContext.",
             "fields": [
                 {
-                    "field-name": "TargetServerUser",
-                    "field-type": "core.TargetServerUser"
+                    "name": "TargetServerUser",
+                    "type": "core.TargetServerUser"
                 }
             ]
         },
@@ -1662,24 +1662,24 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "alias-type",
-                    "field-type": "string"
+                    "name": "alias-type",
+                    "type": "string"
                 },
                 {
-                    "field-name": "category",
-                    "field-type": "string"
+                    "name": "category",
+                    "type": "string"
                 },
                 {
-                    "field-name": "description",
-                    "field-type": "string"
+                    "name": "description",
+                    "type": "string"
                 },
                 {
-                    "field-name": "element-type",
-                    "field-type": "string"
+                    "name": "element-type",
+                    "type": "string"
                 },
                 {
-                    "field-name": "fields",
-                    "field-type": "[]core.FieldDescription"
+                    "name": "fields",
+                    "type": "[]core.FieldDescription"
                 }
             ]
         },
@@ -1691,28 +1691,28 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "dry-run",
-                    "field-type": "bool"
+                    "name": "dry-run",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-build-images",
-                    "field-type": "bool"
+                    "name": "skip-build-images",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-emails",
-                    "field-type": "bool"
+                    "name": "skip-emails",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-lms-sync",
-                    "field-type": "bool"
+                    "name": "skip-lms-sync",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-source-sync",
-                    "field-type": "bool"
+                    "name": "skip-source-sync",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-template-files",
-                    "field-type": "bool"
+                    "name": "skip-template-files",
+                    "type": "bool"
                 }
             ]
         },
@@ -1720,28 +1720,28 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "dry-run",
-                    "field-type": "bool"
+                    "name": "dry-run",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-build-images",
-                    "field-type": "bool"
+                    "name": "skip-build-images",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-emails",
-                    "field-type": "bool"
+                    "name": "skip-emails",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-lms-sync",
-                    "field-type": "bool"
+                    "name": "skip-lms-sync",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-source-sync",
-                    "field-type": "bool"
+                    "name": "skip-source-sync",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-template-files",
-                    "field-type": "bool"
+                    "name": "skip-template-files",
+                    "type": "bool"
                 }
             ]
         },
@@ -1749,36 +1749,36 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "assignment-template-files",
-                    "field-type": "map[string][]string"
+                    "name": "assignment-template-files",
+                    "type": "map[string][]string"
                 },
                 {
-                    "field-name": "built-assignment-images",
-                    "field-type": "[]string"
+                    "name": "built-assignment-images",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "created",
-                    "field-type": "bool"
+                    "name": "created",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "lms-sync-result",
-                    "field-type": "*model.LMSSyncResult"
+                    "name": "lms-sync-result",
+                    "type": "*model.LMSSyncResult"
                 },
                 {
-                    "field-name": "message",
-                    "field-type": "string"
+                    "name": "message",
+                    "type": "string"
                 },
                 {
-                    "field-name": "success",
-                    "field-type": "bool"
+                    "name": "success",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "updated",
-                    "field-type": "bool"
+                    "name": "updated",
+                    "type": "bool"
                 }
             ]
         },
@@ -1786,28 +1786,28 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "bcc",
-                    "field-type": "[]string"
+                    "name": "bcc",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "body",
-                    "field-type": "string"
+                    "name": "body",
+                    "type": "string"
                 },
                 {
-                    "field-name": "cc",
-                    "field-type": "[]string"
+                    "name": "cc",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "html",
-                    "field-type": "bool"
+                    "name": "html",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "subject",
-                    "field-type": "string"
+                    "name": "subject",
+                    "type": "string"
                 },
                 {
-                    "field-name": "to",
-                    "field-type": "[]string"
+                    "name": "to",
+                    "type": "[]string"
                 }
             ]
         },
@@ -1820,28 +1820,28 @@
             "description": "A representation of a query for server log records.\nA raw query can be processed (validated for structure and permissions)\nby the internal/procedures/log package.\nBecause of some assumptions we make, log times before UNIX epoch are not supported.\nHowever, since this code was created well past that only time travelers should be concerned.",
             "fields": [
                 {
-                    "field-name": "after",
-                    "field-type": "string"
+                    "name": "after",
+                    "type": "string"
                 },
                 {
-                    "field-name": "level",
-                    "field-type": "string"
+                    "name": "level",
+                    "type": "string"
                 },
                 {
-                    "field-name": "past",
-                    "field-type": "string"
+                    "name": "past",
+                    "type": "string"
                 },
                 {
-                    "field-name": "target-assignment",
-                    "field-type": "string"
+                    "name": "target-assignment",
+                    "type": "string"
                 },
                 {
-                    "field-name": "target-course",
-                    "field-type": "string"
+                    "name": "target-course",
+                    "type": "string"
                 },
                 {
-                    "field-name": "target-email",
-                    "field-type": "string"
+                    "name": "target-email",
+                    "type": "string"
                 }
             ]
         },
@@ -1849,36 +1849,36 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "assignment",
-                    "field-type": "string"
+                    "name": "assignment",
+                    "type": "string"
                 },
                 {
-                    "field-name": "attributes",
-                    "field-type": "map[string]interface {}"
+                    "name": "attributes",
+                    "type": "map[string]interface {}"
                 },
                 {
-                    "field-name": "course",
-                    "field-type": "string"
+                    "name": "course",
+                    "type": "string"
                 },
                 {
-                    "field-name": "error",
-                    "field-type": "string"
+                    "name": "error",
+                    "type": "string"
                 },
                 {
-                    "field-name": "level",
-                    "field-type": "int32"
+                    "name": "level",
+                    "type": "int32"
                 },
                 {
-                    "field-name": "message",
-                    "field-type": "string"
+                    "name": "message",
+                    "type": "string"
                 },
                 {
-                    "field-name": "timestamp",
-                    "field-type": "int64"
+                    "name": "timestamp",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "user",
-                    "field-type": "string"
+                    "name": "user",
+                    "type": "string"
                 }
             ]
         },
@@ -1886,16 +1886,16 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "filename",
-                    "field-type": "string"
+                    "name": "filename",
+                    "type": "string"
                 },
                 {
-                    "field-name": "lines-of-code",
-                    "field-type": "int"
+                    "name": "lines-of-code",
+                    "type": "int"
                 },
                 {
-                    "field-name": "original-filename",
-                    "field-type": "string"
+                    "name": "original-filename",
+                    "type": "string"
                 }
             ]
         },
@@ -1903,28 +1903,28 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "complete",
-                    "field-type": "bool"
+                    "name": "complete",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "complete-count",
-                    "field-type": "int"
+                    "name": "complete-count",
+                    "type": "int"
                 },
                 {
-                    "field-name": "failure-count",
-                    "field-type": "int"
+                    "name": "failure-count",
+                    "type": "int"
                 },
                 {
-                    "field-name": "first-timestamp",
-                    "field-type": "int64"
+                    "name": "first-timestamp",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "last-timestamp",
-                    "field-type": "int64"
+                    "name": "last-timestamp",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "pending-count",
-                    "field-type": "int"
+                    "name": "pending-count",
+                    "type": "int"
                 }
             ]
         },
@@ -1932,20 +1932,20 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "exclude-patterns",
-                    "field-type": "[]string"
+                    "name": "exclude-patterns",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "include-patterns",
-                    "field-type": "[]string"
+                    "name": "include-patterns",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "template-file-ops",
-                    "field-type": "[]*util.FileOperation"
+                    "name": "template-file-ops",
+                    "type": "[]*util.FileOperation"
                 },
                 {
-                    "field-name": "template-files",
-                    "field-type": "[]*util.FileSpec"
+                    "name": "template-files",
+                    "type": "[]*util.FileSpec"
                 }
             ]
         },
@@ -1953,20 +1953,20 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "id",
-                    "field-type": "string"
+                    "name": "id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "late-days-lms-id",
-                    "field-type": "string"
+                    "name": "late-days-lms-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "late-days-lms-name",
-                    "field-type": "string"
+                    "name": "late-days-lms-name",
+                    "type": "string"
                 },
                 {
-                    "field-name": "name",
-                    "field-type": "string"
+                    "name": "name",
+                    "type": "string"
                 }
             ]
         },
@@ -1974,20 +1974,20 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "ambiguous-matches",
-                    "field-type": "[]model.AssignmentInfo"
+                    "name": "ambiguous-matches",
+                    "type": "[]model.AssignmentInfo"
                 },
                 {
-                    "field-name": "non-matched-assignments",
-                    "field-type": "[]model.AssignmentInfo"
+                    "name": "non-matched-assignments",
+                    "type": "[]model.AssignmentInfo"
                 },
                 {
-                    "field-name": "synced-assignments",
-                    "field-type": "[]model.AssignmentInfo"
+                    "name": "synced-assignments",
+                    "type": "[]model.AssignmentInfo"
                 },
                 {
-                    "field-name": "unchanged-assignments",
-                    "field-type": "[]model.AssignmentInfo"
+                    "name": "unchanged-assignments",
+                    "type": "[]model.AssignmentInfo"
                 }
             ]
         },
@@ -1996,40 +1996,40 @@
             "description": "A general representation of the result of operations that modify a user in any way (add, remove, enroll, drop, etc).",
             "fields": [
                 {
-                    "field-name": "added",
-                    "field-type": "bool"
+                    "name": "added",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "dropped",
-                    "field-type": "[]string"
+                    "name": "dropped",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "email",
-                    "field-type": "string"
+                    "name": "email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "emailed",
-                    "field-type": "bool"
+                    "name": "emailed",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "enrolled",
-                    "field-type": "[]string"
+                    "name": "enrolled",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "modified",
-                    "field-type": "bool"
+                    "name": "modified",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "not-exists",
-                    "field-type": "bool"
+                    "name": "not-exists",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "removed",
-                    "field-type": "bool"
+                    "name": "removed",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skipped",
-                    "field-type": "bool"
+                    "name": "skipped",
+                    "type": "bool"
                 }
             ]
         },
@@ -2042,12 +2042,12 @@
             "description": "A user safe version of locatable errors.\nAll LocatableErrors must be converted to ExternalLocatableErrors\nif it is to be given to a user.",
             "fields": [
                 {
-                    "field-name": "locator",
-                    "field-type": "string"
+                    "name": "locator",
+                    "type": "string"
                 },
                 {
-                    "field-name": "message",
-                    "field-type": "string"
+                    "name": "message",
+                    "type": "string"
                 }
             ]
         },
@@ -2056,32 +2056,32 @@
             "description": "A trimmed-down version of ScoringInfo meant for external usage.",
             "fields": [
                 {
-                    "field-name": "assignment",
-                    "field-type": "string"
+                    "name": "assignment",
+                    "type": "string"
                 },
                 {
-                    "field-name": "raw-score",
-                    "field-type": "float64"
+                    "name": "raw-score",
+                    "type": "float64"
                 },
                 {
-                    "field-name": "score",
-                    "field-type": "float64"
+                    "name": "score",
+                    "type": "float64"
                 },
                 {
-                    "field-name": "submission-id",
-                    "field-type": "string"
+                    "name": "submission-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "submission-time",
-                    "field-type": "int64"
+                    "name": "submission-time",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "upload-time",
-                    "field-type": "int64"
+                    "name": "upload-time",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "user",
-                    "field-type": "string"
+                    "name": "user",
+                    "type": "string"
                 }
             ]
         },
@@ -2090,52 +2090,52 @@
             "description": "A user safe representation of the UserOpResult struct.\nNotably all errors will be converted to responses and the cleartext password field is removed.\nFor descriptions of shared fields, see UserOpResult above.",
             "fields": [
                 {
-                    "field-name": "added",
-                    "field-type": "bool"
+                    "name": "added",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "communication-error",
-                    "field-type": "*model.ExternalLocatableError"
+                    "name": "communication-error",
+                    "type": "*model.ExternalLocatableError"
                 },
                 {
-                    "field-name": "dropped",
-                    "field-type": "[]string"
+                    "name": "dropped",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "email",
-                    "field-type": "string"
+                    "name": "email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "emailed",
-                    "field-type": "bool"
+                    "name": "emailed",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "enrolled",
-                    "field-type": "[]string"
+                    "name": "enrolled",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "modified",
-                    "field-type": "bool"
+                    "name": "modified",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "not-exists",
-                    "field-type": "bool"
+                    "name": "not-exists",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "removed",
-                    "field-type": "bool"
+                    "name": "removed",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skipped",
-                    "field-type": "bool"
+                    "name": "skipped",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "system-error",
-                    "field-type": "*model.ExternalLocatableError"
+                    "name": "system-error",
+                    "type": "*model.ExternalLocatableError"
                 },
                 {
-                    "field-name": "validation-error",
-                    "field-type": "*model.ExternalLocatableError"
+                    "name": "validation-error",
+                    "type": "*model.ExternalLocatableError"
                 }
             ]
         },
@@ -2143,28 +2143,28 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "filename",
-                    "field-type": "string"
+                    "name": "filename",
+                    "type": "string"
                 },
                 {
-                    "field-name": "options",
-                    "field-type": "map[string]interface {}"
+                    "name": "options",
+                    "type": "map[string]interface {}"
                 },
                 {
-                    "field-name": "original-filename",
-                    "field-type": "string"
+                    "name": "original-filename",
+                    "type": "string"
                 },
                 {
-                    "field-name": "score",
-                    "field-type": "float64"
+                    "name": "score",
+                    "type": "float64"
                 },
                 {
-                    "field-name": "tool",
-                    "field-type": "string"
+                    "name": "tool",
+                    "type": "string"
                 },
                 {
-                    "field-name": "version",
-                    "field-type": "string"
+                    "name": "version",
+                    "type": "string"
                 }
             ]
         },
@@ -2172,36 +2172,36 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "grading_end_time",
-                    "field-type": "int64"
+                    "name": "grading_end_time",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "grading_start_time",
-                    "field-type": "int64"
+                    "name": "grading_start_time",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "hard_fail",
-                    "field-type": "bool"
+                    "name": "hard_fail",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "max_points",
-                    "field-type": "float64"
+                    "name": "max_points",
+                    "type": "float64"
                 },
                 {
-                    "field-name": "message",
-                    "field-type": "string"
+                    "name": "message",
+                    "type": "string"
                 },
                 {
-                    "field-name": "name",
-                    "field-type": "string"
+                    "name": "name",
+                    "type": "string"
                 },
                 {
-                    "field-name": "score",
-                    "field-type": "float64"
+                    "name": "score",
+                    "type": "float64"
                 },
                 {
-                    "field-name": "skipped",
-                    "field-type": "bool"
+                    "name": "skipped",
+                    "type": "bool"
                 }
             ]
         },
@@ -2209,76 +2209,76 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "additional-info",
-                    "field-type": "map[string]interface {}"
+                    "name": "additional-info",
+                    "type": "map[string]interface {}"
                 },
                 {
-                    "field-name": "assignment-id",
-                    "field-type": "string"
+                    "name": "assignment-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "epilogue",
-                    "field-type": "string"
+                    "name": "epilogue",
+                    "type": "string"
                 },
                 {
-                    "field-name": "grading_end_time",
-                    "field-type": "int64"
+                    "name": "grading_end_time",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "grading_start_time",
-                    "field-type": "int64"
+                    "name": "grading_start_time",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "id",
-                    "field-type": "string"
+                    "name": "id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "max_points",
-                    "field-type": "float64"
+                    "name": "max_points",
+                    "type": "float64"
                 },
                 {
-                    "field-name": "message",
-                    "field-type": "string"
+                    "name": "message",
+                    "type": "string"
                 },
                 {
-                    "field-name": "name",
-                    "field-type": "string"
+                    "name": "name",
+                    "type": "string"
                 },
                 {
-                    "field-name": "prologue",
-                    "field-type": "string"
+                    "name": "prologue",
+                    "type": "string"
                 },
                 {
-                    "field-name": "proxy-user",
-                    "field-type": "string"
+                    "name": "proxy-user",
+                    "type": "string"
                 },
                 {
-                    "field-name": "proxy_end_time",
-                    "field-type": "int64"
+                    "name": "proxy_end_time",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "proxy_start_time",
-                    "field-type": "int64"
+                    "name": "proxy_start_time",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "questions",
-                    "field-type": "[]*model.GradedQuestion"
+                    "name": "questions",
+                    "type": "[]*model.GradedQuestion"
                 },
                 {
-                    "field-name": "score",
-                    "field-type": "float64"
+                    "name": "score",
+                    "type": "float64"
                 },
                 {
-                    "field-name": "short-id",
-                    "field-type": "string"
+                    "name": "short-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user",
-                    "field-type": "string"
+                    "name": "user",
+                    "type": "string"
                 }
             ]
         },
@@ -2286,24 +2286,24 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "info",
-                    "field-type": "*model.GradingInfo"
+                    "name": "info",
+                    "type": "*model.GradingInfo"
                 },
                 {
-                    "field-name": "input-files-gzip",
-                    "field-type": "map[string][]uint8"
+                    "name": "input-files-gzip",
+                    "type": "map[string][]uint8"
                 },
                 {
-                    "field-name": "output-files-gzip",
-                    "field-type": "map[string][]uint8"
+                    "name": "output-files-gzip",
+                    "type": "map[string][]uint8"
                 },
                 {
-                    "field-name": "stderr",
-                    "field-type": "string"
+                    "name": "stderr",
+                    "type": "string"
                 },
                 {
-                    "field-name": "stdout",
-                    "field-type": "string"
+                    "name": "stdout",
+                    "type": "string"
                 }
             ]
         },
@@ -2311,80 +2311,80 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "analysis-timestamp",
-                    "field-type": "int64"
+                    "name": "analysis-timestamp",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "assignment-id",
-                    "field-type": "string"
+                    "name": "assignment-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "failure",
-                    "field-type": "bool"
+                    "name": "failure",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "failure-message",
-                    "field-type": "string"
+                    "name": "failure-message",
+                    "type": "string"
                 },
                 {
-                    "field-name": "files",
-                    "field-type": "[]model.AnalysisFileInfo"
+                    "name": "files",
+                    "type": "[]model.AnalysisFileInfo"
                 },
                 {
-                    "field-name": "lines-of-code",
-                    "field-type": "int"
+                    "name": "lines-of-code",
+                    "type": "int"
                 },
                 {
-                    "field-name": "lines-of-code-delta",
-                    "field-type": "int"
+                    "name": "lines-of-code-delta",
+                    "type": "int"
                 },
                 {
-                    "field-name": "lines-of-code-per-hour",
-                    "field-type": "float64"
+                    "name": "lines-of-code-per-hour",
+                    "type": "float64"
                 },
                 {
-                    "field-name": "options",
-                    "field-type": "*model.AssignmentAnalysisOptions"
+                    "name": "options",
+                    "type": "*model.AssignmentAnalysisOptions"
                 },
                 {
-                    "field-name": "score",
-                    "field-type": "float64"
+                    "name": "score",
+                    "type": "float64"
                 },
                 {
-                    "field-name": "score-delta",
-                    "field-type": "float64"
+                    "name": "score-delta",
+                    "type": "float64"
                 },
                 {
-                    "field-name": "score-per-hour",
-                    "field-type": "float64"
+                    "name": "score-per-hour",
+                    "type": "float64"
                 },
                 {
-                    "field-name": "short-id",
-                    "field-type": "string"
+                    "name": "short-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "skipped-files",
-                    "field-type": "[]string"
+                    "name": "skipped-files",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "submission-id",
-                    "field-type": "string"
+                    "name": "submission-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "submission-start-time",
-                    "field-type": "int64"
+                    "name": "submission-start-time",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "submission-time-delta",
-                    "field-type": "int64"
+                    "name": "submission-time-delta",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "user-email",
-                    "field-type": "string"
+                    "name": "user-email",
+                    "type": "string"
                 }
             ]
         },
@@ -2392,60 +2392,60 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "aggregate-lines-of-code",
-                    "field-type": "util.AggregateValues"
+                    "name": "aggregate-lines-of-code",
+                    "type": "util.AggregateValues"
                 },
                 {
-                    "field-name": "aggregate-lines-of-code-delta",
-                    "field-type": "util.AggregateValues"
+                    "name": "aggregate-lines-of-code-delta",
+                    "type": "util.AggregateValues"
                 },
                 {
-                    "field-name": "aggregate-lines-of-code-per-file",
-                    "field-type": "map[string]util.AggregateValues"
+                    "name": "aggregate-lines-of-code-per-file",
+                    "type": "map[string]util.AggregateValues"
                 },
                 {
-                    "field-name": "aggregate-lines-of-code-per-hour",
-                    "field-type": "util.AggregateValues"
+                    "name": "aggregate-lines-of-code-per-hour",
+                    "type": "util.AggregateValues"
                 },
                 {
-                    "field-name": "aggregate-score",
-                    "field-type": "util.AggregateValues"
+                    "name": "aggregate-score",
+                    "type": "util.AggregateValues"
                 },
                 {
-                    "field-name": "aggregate-score-delta",
-                    "field-type": "util.AggregateValues"
+                    "name": "aggregate-score-delta",
+                    "type": "util.AggregateValues"
                 },
                 {
-                    "field-name": "aggregate-score-per-hour",
-                    "field-type": "util.AggregateValues"
+                    "name": "aggregate-score-per-hour",
+                    "type": "util.AggregateValues"
                 },
                 {
-                    "field-name": "aggregate-submission-time-delta",
-                    "field-type": "util.AggregateValues"
+                    "name": "aggregate-submission-time-delta",
+                    "type": "util.AggregateValues"
                 },
                 {
-                    "field-name": "complete",
-                    "field-type": "bool"
+                    "name": "complete",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "complete-count",
-                    "field-type": "int"
+                    "name": "complete-count",
+                    "type": "int"
                 },
                 {
-                    "field-name": "failure-count",
-                    "field-type": "int"
+                    "name": "failure-count",
+                    "type": "int"
                 },
                 {
-                    "field-name": "first-timestamp",
-                    "field-type": "int64"
+                    "name": "first-timestamp",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "last-timestamp",
-                    "field-type": "int64"
+                    "name": "last-timestamp",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "pending-count",
-                    "field-type": "int"
+                    "name": "pending-count",
+                    "type": "int"
                 }
             ]
         },
@@ -2453,12 +2453,12 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "assignment-sync",
-                    "field-type": "*model.AssignmentSyncResult"
+                    "name": "assignment-sync",
+                    "type": "*model.AssignmentSyncResult"
                 },
                 {
-                    "field-name": "user-sync",
-                    "field-type": "[]*model.UserOpResult"
+                    "name": "user-sync",
+                    "type": "[]*model.UserOpResult"
                 }
             ]
         },
@@ -2470,44 +2470,44 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "analysis-timestamp",
-                    "field-type": "int64"
+                    "name": "analysis-timestamp",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "failure",
-                    "field-type": "bool"
+                    "name": "failure",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "failure-message",
-                    "field-type": "string"
+                    "name": "failure-message",
+                    "type": "string"
                 },
                 {
-                    "field-name": "mean-similarities",
-                    "field-type": "map[string]float64"
+                    "name": "mean-similarities",
+                    "type": "map[string]float64"
                 },
                 {
-                    "field-name": "options",
-                    "field-type": "*model.AssignmentAnalysisOptions"
+                    "name": "options",
+                    "type": "*model.AssignmentAnalysisOptions"
                 },
                 {
-                    "field-name": "similarities",
-                    "field-type": "map[string][]*model.FileSimilarity"
+                    "name": "similarities",
+                    "type": "map[string][]*model.FileSimilarity"
                 },
                 {
-                    "field-name": "skipped-files",
-                    "field-type": "[]string"
+                    "name": "skipped-files",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "submission-ids",
-                    "field-type": "model.PairwiseKey"
+                    "name": "submission-ids",
+                    "type": "model.PairwiseKey"
                 },
                 {
-                    "field-name": "total-mean-similarity",
-                    "field-type": "float64"
+                    "name": "total-mean-similarity",
+                    "type": "float64"
                 },
                 {
-                    "field-name": "unmatched-files",
-                    "field-type": "[][]string"
+                    "name": "unmatched-files",
+                    "type": "[][]string"
                 }
             ]
         },
@@ -2515,36 +2515,36 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "aggregate-mean-similarities",
-                    "field-type": "map[string]util.AggregateValues"
+                    "name": "aggregate-mean-similarities",
+                    "type": "map[string]util.AggregateValues"
                 },
                 {
-                    "field-name": "aggregate-total-mean-similarity",
-                    "field-type": "util.AggregateValues"
+                    "name": "aggregate-total-mean-similarity",
+                    "type": "util.AggregateValues"
                 },
                 {
-                    "field-name": "complete",
-                    "field-type": "bool"
+                    "name": "complete",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "complete-count",
-                    "field-type": "int"
+                    "name": "complete-count",
+                    "type": "int"
                 },
                 {
-                    "field-name": "failure-count",
-                    "field-type": "int"
+                    "name": "failure-count",
+                    "type": "int"
                 },
                 {
-                    "field-name": "first-timestamp",
-                    "field-type": "int64"
+                    "name": "first-timestamp",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "last-timestamp",
-                    "field-type": "int64"
+                    "name": "last-timestamp",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "pending-count",
-                    "field-type": "int"
+                    "name": "pending-count",
+                    "type": "int"
                 }
             ]
         },
@@ -2557,20 +2557,20 @@
             "description": "Raw/dirty data for a course user.\nThis struct is used for raw data coming from a single course.",
             "fields": [
                 {
-                    "field-name": "course-lms-id",
-                    "field-type": "string"
+                    "name": "course-lms-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-role",
-                    "field-type": "string"
+                    "name": "course-role",
+                    "type": "string"
                 },
                 {
-                    "field-name": "email",
-                    "field-type": "string"
+                    "name": "email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "name",
-                    "field-type": "string"
+                    "name": "name",
+                    "type": "string"
                 }
             ]
         },
@@ -2579,32 +2579,32 @@
             "description": "Raw/dirty data for a user.\nThis struct can be directly embedded for Kong arguments.",
             "fields": [
                 {
-                    "field-name": "course",
-                    "field-type": "string"
+                    "name": "course",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-lms-id",
-                    "field-type": "string"
+                    "name": "course-lms-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-role",
-                    "field-type": "string"
+                    "name": "course-role",
+                    "type": "string"
                 },
                 {
-                    "field-name": "email",
-                    "field-type": "string"
+                    "name": "email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "name",
-                    "field-type": "string"
+                    "name": "name",
+                    "type": "string"
                 },
                 {
-                    "field-name": "pass",
-                    "field-type": "string"
+                    "name": "pass",
+                    "type": "string"
                 },
                 {
-                    "field-name": "role",
-                    "field-type": "string"
+                    "name": "role",
+                    "type": "string"
                 }
             ]
         },
@@ -2616,40 +2616,40 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "assignment-id",
-                    "field-type": "string"
+                    "name": "assignment-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "course-id",
-                    "field-type": "string"
+                    "name": "course-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "grading_start_time",
-                    "field-type": "int64"
+                    "name": "grading_start_time",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "id",
-                    "field-type": "string"
+                    "name": "id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "max_points",
-                    "field-type": "float64"
+                    "name": "max_points",
+                    "type": "float64"
                 },
                 {
-                    "field-name": "message",
-                    "field-type": "string"
+                    "name": "message",
+                    "type": "string"
                 },
                 {
-                    "field-name": "score",
-                    "field-type": "float64"
+                    "name": "score",
+                    "type": "float64"
                 },
                 {
-                    "field-name": "short-id",
-                    "field-type": "string"
+                    "name": "short-id",
+                    "type": "string"
                 },
                 {
-                    "field-name": "user",
-                    "field-type": "string"
+                    "name": "user",
+                    "type": "string"
                 }
             ]
         },
@@ -2658,56 +2658,56 @@
             "description": "A general representation of the result of operations that modify a user in any way (add, remove, enroll, drop, etc).\nAll user-facing functions (essentially non-db functions) should return an instance or collection of these objects.",
             "fields": [
                 {
-                    "field-name": "added",
-                    "field-type": "bool"
+                    "name": "added",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "cleartext-password",
-                    "field-type": "string"
+                    "name": "cleartext-password",
+                    "type": "string"
                 },
                 {
-                    "field-name": "communication-error",
-                    "field-type": "*model.LocatableError"
+                    "name": "communication-error",
+                    "type": "*model.LocatableError"
                 },
                 {
-                    "field-name": "dropped",
-                    "field-type": "[]string"
+                    "name": "dropped",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "email",
-                    "field-type": "string"
+                    "name": "email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "emailed",
-                    "field-type": "bool"
+                    "name": "emailed",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "enrolled",
-                    "field-type": "[]string"
+                    "name": "enrolled",
+                    "type": "[]string"
                 },
                 {
-                    "field-name": "modified",
-                    "field-type": "bool"
+                    "name": "modified",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "not-exists",
-                    "field-type": "bool"
+                    "name": "not-exists",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "removed",
-                    "field-type": "bool"
+                    "name": "removed",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skipped",
-                    "field-type": "bool"
+                    "name": "skipped",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "system-error",
-                    "field-type": "*model.LocatableError"
+                    "name": "system-error",
+                    "type": "*model.LocatableError"
                 },
                 {
-                    "field-name": "validation-error",
-                    "field-type": "*model.LocatableError"
+                    "name": "validation-error",
+                    "type": "*model.LocatableError"
                 }
             ]
         },
@@ -2715,20 +2715,20 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "attributes",
-                    "field-type": "map[stats.MetricAttribute]interface {}"
+                    "name": "attributes",
+                    "type": "map[stats.MetricAttribute]interface {}"
                 },
                 {
-                    "field-name": "timestamp",
-                    "field-type": "int64"
+                    "name": "timestamp",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "type",
-                    "field-type": "string"
+                    "name": "type",
+                    "type": "string"
                 },
                 {
-                    "field-name": "value",
-                    "field-type": "float64"
+                    "name": "value",
+                    "type": "float64"
                 }
             ]
         },
@@ -2745,28 +2745,28 @@
             "description": "The query for stats.\nNote that the semantics of this struct mean that times before UNIX epoch (negative times)\nmust be offset by at least one MS (as a zero value is treated as the end of time).",
             "fields": [
                 {
-                    "field-name": "after",
-                    "field-type": "int64"
+                    "name": "after",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "before",
-                    "field-type": "int64"
+                    "name": "before",
+                    "type": "int64"
                 },
                 {
-                    "field-name": "limit",
-                    "field-type": "int"
+                    "name": "limit",
+                    "type": "int"
                 },
                 {
-                    "field-name": "sort",
-                    "field-type": "int"
+                    "name": "sort",
+                    "type": "int"
                 },
                 {
-                    "field-name": "type",
-                    "field-type": "string"
+                    "name": "type",
+                    "type": "string"
                 },
                 {
-                    "field-name": "where",
-                    "field-type": "map[stats.MetricAttribute]interface {}"
+                    "name": "where",
+                    "type": "map[stats.MetricAttribute]interface {}"
                 }
             ]
         },
@@ -2778,12 +2778,12 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "entry",
-                    "field-type": "interface {}"
+                    "name": "entry",
+                    "type": "interface {}"
                 },
                 {
-                    "field-name": "row",
-                    "field-type": "int"
+                    "name": "row",
+                    "type": "int"
                 }
             ]
         },
@@ -2791,12 +2791,12 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "email",
-                    "field-type": "string"
+                    "name": "email",
+                    "type": "string"
                 },
                 {
-                    "field-name": "score",
-                    "field-type": "float64"
+                    "name": "score",
+                    "type": "float64"
                 }
             ]
         },
@@ -2805,24 +2805,24 @@
             "description": "Data for upserting users.\nUpserting should only be done by server or course admins,\nit should not be used for self creation.",
             "fields": [
                 {
-                    "field-name": "dry-run",
-                    "field-type": "bool"
+                    "name": "dry-run",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "raw-users",
-                    "field-type": "[]*model.RawServerUserData"
+                    "name": "raw-users",
+                    "type": "[]*model.RawServerUserData"
                 },
                 {
-                    "field-name": "send-emails",
-                    "field-type": "bool"
+                    "name": "send-emails",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-inserts",
-                    "field-type": "bool"
+                    "name": "skip-inserts",
+                    "type": "bool"
                 },
                 {
-                    "field-name": "skip-updates",
-                    "field-type": "bool"
+                    "name": "skip-updates",
+                    "type": "bool"
                 }
             ]
         },
@@ -2830,24 +2830,24 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "count",
-                    "field-type": "int"
+                    "name": "count",
+                    "type": "int"
                 },
                 {
-                    "field-name": "max",
-                    "field-type": "float64"
+                    "name": "max",
+                    "type": "float64"
                 },
                 {
-                    "field-name": "mean",
-                    "field-type": "float64"
+                    "name": "mean",
+                    "type": "float64"
                 },
                 {
-                    "field-name": "median",
-                    "field-type": "float64"
+                    "name": "median",
+                    "type": "float64"
                 },
                 {
-                    "field-name": "min",
-                    "field-type": "float64"
+                    "name": "min",
+                    "type": "float64"
                 }
             ]
         },
@@ -2855,16 +2855,16 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "name",
-                    "field-type": "string"
+                    "name": "name",
+                    "type": "string"
                 },
                 {
-                    "field-name": "records",
-                    "field-type": "[]util.CallStackRecord"
+                    "name": "records",
+                    "type": "[]util.CallStackRecord"
                 },
                 {
-                    "field-name": "status",
-                    "field-type": "string"
+                    "name": "status",
+                    "type": "string"
                 }
             ]
         },
@@ -2872,20 +2872,20 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "call",
-                    "field-type": "string"
+                    "name": "call",
+                    "type": "string"
                 },
                 {
-                    "field-name": "file",
-                    "field-type": "string"
+                    "name": "file",
+                    "type": "string"
                 },
                 {
-                    "field-name": "line",
-                    "field-type": "int"
+                    "name": "line",
+                    "type": "int"
                 },
                 {
-                    "field-name": "pointer",
-                    "field-type": "string"
+                    "name": "pointer",
+                    "type": "string"
                 }
             ]
         },
@@ -2897,28 +2897,28 @@
             "category": "struct",
             "fields": [
                 {
-                    "field-name": "dest",
-                    "field-type": "string"
+                    "name": "dest",
+                    "type": "string"
                 },
                 {
-                    "field-name": "path",
-                    "field-type": "string"
+                    "name": "path",
+                    "type": "string"
                 },
                 {
-                    "field-name": "reference",
-                    "field-type": "string"
+                    "name": "reference",
+                    "type": "string"
                 },
                 {
-                    "field-name": "token",
-                    "field-type": "string"
+                    "name": "token",
+                    "type": "string"
                 },
                 {
-                    "field-name": "type",
-                    "field-type": "string"
+                    "name": "type",
+                    "type": "string"
                 },
                 {
-                    "field-name": "username",
-                    "field-type": "string"
+                    "name": "username",
+                    "type": "string"
                 }
             ]
         },

--- a/resources/api.json
+++ b/resources/api.json
@@ -2,648 +2,1605 @@
     "endpoints": {
         "courses/admin/email": {
             "description": "Send an email to course users.",
-            "input": {
-                "bcc": "[]string",
-                "body": "string",
-                "cc": "[]string",
-                "course-id": "string",
-                "dry-run": "bool",
-                "html": "bool",
-                "subject": "string",
-                "to": "[]string",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "bcc": "[]string",
-                "cc": "[]string",
-                "to": "[]string"
-            }
+            "input": [
+                {
+                    "field-name": "bcc",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "body",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "cc",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "dry-run",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "html",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "subject",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "to",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "bcc",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "cc",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "to",
+                    "field-type": "[]string"
+                }
+            ]
         },
         "courses/admin/update": {
             "description": "Update an existing course.",
-            "input": {
-                "course-id": "string",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "result": "*courses.CourseUpsertResult"
-            }
+            "input": [
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "result",
+                    "field-type": "*courses.CourseUpsertResult"
+                }
+            ]
         },
         "courses/assignments/get": {
             "description": "Get the information for a course assignment.",
-            "input": {
-                "assignment-id": "string",
-                "course-id": "string",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "assignment": "*core.AssignmentInfo"
-            }
+            "input": [
+                {
+                    "field-name": "assignment-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "assignment",
+                    "field-type": "*core.AssignmentInfo"
+                }
+            ]
         },
         "courses/assignments/list": {
             "description": "List the assignments in the course.",
-            "input": {
-                "course-id": "string",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "assignments": "[]*core.AssignmentInfo"
-            }
+            "input": [
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "assignments",
+                    "field-type": "[]*core.AssignmentInfo"
+                }
+            ]
         },
         "courses/assignments/submissions/analysis/individual": {
             "description": "Get the result of a individual analysis for the specified submissions.",
-            "input": {
-                "dry-run": "bool",
-                "overwrite-cache": "bool",
-                "submissions": "[]string",
-                "user-email": "string",
-                "user-pass": "string",
-                "wait-for-completion": "bool"
-            },
-            "output": {
-                "complete": "bool",
-                "options": "analysis.AnalysisOptions",
-                "results": "[]*model.IndividualAnalysis",
-                "summary": "*model.IndividualAnalysisSummary"
-            }
+            "input": [
+                {
+                    "field-name": "dry-run",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "overwrite-cache",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "submissions",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "wait-for-completion",
+                    "field-type": "bool"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "complete",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "options",
+                    "field-type": "analysis.AnalysisOptions"
+                },
+                {
+                    "field-name": "results",
+                    "field-type": "[]*model.IndividualAnalysis"
+                },
+                {
+                    "field-name": "summary",
+                    "field-type": "*model.IndividualAnalysisSummary"
+                }
+            ]
         },
         "courses/assignments/submissions/analysis/pairwise": {
             "description": "Get the result of a pairwise analysis for the specified submissions.",
-            "input": {
-                "dry-run": "bool",
-                "overwrite-cache": "bool",
-                "submissions": "[]string",
-                "user-email": "string",
-                "user-pass": "string",
-                "wait-for-completion": "bool"
-            },
-            "output": {
-                "complete": "bool",
-                "options": "analysis.AnalysisOptions",
-                "results": "[]*model.PairwiseAnalysis",
-                "summary": "*model.PairwiseAnalysisSummary"
-            }
+            "input": [
+                {
+                    "field-name": "dry-run",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "overwrite-cache",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "submissions",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "wait-for-completion",
+                    "field-type": "bool"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "complete",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "options",
+                    "field-type": "analysis.AnalysisOptions"
+                },
+                {
+                    "field-name": "results",
+                    "field-type": "[]*model.PairwiseAnalysis"
+                },
+                {
+                    "field-name": "summary",
+                    "field-type": "*model.PairwiseAnalysisSummary"
+                }
+            ]
         },
         "courses/assignments/submissions/fetch/course/attempts": {
             "description": "Get all recent submissions and grading information for this assignment.",
-            "input": {
-                "assignment-id": "string",
-                "course-id": "string",
-                "filter-role": "int",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "grading-results": "map[string]*model.GradingResult"
-            }
+            "input": [
+                {
+                    "field-name": "assignment-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "filter-role",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "grading-results",
+                    "field-type": "map[string]*model.GradingResult"
+                }
+            ]
         },
         "courses/assignments/submissions/fetch/course/scores": {
             "description": "Get a summary of the most recent scores for this assignment.",
-            "input": {
-                "assignment-id": "string",
-                "course-id": "string",
-                "filter-role": "int",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "submission-infos": "map[string]*model.SubmissionHistoryItem"
-            }
+            "input": [
+                {
+                    "field-name": "assignment-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "filter-role",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "submission-infos",
+                    "field-type": "map[string]*model.SubmissionHistoryItem"
+                }
+            ]
         },
         "courses/assignments/submissions/fetch/user/attempt": {
             "description": "Get a submission along with all grading information.",
-            "input": {
-                "assignment-id": "string",
-                "course-id": "string",
-                "target-email": "core.TargetCourseUserSelfOrGrader",
-                "target-submission": "string",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "found-submission": "bool",
-                "found-user": "bool",
-                "grading-result": "*model.GradingResult"
-            }
+            "input": [
+                {
+                    "field-name": "assignment-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "target-email",
+                    "field-type": "core.TargetCourseUserSelfOrGrader"
+                },
+                {
+                    "field-name": "target-submission",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "found-submission",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "found-user",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "grading-result",
+                    "field-type": "*model.GradingResult"
+                }
+            ]
         },
         "courses/assignments/submissions/fetch/user/attempts": {
             "description": "Get all submission attempts made by a user along with all grading information.",
-            "input": {
-                "assignment-id": "string",
-                "course-id": "string",
-                "target-email": "core.TargetCourseUserSelfOrGrader",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "found-user": "bool",
-                "grading-results": "[]*model.GradingResult"
-            }
+            "input": [
+                {
+                    "field-name": "assignment-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "target-email",
+                    "field-type": "core.TargetCourseUserSelfOrGrader"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "found-user",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "grading-results",
+                    "field-type": "[]*model.GradingResult"
+                }
+            ]
         },
         "courses/assignments/submissions/fetch/user/history": {
             "description": "Get a summary of the submissions for this assignment.",
-            "input": {
-                "assignment-id": "string",
-                "course-id": "string",
-                "target-email": "core.TargetCourseUserSelfOrGrader",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "found-user": "bool",
-                "history": "[]*model.SubmissionHistoryItem"
-            }
+            "input": [
+                {
+                    "field-name": "assignment-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "target-email",
+                    "field-type": "core.TargetCourseUserSelfOrGrader"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "found-user",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "history",
+                    "field-type": "[]*model.SubmissionHistoryItem"
+                }
+            ]
         },
         "courses/assignments/submissions/fetch/user/peek": {
             "description": "Get a copy of the grading report for the specified submission. Does not submit a new submission.",
-            "input": {
-                "assignment-id": "string",
-                "course-id": "string",
-                "target-email": "core.TargetCourseUserSelfOrGrader",
-                "target-submission": "string",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "found-submission": "bool",
-                "found-user": "bool",
-                "submission-result": "*model.GradingInfo"
-            }
+            "input": [
+                {
+                    "field-name": "assignment-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "target-email",
+                    "field-type": "core.TargetCourseUserSelfOrGrader"
+                },
+                {
+                    "field-name": "target-submission",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "found-submission",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "found-user",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "submission-result",
+                    "field-type": "*model.GradingInfo"
+                }
+            ]
         },
         "courses/assignments/submissions/proxy/resubmit": {
             "description": "Proxy resubmit an assignment submission to the autograder.",
-            "input": {
-                "assignment-id": "string",
-                "course-id": "string",
-                "proxy-email": "core.TargetCourseUser",
-                "proxy-time": "int64",
-                "target-submission": "string",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "found-submission": "bool",
-                "found-user": "bool",
-                "grading-success": "bool",
-                "message": "string",
-                "rejected": "bool",
-                "result": "*model.GradingInfo"
-            }
+            "input": [
+                {
+                    "field-name": "assignment-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "proxy-email",
+                    "field-type": "core.TargetCourseUser"
+                },
+                {
+                    "field-name": "proxy-time",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "target-submission",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "found-submission",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "found-user",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "grading-success",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "message",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "rejected",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "result",
+                    "field-type": "*model.GradingInfo"
+                }
+            ]
         },
         "courses/assignments/submissions/proxy/submit": {
             "description": "Proxy submit an assignment submission to the autograder.",
-            "input": {
-                "assignment-id": "string",
-                "course-id": "string",
-                "message": "string",
-                "proxy-email": "core.TargetCourseUser",
-                "proxy-time": "int64",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "found-user": "bool",
-                "grading-success": "bool",
-                "message": "string",
-                "rejected": "bool",
-                "result": "*model.GradingInfo"
-            }
+            "input": [
+                {
+                    "field-name": "assignment-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "message",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "proxy-email",
+                    "field-type": "core.TargetCourseUser"
+                },
+                {
+                    "field-name": "proxy-time",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "found-user",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "grading-success",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "message",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "rejected",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "result",
+                    "field-type": "*model.GradingInfo"
+                }
+            ]
         },
         "courses/assignments/submissions/remove": {
             "description": "Remove a specified submission. Defaults to the most recent submission.",
-            "input": {
-                "assignment-id": "string",
-                "course-id": "string",
-                "target-email": "core.TargetCourseUserSelfOrGrader",
-                "target-submission": "string",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "found-submission": "bool",
-                "found-user": "bool"
-            }
+            "input": [
+                {
+                    "field-name": "assignment-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "target-email",
+                    "field-type": "core.TargetCourseUserSelfOrGrader"
+                },
+                {
+                    "field-name": "target-submission",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "found-submission",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "found-user",
+                    "field-type": "bool"
+                }
+            ]
         },
         "courses/assignments/submissions/submit": {
             "description": "Submit an assignment submission to the autograder.",
-            "input": {
-                "allow-late": "bool",
-                "assignment-id": "string",
-                "course-id": "string",
-                "message": "string",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "grading-success": "bool",
-                "message": "string",
-                "rejected": "bool",
-                "result": "*model.GradingInfo"
-            }
+            "input": [
+                {
+                    "field-name": "allow-late",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "assignment-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "message",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "grading-success",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "message",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "rejected",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "result",
+                    "field-type": "*model.GradingInfo"
+                }
+            ]
         },
         "courses/lms/scores/upload": {
             "description": "Perform a full scoring and upload scores to the course's LMS.",
-            "input": {
-                "course-id": "string",
-                "dry-run": "bool",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "dry-run": "bool",
-                "results": "[]*model.ExternalScoringInfo"
-            }
+            "input": [
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "dry-run",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "dry-run",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "results",
+                    "field-type": "[]*model.ExternalScoringInfo"
+                }
+            ]
         },
         "courses/stats/query": {
             "description": "Query metrics for a specific course.\nOnly the context course can be queried for, the target-course field will be ignored for this endpoint.",
-            "input": {
-                "after": "int64",
-                "before": "int64",
-                "course-id": "string",
-                "limit": "int",
-                "sort": "int",
-                "type": "string",
-                "user-email": "string",
-                "user-pass": "string",
-                "where": "map[stats.MetricAttribute]interface {}"
-            },
-            "output": {
-                "results": "[]*stats.Metric"
-            }
+            "input": [
+                {
+                    "field-name": "after",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "before",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "limit",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "sort",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "type",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "where",
+                    "field-type": "map[stats.MetricAttribute]interface {}"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "results",
+                    "field-type": "[]*stats.Metric"
+                }
+            ]
         },
         "courses/upsert/filespec": {
             "description": "Upsert a course using a filespec.",
-            "input": {
-                "dry-run": "bool",
-                "filespec": "util.FileSpec",
-                "skip-build-images": "bool",
-                "skip-emails": "bool",
-                "skip-lms-sync": "bool",
-                "skip-source-sync": "bool",
-                "skip-template-files": "bool",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "results": "[]courses.CourseUpsertResult"
-            }
+            "input": [
+                {
+                    "field-name": "dry-run",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "filespec",
+                    "field-type": "util.FileSpec"
+                },
+                {
+                    "field-name": "skip-build-images",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-emails",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-lms-sync",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-source-sync",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-template-files",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "results",
+                    "field-type": "[]courses.CourseUpsertResult"
+                }
+            ]
         },
         "courses/upsert/zip": {
             "description": "Upsert a course using a zip file.",
-            "input": {
-                "dry-run": "bool",
-                "skip-build-images": "bool",
-                "skip-emails": "bool",
-                "skip-lms-sync": "bool",
-                "skip-source-sync": "bool",
-                "skip-template-files": "bool",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "results": "[]courses.CourseUpsertResult"
-            }
+            "input": [
+                {
+                    "field-name": "dry-run",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-build-images",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-emails",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-lms-sync",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-source-sync",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-template-files",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "results",
+                    "field-type": "[]courses.CourseUpsertResult"
+                }
+            ]
         },
         "courses/users/drop": {
             "description": "Drop a user from the course.",
-            "input": {
-                "course-id": "string",
-                "target-email": "core.TargetCourseUser",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "found-user": "bool"
-            }
+            "input": [
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "target-email",
+                    "field-type": "core.TargetCourseUser"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "found-user",
+                    "field-type": "bool"
+                }
+            ]
         },
         "courses/users/enroll": {
             "description": "Enroll one or more users to the course.",
-            "input": {
-                "course-id": "string",
-                "dry-run": "bool",
-                "raw-course-users": "[]*model.RawCourseUserData",
-                "send-emails": "bool",
-                "skip-inserts": "bool",
-                "skip-updates": "bool",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "results": "[]*model.ExternalUserOpResult"
-            }
+            "input": [
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "dry-run",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "raw-course-users",
+                    "field-type": "[]*model.RawCourseUserData"
+                },
+                {
+                    "field-name": "send-emails",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-inserts",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-updates",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "results",
+                    "field-type": "[]*model.ExternalUserOpResult"
+                }
+            ]
         },
         "courses/users/get": {
             "description": "Get the information for a course user.",
-            "input": {
-                "course-id": "string",
-                "target-email": "core.TargetCourseUserSelfOrGrader",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "found": "bool",
-                "user": "*core.CourseUserInfo"
-            }
+            "input": [
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "target-email",
+                    "field-type": "core.TargetCourseUserSelfOrGrader"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "found",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "user",
+                    "field-type": "*core.CourseUserInfo"
+                }
+            ]
         },
         "courses/users/list": {
             "description": "List the users in the course.",
-            "input": {
-                "course-id": "string",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "users": "[]*core.CourseUserInfo"
-            }
+            "input": [
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "users",
+                    "field-type": "[]*core.CourseUserInfo"
+                }
+            ]
         },
         "lms/upload/scores": {
             "description": "Upload scores from a tab-separated file to the course's LMS.\nThe file should not have headers, and should have two columns: email and score.",
-            "input": {
-                "assignment-lms-id": "string",
-                "course-id": "string",
-                "scores": "[]upload.ScoreEntry",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "count": "int",
-                "error-count": "int",
-                "no-lms-id-users": "[]upload.RowEntry",
-                "unrecognized-users": "[]upload.RowEntry"
-            }
+            "input": [
+                {
+                    "field-name": "assignment-lms-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "scores",
+                    "field-type": "[]upload.ScoreEntry"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "count",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "error-count",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "no-lms-id-users",
+                    "field-type": "[]upload.RowEntry"
+                },
+                {
+                    "field-name": "unrecognized-users",
+                    "field-type": "[]upload.RowEntry"
+                }
+            ]
         },
         "lms/user/get": {
             "description": "Get information for an LMS user.",
-            "input": {
-                "course-id": "string",
-                "target-email": "core.TargetCourseUser",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "found-autograder-user": "bool",
-                "found-lms-user": "bool",
-                "user": "*core.CourseUserInfo"
-            }
+            "input": [
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "target-email",
+                    "field-type": "core.TargetCourseUser"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "found-autograder-user",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "found-lms-user",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "user",
+                    "field-type": "*core.CourseUserInfo"
+                }
+            ]
         },
         "logs/query": {
             "description": "Query log entries from the autograder server.",
-            "input": {
-                "after": "string",
-                "level": "string",
-                "past": "string",
-                "target-assignment": "string",
-                "target-course": "string",
-                "target-email": "string",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "error": "*model.ExternalLocatableError",
-                "results": "[]*log.Record",
-                "success": "bool"
-            }
+            "input": [
+                {
+                    "field-name": "after",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "level",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "past",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "target-assignment",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "target-course",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "target-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "error",
+                    "field-type": "*model.ExternalLocatableError"
+                },
+                {
+                    "field-name": "results",
+                    "field-type": "[]*log.Record"
+                },
+                {
+                    "field-name": "success",
+                    "field-type": "bool"
+                }
+            ]
         },
         "metadata/describe": {
             "description": "Describe all endpoints on the server.",
-            "input": {},
-            "output": {
-                "endpoints": "map[string]core.EndpointDescription",
-                "types": "map[string]core.TypeDescription"
-            }
+            "input": [],
+            "output": [
+                {
+                    "field-name": "endpoints",
+                    "field-type": "map[string]core.EndpointDescription"
+                },
+                {
+                    "field-name": "types",
+                    "field-type": "map[string]core.FullTypeDescription"
+                }
+            ]
         },
         "stats/query": {
             "description": "Query stats for the server.",
-            "input": {
-                "after": "int64",
-                "before": "int64",
-                "limit": "int",
-                "sort": "int",
-                "type": "string",
-                "user-email": "string",
-                "user-pass": "string",
-                "where": "map[stats.MetricAttribute]interface {}"
-            },
-            "output": {
-                "results": "[]*stats.Metric"
-            }
+            "input": [
+                {
+                    "field-name": "after",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "before",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "limit",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "sort",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "type",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "where",
+                    "field-type": "map[stats.MetricAttribute]interface {}"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "results",
+                    "field-type": "[]*stats.Metric"
+                }
+            ]
         },
         "system/stacks": {
             "description": "Get stack traces for all the currently running routines (threads) on the server.",
-            "input": {
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "count": "int",
-                "stacks": "[]*util.CallStack"
-            }
+            "input": [
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "count",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "stacks",
+                    "field-type": "[]*util.CallStack"
+                }
+            ]
         },
         "users/auth": {
             "description": "Authenticate as a user.",
-            "input": {
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "success": "bool"
-            }
+            "input": [
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "success",
+                    "field-type": "bool"
+                }
+            ]
         },
         "users/get": {
             "description": "Get the information for a server user.",
-            "input": {
-                "target-email": "core.TargetServerUserSelfOrAdmin",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "courses": "map[string]*core.CourseInfo",
-                "found": "bool",
-                "user": "*core.ServerUserInfo"
-            }
+            "input": [
+                {
+                    "field-name": "target-email",
+                    "field-type": "core.TargetServerUserSelfOrAdmin"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "courses",
+                    "field-type": "map[string]*core.CourseInfo"
+                },
+                {
+                    "field-name": "found",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "user",
+                    "field-type": "*core.ServerUserInfo"
+                }
+            ]
         },
         "users/list": {
             "description": "List the users on the server.",
-            "input": {
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "users": "[]*core.ServerUserInfo"
-            }
+            "input": [
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "users",
+                    "field-type": "[]*core.ServerUserInfo"
+                }
+            ]
         },
         "users/password/change": {
             "description": "Change your password to the one provided.",
-            "input": {
-                "new-pass": "string",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "duplicate": "bool",
-                "success": "bool"
-            }
+            "input": [
+                {
+                    "field-name": "new-pass",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "duplicate",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "success",
+                    "field-type": "bool"
+                }
+            ]
         },
         "users/password/reset": {
             "description": "Reset to a random password that will be emailed to you.",
-            "input": {
-                "user-email": "string"
-            },
-            "output": {}
+            "input": [
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                }
+            ],
+            "output": []
         },
         "users/remove": {
             "description": "Remove a user from the server.",
-            "input": {
-                "target-email": "core.TargetServerUser",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "found-user": "bool"
-            }
+            "input": [
+                {
+                    "field-name": "target-email",
+                    "field-type": "core.TargetServerUser"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "found-user",
+                    "field-type": "bool"
+                }
+            ]
         },
         "users/tokens/create": {
             "description": "Create a new authentication token.",
-            "input": {
-                "name": "string",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "token-cleartext": "string",
-                "token-id": "string"
-            }
+            "input": [
+                {
+                    "field-name": "name",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "token-cleartext",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "token-id",
+                    "field-type": "string"
+                }
+            ]
         },
         "users/tokens/delete": {
             "description": "Delete an authentication token.",
-            "input": {
-                "token-id": "string",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "found": "bool"
-            }
+            "input": [
+                {
+                    "field-name": "token-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "found",
+                    "field-type": "bool"
+                }
+            ]
         },
         "users/upsert": {
             "description": "Upsert one or more users to the server (update if exists, insert otherwise).",
-            "input": {
-                "dry-run": "bool",
-                "raw-users": "[]*model.RawServerUserData",
-                "send-emails": "bool",
-                "skip-inserts": "bool",
-                "skip-updates": "bool",
-                "user-email": "string",
-                "user-pass": "string"
-            },
-            "output": {
-                "results": "[]*model.ExternalUserOpResult"
-            }
+            "input": [
+                {
+                    "field-name": "dry-run",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "raw-users",
+                    "field-type": "[]*model.RawServerUserData"
+                },
+                {
+                    "field-name": "send-emails",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-inserts",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-updates",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ],
+            "output": [
+                {
+                    "field-name": "results",
+                    "field-type": "[]*model.ExternalUserOpResult"
+                }
+            ]
         }
     },
     "types": {
         "analysis.AnalysisOptions": {
             "category": "struct",
-            "fields": {
-                "dry-run": "bool",
-                "overwrite-cache": "bool",
-                "submissions": "[]string",
-                "wait-for-completion": "bool"
-            }
+            "fields": [
+                {
+                    "field-name": "dry-run",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "overwrite-cache",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "submissions",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "wait-for-completion",
+                    "field-type": "bool"
+                }
+            ]
         },
         "core.APIDescription": {
             "category": "struct",
-            "fields": {
-                "endpoints": "map[string]core.EndpointDescription",
-                "types": "map[string]core.TypeDescription"
-            }
+            "fields": [
+                {
+                    "field-name": "endpoints",
+                    "field-type": "map[string]core.EndpointDescription"
+                },
+                {
+                    "field-name": "types",
+                    "field-type": "map[string]core.FullTypeDescription"
+                }
+            ]
         },
         "core.APIRequestAssignmentContext": {
             "category": "struct",
-            "fields": {
-                "assignment-id": "string",
-                "course-id": "string",
-                "user-email": "string",
-                "user-pass": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "assignment-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ]
         },
         "core.APIRequestCourseUserContext": {
             "category": "struct",
-            "fields": {
-                "course-id": "string",
-                "user-email": "string",
-                "user-pass": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ]
         },
         "core.APIRequestUserContext": {
             "category": "struct",
-            "fields": {
-                "user-email": "string",
-                "user-pass": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user-pass",
+                    "field-type": "string"
+                }
+            ]
         },
         "core.AssignmentInfo": {
             "category": "struct",
-            "fields": {
-                "due-date": "int64",
-                "id": "string",
-                "max-points": "float64",
-                "name": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "due-date",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "max-points",
+                    "field-type": "float64"
+                },
+                {
+                    "field-name": "name",
+                    "field-type": "string"
+                }
+            ]
         },
         "core.BaseSubmitResponse": {
             "category": "struct",
-            "fields": {
-                "grading-success": "bool",
-                "message": "string",
-                "rejected": "bool",
-                "result": "*model.GradingInfo"
-            }
+            "fields": [
+                {
+                    "field-name": "grading-success",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "message",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "rejected",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "result",
+                    "field-type": "*model.GradingInfo"
+                }
+            ]
         },
         "core.BaseUserInfo": {
             "category": "struct",
-            "fields": {
-                "email": "string",
-                "name": "string",
-                "type": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "name",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "type",
+                    "field-type": "string"
+                }
+            ]
         },
         "core.CourseInfo": {
             "category": "struct",
-            "fields": {
-                "assignments": "map[string]*core.AssignmentInfo",
-                "id": "string",
-                "name": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "assignments",
+                    "field-type": "map[string]*core.AssignmentInfo"
+                },
+                {
+                    "field-name": "id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "name",
+                    "field-type": "string"
+                }
+            ]
         },
         "core.CourseUserInfo": {
             "category": "struct",
-            "fields": {
-                "email": "string",
-                "lms-id": "string",
-                "name": "string",
-                "role": "int",
-                "type": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "lms-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "name",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "role",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "type",
+                    "field-type": "string"
+                }
+            ]
         },
         "core.EndpointDescription": {
             "category": "struct",
-            "fields": {
-                "description": "string",
-                "input": "map[string]string",
-                "output": "map[string]string"
-            }
+            "fields": [
+                {
+                    "field-name": "description",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "input",
+                    "field-type": "[]core.TypeDescription"
+                },
+                {
+                    "field-name": "output",
+                    "field-type": "[]core.TypeDescription"
+                }
+            ]
         },
         "core.EnrollmentInfo": {
             "category": "struct",
-            "fields": {
-                "id": "string",
-                "role": "int"
-            }
+            "fields": [
+                {
+                    "field-name": "id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "role",
+                    "field-type": "int"
+                }
+            ]
+        },
+        "core.FullTypeDescription": {
+            "category": "struct",
+            "fields": [
+                {
+                    "field-name": "alias-type",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "category",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "element-type",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "fields",
+                    "field-type": "[]core.TypeDescription"
+                }
+            ]
         },
         "core.NonEmptyString": {
             "alias-type": "string",
@@ -651,40 +1608,65 @@
         },
         "core.ServerUserInfo": {
             "category": "struct",
-            "fields": {
-                "courses": "map[string]core.EnrollmentInfo",
-                "email": "string",
-                "name": "string",
-                "role": "int",
-                "type": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "courses",
+                    "field-type": "map[string]core.EnrollmentInfo"
+                },
+                {
+                    "field-name": "email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "name",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "role",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "type",
+                    "field-type": "string"
+                }
+            ]
         },
         "core.TargetCourseUser": {
             "category": "struct"
         },
         "core.TargetCourseUserSelfOrGrader": {
             "category": "struct",
-            "fields": {
-                "TargetCourseUser": "core.TargetCourseUser"
-            }
+            "fields": [
+                {
+                    "field-name": "TargetCourseUser",
+                    "field-type": "core.TargetCourseUser"
+                }
+            ]
         },
         "core.TargetServerUser": {
             "category": "struct"
         },
         "core.TargetServerUserSelfOrAdmin": {
             "category": "struct",
-            "fields": {
-                "TargetServerUser": "core.TargetServerUser"
-            }
+            "fields": [
+                {
+                    "field-name": "TargetServerUser",
+                    "field-type": "core.TargetServerUser"
+                }
+            ]
         },
         "core.TypeDescription": {
             "category": "struct",
-            "fields": {
-                "alias-type": "string",
-                "category": "string",
-                "element-type": "string",
-                "fields": "map[string]string"
-            }
+            "fields": [
+                {
+                    "field-name": "field-name",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "field-type",
+                    "field-type": "string"
+                }
+            ]
         },
         "core.UserInfoType": {
             "alias-type": "string",
@@ -692,49 +1674,127 @@
         },
         "courses.CourseUpsertOptions": {
             "category": "struct",
-            "fields": {
-                "dry-run": "bool",
-                "skip-build-images": "bool",
-                "skip-emails": "bool",
-                "skip-lms-sync": "bool",
-                "skip-source-sync": "bool",
-                "skip-template-files": "bool"
-            }
+            "fields": [
+                {
+                    "field-name": "dry-run",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-build-images",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-emails",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-lms-sync",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-source-sync",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-template-files",
+                    "field-type": "bool"
+                }
+            ]
         },
         "courses.CourseUpsertPublicOptions": {
             "category": "struct",
-            "fields": {
-                "dry-run": "bool",
-                "skip-build-images": "bool",
-                "skip-emails": "bool",
-                "skip-lms-sync": "bool",
-                "skip-source-sync": "bool",
-                "skip-template-files": "bool"
-            }
+            "fields": [
+                {
+                    "field-name": "dry-run",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-build-images",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-emails",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-lms-sync",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-source-sync",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-template-files",
+                    "field-type": "bool"
+                }
+            ]
         },
         "courses.CourseUpsertResult": {
             "category": "struct",
-            "fields": {
-                "assignment-template-files": "map[string][]string",
-                "built-assignment-images": "[]string",
-                "course-id": "string",
-                "created": "bool",
-                "lms-sync-result": "*model.LMSSyncResult",
-                "message": "string",
-                "success": "bool",
-                "updated": "bool"
-            }
+            "fields": [
+                {
+                    "field-name": "assignment-template-files",
+                    "field-type": "map[string][]string"
+                },
+                {
+                    "field-name": "built-assignment-images",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "created",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "lms-sync-result",
+                    "field-type": "*model.LMSSyncResult"
+                },
+                {
+                    "field-name": "message",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "success",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "updated",
+                    "field-type": "bool"
+                }
+            ]
         },
         "email.Message": {
             "category": "struct",
-            "fields": {
-                "bcc": "[]string",
-                "body": "string",
-                "cc": "[]string",
-                "html": "bool",
-                "subject": "string",
-                "to": "[]string"
-            }
+            "fields": [
+                {
+                    "field-name": "bcc",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "body",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "cc",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "html",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "subject",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "to",
+                    "field-type": "[]string"
+                }
+            ]
         },
         "log.LogLevel": {
             "alias-type": "int32",
@@ -742,87 +1802,219 @@
         },
         "log.RawLogQuery": {
             "category": "struct",
-            "fields": {
-                "after": "string",
-                "level": "string",
-                "past": "string",
-                "target-assignment": "string",
-                "target-course": "string",
-                "target-email": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "after",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "level",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "past",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "target-assignment",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "target-course",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "target-email",
+                    "field-type": "string"
+                }
+            ]
         },
         "log.Record": {
             "category": "struct",
-            "fields": {
-                "assignment": "string",
-                "attributes": "map[string]interface {}",
-                "course": "string",
-                "error": "string",
-                "level": "int32",
-                "message": "string",
-                "timestamp": "int64",
-                "user": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "assignment",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "attributes",
+                    "field-type": "map[string]interface {}"
+                },
+                {
+                    "field-name": "course",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "error",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "level",
+                    "field-type": "int32"
+                },
+                {
+                    "field-name": "message",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "timestamp",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "user",
+                    "field-type": "string"
+                }
+            ]
         },
         "model.AnalysisFileInfo": {
             "category": "struct",
-            "fields": {
-                "filename": "string",
-                "lines-of-code": "int",
-                "original-filename": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "filename",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "lines-of-code",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "original-filename",
+                    "field-type": "string"
+                }
+            ]
         },
         "model.AnalysisSummary": {
             "category": "struct",
-            "fields": {
-                "complete": "bool",
-                "complete-count": "int",
-                "failure-count": "int",
-                "first-timestamp": "int64",
-                "last-timestamp": "int64",
-                "pending-count": "int"
-            }
+            "fields": [
+                {
+                    "field-name": "complete",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "complete-count",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "failure-count",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "first-timestamp",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "last-timestamp",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "pending-count",
+                    "field-type": "int"
+                }
+            ]
         },
         "model.AssignmentAnalysisOptions": {
             "category": "struct",
-            "fields": {
-                "exclude-patterns": "[]string",
-                "include-patterns": "[]string",
-                "template-file-ops": "[]*util.FileOperation",
-                "template-files": "[]*util.FileSpec"
-            }
+            "fields": [
+                {
+                    "field-name": "exclude-patterns",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "include-patterns",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "template-file-ops",
+                    "field-type": "[]*util.FileOperation"
+                },
+                {
+                    "field-name": "template-files",
+                    "field-type": "[]*util.FileSpec"
+                }
+            ]
         },
         "model.AssignmentInfo": {
             "category": "struct",
-            "fields": {
-                "id": "string",
-                "late-days-lms-id": "string",
-                "late-days-lms-name": "string",
-                "name": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "late-days-lms-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "late-days-lms-name",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "name",
+                    "field-type": "string"
+                }
+            ]
         },
         "model.AssignmentSyncResult": {
             "category": "struct",
-            "fields": {
-                "ambiguous-matches": "[]model.AssignmentInfo",
-                "non-matched-assignments": "[]model.AssignmentInfo",
-                "synced-assignments": "[]model.AssignmentInfo",
-                "unchanged-assignments": "[]model.AssignmentInfo"
-            }
+            "fields": [
+                {
+                    "field-name": "ambiguous-matches",
+                    "field-type": "[]model.AssignmentInfo"
+                },
+                {
+                    "field-name": "non-matched-assignments",
+                    "field-type": "[]model.AssignmentInfo"
+                },
+                {
+                    "field-name": "synced-assignments",
+                    "field-type": "[]model.AssignmentInfo"
+                },
+                {
+                    "field-name": "unchanged-assignments",
+                    "field-type": "[]model.AssignmentInfo"
+                }
+            ]
         },
         "model.BaseUserOpResult": {
             "category": "struct",
-            "fields": {
-                "added": "bool",
-                "dropped": "[]string",
-                "email": "string",
-                "emailed": "bool",
-                "enrolled": "[]string",
-                "modified": "bool",
-                "not-exists": "bool",
-                "removed": "bool",
-                "skipped": "bool"
-            }
+            "fields": [
+                {
+                    "field-name": "added",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "dropped",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "emailed",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "enrolled",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "modified",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "not-exists",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "removed",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skipped",
+                    "field-type": "bool"
+                }
+            ]
         },
         "model.CourseUserRole": {
             "alias-type": "int",
@@ -830,177 +2022,510 @@
         },
         "model.ExternalLocatableError": {
             "category": "struct",
-            "fields": {
-                "locator": "string",
-                "message": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "locator",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "message",
+                    "field-type": "string"
+                }
+            ]
         },
         "model.ExternalScoringInfo": {
             "category": "struct",
-            "fields": {
-                "assignment": "string",
-                "raw-score": "float64",
-                "score": "float64",
-                "submission-id": "string",
-                "submission-time": "int64",
-                "upload-time": "int64",
-                "user": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "assignment",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "raw-score",
+                    "field-type": "float64"
+                },
+                {
+                    "field-name": "score",
+                    "field-type": "float64"
+                },
+                {
+                    "field-name": "submission-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "submission-time",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "upload-time",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "user",
+                    "field-type": "string"
+                }
+            ]
         },
         "model.ExternalUserOpResult": {
             "category": "struct",
-            "fields": {
-                "added": "bool",
-                "communication-error": "*model.ExternalLocatableError",
-                "dropped": "[]string",
-                "email": "string",
-                "emailed": "bool",
-                "enrolled": "[]string",
-                "modified": "bool",
-                "not-exists": "bool",
-                "removed": "bool",
-                "skipped": "bool",
-                "system-error": "*model.ExternalLocatableError",
-                "validation-error": "*model.ExternalLocatableError"
-            }
+            "fields": [
+                {
+                    "field-name": "added",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "communication-error",
+                    "field-type": "*model.ExternalLocatableError"
+                },
+                {
+                    "field-name": "dropped",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "emailed",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "enrolled",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "modified",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "not-exists",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "removed",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skipped",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "system-error",
+                    "field-type": "*model.ExternalLocatableError"
+                },
+                {
+                    "field-name": "validation-error",
+                    "field-type": "*model.ExternalLocatableError"
+                }
+            ]
         },
         "model.FileSimilarity": {
             "category": "struct",
-            "fields": {
-                "filename": "string",
-                "options": "map[string]interface {}",
-                "original-filename": "string",
-                "score": "float64",
-                "tool": "string",
-                "version": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "filename",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "options",
+                    "field-type": "map[string]interface {}"
+                },
+                {
+                    "field-name": "original-filename",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "score",
+                    "field-type": "float64"
+                },
+                {
+                    "field-name": "tool",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "version",
+                    "field-type": "string"
+                }
+            ]
         },
         "model.GradedQuestion": {
             "category": "struct",
-            "fields": {
-                "grading_end_time": "int64",
-                "grading_start_time": "int64",
-                "hard_fail": "bool",
-                "max_points": "float64",
-                "message": "string",
-                "name": "string",
-                "score": "float64",
-                "skipped": "bool"
-            }
+            "fields": [
+                {
+                    "field-name": "grading_end_time",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "grading_start_time",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "hard_fail",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "max_points",
+                    "field-type": "float64"
+                },
+                {
+                    "field-name": "message",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "name",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "score",
+                    "field-type": "float64"
+                },
+                {
+                    "field-name": "skipped",
+                    "field-type": "bool"
+                }
+            ]
         },
         "model.GradingInfo": {
             "category": "struct",
-            "fields": {
-                "additional-info": "map[string]interface {}",
-                "assignment-id": "string",
-                "course-id": "string",
-                "epilogue": "string",
-                "grading_end_time": "int64",
-                "grading_start_time": "int64",
-                "id": "string",
-                "max_points": "float64",
-                "message": "string",
-                "name": "string",
-                "prologue": "string",
-                "proxy-user": "string",
-                "proxy_end_time": "int64",
-                "proxy_start_time": "int64",
-                "questions": "[]*model.GradedQuestion",
-                "score": "float64",
-                "short-id": "string",
-                "user": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "additional-info",
+                    "field-type": "map[string]interface {}"
+                },
+                {
+                    "field-name": "assignment-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "epilogue",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "grading_end_time",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "grading_start_time",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "max_points",
+                    "field-type": "float64"
+                },
+                {
+                    "field-name": "message",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "name",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "prologue",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "proxy-user",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "proxy_end_time",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "proxy_start_time",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "questions",
+                    "field-type": "[]*model.GradedQuestion"
+                },
+                {
+                    "field-name": "score",
+                    "field-type": "float64"
+                },
+                {
+                    "field-name": "short-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user",
+                    "field-type": "string"
+                }
+            ]
         },
         "model.GradingResult": {
             "category": "struct",
-            "fields": {
-                "info": "*model.GradingInfo",
-                "input-files-gzip": "map[string][]uint8",
-                "output-files-gzip": "map[string][]uint8",
-                "stderr": "string",
-                "stdout": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "info",
+                    "field-type": "*model.GradingInfo"
+                },
+                {
+                    "field-name": "input-files-gzip",
+                    "field-type": "map[string][]uint8"
+                },
+                {
+                    "field-name": "output-files-gzip",
+                    "field-type": "map[string][]uint8"
+                },
+                {
+                    "field-name": "stderr",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "stdout",
+                    "field-type": "string"
+                }
+            ]
         },
         "model.IndividualAnalysis": {
             "category": "struct",
-            "fields": {
-                "analysis-timestamp": "int64",
-                "assignment-id": "string",
-                "course-id": "string",
-                "failure": "bool",
-                "failure-message": "string",
-                "files": "[]model.AnalysisFileInfo",
-                "lines-of-code": "int",
-                "lines-of-code-delta": "int",
-                "lines-of-code-per-hour": "float64",
-                "options": "*model.AssignmentAnalysisOptions",
-                "score": "float64",
-                "score-delta": "float64",
-                "score-per-hour": "float64",
-                "short-id": "string",
-                "skipped-files": "[]string",
-                "submission-id": "string",
-                "submission-start-time": "int64",
-                "submission-time-delta": "int64",
-                "user-email": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "analysis-timestamp",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "assignment-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "failure",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "failure-message",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "files",
+                    "field-type": "[]model.AnalysisFileInfo"
+                },
+                {
+                    "field-name": "lines-of-code",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "lines-of-code-delta",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "lines-of-code-per-hour",
+                    "field-type": "float64"
+                },
+                {
+                    "field-name": "options",
+                    "field-type": "*model.AssignmentAnalysisOptions"
+                },
+                {
+                    "field-name": "score",
+                    "field-type": "float64"
+                },
+                {
+                    "field-name": "score-delta",
+                    "field-type": "float64"
+                },
+                {
+                    "field-name": "score-per-hour",
+                    "field-type": "float64"
+                },
+                {
+                    "field-name": "short-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "skipped-files",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "submission-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "submission-start-time",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "submission-time-delta",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "user-email",
+                    "field-type": "string"
+                }
+            ]
         },
         "model.IndividualAnalysisSummary": {
             "category": "struct",
-            "fields": {
-                "aggregate-lines-of-code": "util.AggregateValues",
-                "aggregate-lines-of-code-delta": "util.AggregateValues",
-                "aggregate-lines-of-code-per-file": "map[string]util.AggregateValues",
-                "aggregate-lines-of-code-per-hour": "util.AggregateValues",
-                "aggregate-score": "util.AggregateValues",
-                "aggregate-score-delta": "util.AggregateValues",
-                "aggregate-score-per-hour": "util.AggregateValues",
-                "aggregate-submission-time-delta": "util.AggregateValues",
-                "complete": "bool",
-                "complete-count": "int",
-                "failure-count": "int",
-                "first-timestamp": "int64",
-                "last-timestamp": "int64",
-                "pending-count": "int"
-            }
+            "fields": [
+                {
+                    "field-name": "aggregate-lines-of-code",
+                    "field-type": "util.AggregateValues"
+                },
+                {
+                    "field-name": "aggregate-lines-of-code-delta",
+                    "field-type": "util.AggregateValues"
+                },
+                {
+                    "field-name": "aggregate-lines-of-code-per-file",
+                    "field-type": "map[string]util.AggregateValues"
+                },
+                {
+                    "field-name": "aggregate-lines-of-code-per-hour",
+                    "field-type": "util.AggregateValues"
+                },
+                {
+                    "field-name": "aggregate-score",
+                    "field-type": "util.AggregateValues"
+                },
+                {
+                    "field-name": "aggregate-score-delta",
+                    "field-type": "util.AggregateValues"
+                },
+                {
+                    "field-name": "aggregate-score-per-hour",
+                    "field-type": "util.AggregateValues"
+                },
+                {
+                    "field-name": "aggregate-submission-time-delta",
+                    "field-type": "util.AggregateValues"
+                },
+                {
+                    "field-name": "complete",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "complete-count",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "failure-count",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "first-timestamp",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "last-timestamp",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "pending-count",
+                    "field-type": "int"
+                }
+            ]
         },
         "model.LMSSyncResult": {
             "category": "struct",
-            "fields": {
-                "assignment-sync": "*model.AssignmentSyncResult",
-                "user-sync": "[]*model.UserOpResult"
-            }
+            "fields": [
+                {
+                    "field-name": "assignment-sync",
+                    "field-type": "*model.AssignmentSyncResult"
+                },
+                {
+                    "field-name": "user-sync",
+                    "field-type": "[]*model.UserOpResult"
+                }
+            ]
         },
         "model.LocatableError": {
             "category": "struct"
         },
         "model.PairwiseAnalysis": {
             "category": "struct",
-            "fields": {
-                "analysis-timestamp": "int64",
-                "failure": "bool",
-                "failure-message": "string",
-                "mean-similarities": "map[string]float64",
-                "options": "*model.AssignmentAnalysisOptions",
-                "similarities": "map[string][]*model.FileSimilarity",
-                "skipped-files": "[]string",
-                "submission-ids": "model.PairwiseKey",
-                "total-mean-similarity": "float64",
-                "unmatched-files": "[][]string"
-            }
+            "fields": [
+                {
+                    "field-name": "analysis-timestamp",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "failure",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "failure-message",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "mean-similarities",
+                    "field-type": "map[string]float64"
+                },
+                {
+                    "field-name": "options",
+                    "field-type": "*model.AssignmentAnalysisOptions"
+                },
+                {
+                    "field-name": "similarities",
+                    "field-type": "map[string][]*model.FileSimilarity"
+                },
+                {
+                    "field-name": "skipped-files",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "submission-ids",
+                    "field-type": "model.PairwiseKey"
+                },
+                {
+                    "field-name": "total-mean-similarity",
+                    "field-type": "float64"
+                },
+                {
+                    "field-name": "unmatched-files",
+                    "field-type": "[][]string"
+                }
+            ]
         },
         "model.PairwiseAnalysisSummary": {
             "category": "struct",
-            "fields": {
-                "aggregate-mean-similarities": "map[string]util.AggregateValues",
-                "aggregate-total-mean-similarity": "util.AggregateValues",
-                "complete": "bool",
-                "complete-count": "int",
-                "failure-count": "int",
-                "first-timestamp": "int64",
-                "last-timestamp": "int64",
-                "pending-count": "int"
-            }
+            "fields": [
+                {
+                    "field-name": "aggregate-mean-similarities",
+                    "field-type": "map[string]util.AggregateValues"
+                },
+                {
+                    "field-name": "aggregate-total-mean-similarity",
+                    "field-type": "util.AggregateValues"
+                },
+                {
+                    "field-name": "complete",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "complete-count",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "failure-count",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "first-timestamp",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "last-timestamp",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "pending-count",
+                    "field-type": "int"
+                }
+            ]
         },
         "model.PairwiseKey": {
             "category": "array",
@@ -1008,24 +2533,57 @@
         },
         "model.RawCourseUserData": {
             "category": "struct",
-            "fields": {
-                "course-lms-id": "string",
-                "course-role": "string",
-                "email": "string",
-                "name": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "course-lms-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-role",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "name",
+                    "field-type": "string"
+                }
+            ]
         },
         "model.RawServerUserData": {
             "category": "struct",
-            "fields": {
-                "course": "string",
-                "course-lms-id": "string",
-                "course-role": "string",
-                "email": "string",
-                "name": "string",
-                "pass": "string",
-                "role": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "course",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-lms-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-role",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "name",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "pass",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "role",
+                    "field-type": "string"
+                }
+            ]
         },
         "model.ServerUserRole": {
             "alias-type": "int",
@@ -1033,44 +2591,122 @@
         },
         "model.SubmissionHistoryItem": {
             "category": "struct",
-            "fields": {
-                "assignment-id": "string",
-                "course-id": "string",
-                "grading_start_time": "int64",
-                "id": "string",
-                "max_points": "float64",
-                "message": "string",
-                "score": "float64",
-                "short-id": "string",
-                "user": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "assignment-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "course-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "grading_start_time",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "max_points",
+                    "field-type": "float64"
+                },
+                {
+                    "field-name": "message",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "score",
+                    "field-type": "float64"
+                },
+                {
+                    "field-name": "short-id",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "user",
+                    "field-type": "string"
+                }
+            ]
         },
         "model.UserOpResult": {
             "category": "struct",
-            "fields": {
-                "added": "bool",
-                "cleartext-password": "string",
-                "communication-error": "*model.LocatableError",
-                "dropped": "[]string",
-                "email": "string",
-                "emailed": "bool",
-                "enrolled": "[]string",
-                "modified": "bool",
-                "not-exists": "bool",
-                "removed": "bool",
-                "skipped": "bool",
-                "system-error": "*model.LocatableError",
-                "validation-error": "*model.LocatableError"
-            }
+            "fields": [
+                {
+                    "field-name": "added",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "cleartext-password",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "communication-error",
+                    "field-type": "*model.LocatableError"
+                },
+                {
+                    "field-name": "dropped",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "emailed",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "enrolled",
+                    "field-type": "[]string"
+                },
+                {
+                    "field-name": "modified",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "not-exists",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "removed",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skipped",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "system-error",
+                    "field-type": "*model.LocatableError"
+                },
+                {
+                    "field-name": "validation-error",
+                    "field-type": "*model.LocatableError"
+                }
+            ]
         },
         "stats.Metric": {
             "category": "struct",
-            "fields": {
-                "attributes": "map[stats.MetricAttribute]interface {}",
-                "timestamp": "int64",
-                "type": "string",
-                "value": "float64"
-            }
+            "fields": [
+                {
+                    "field-name": "attributes",
+                    "field-type": "map[stats.MetricAttribute]interface {}"
+                },
+                {
+                    "field-name": "timestamp",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "type",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "value",
+                    "field-type": "float64"
+                }
+            ]
         },
         "stats.MetricAttribute": {
             "alias-type": "string",
@@ -1082,14 +2718,32 @@
         },
         "stats.Query": {
             "category": "struct",
-            "fields": {
-                "after": "int64",
-                "before": "int64",
-                "limit": "int",
-                "sort": "int",
-                "type": "string",
-                "where": "map[stats.MetricAttribute]interface {}"
-            }
+            "fields": [
+                {
+                    "field-name": "after",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "before",
+                    "field-type": "int64"
+                },
+                {
+                    "field-name": "limit",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "sort",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "type",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "where",
+                    "field-type": "map[stats.MetricAttribute]interface {}"
+                }
+            ]
         },
         "timestamp.Timestamp": {
             "alias-type": "int64",
@@ -1097,54 +2751,117 @@
         },
         "upload.RowEntry": {
             "category": "struct",
-            "fields": {
-                "entry": "interface {}",
-                "row": "int"
-            }
+            "fields": [
+                {
+                    "field-name": "entry",
+                    "field-type": "interface {}"
+                },
+                {
+                    "field-name": "row",
+                    "field-type": "int"
+                }
+            ]
         },
         "upload.ScoreEntry": {
             "category": "struct",
-            "fields": {
-                "email": "string",
-                "score": "float64"
-            }
+            "fields": [
+                {
+                    "field-name": "email",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "score",
+                    "field-type": "float64"
+                }
+            ]
         },
         "users.UpsertUsersOptions": {
             "category": "struct",
-            "fields": {
-                "dry-run": "bool",
-                "raw-users": "[]*model.RawServerUserData",
-                "send-emails": "bool",
-                "skip-inserts": "bool",
-                "skip-updates": "bool"
-            }
+            "fields": [
+                {
+                    "field-name": "dry-run",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "raw-users",
+                    "field-type": "[]*model.RawServerUserData"
+                },
+                {
+                    "field-name": "send-emails",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-inserts",
+                    "field-type": "bool"
+                },
+                {
+                    "field-name": "skip-updates",
+                    "field-type": "bool"
+                }
+            ]
         },
         "util.AggregateValues": {
             "category": "struct",
-            "fields": {
-                "count": "int",
-                "max": "float64",
-                "mean": "float64",
-                "median": "float64",
-                "min": "float64"
-            }
+            "fields": [
+                {
+                    "field-name": "count",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "max",
+                    "field-type": "float64"
+                },
+                {
+                    "field-name": "mean",
+                    "field-type": "float64"
+                },
+                {
+                    "field-name": "median",
+                    "field-type": "float64"
+                },
+                {
+                    "field-name": "min",
+                    "field-type": "float64"
+                }
+            ]
         },
         "util.CallStack": {
             "category": "struct",
-            "fields": {
-                "name": "string",
-                "records": "[]util.CallStackRecord",
-                "status": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "name",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "records",
+                    "field-type": "[]util.CallStackRecord"
+                },
+                {
+                    "field-name": "status",
+                    "field-type": "string"
+                }
+            ]
         },
         "util.CallStackRecord": {
             "category": "struct",
-            "fields": {
-                "call": "string",
-                "file": "string",
-                "line": "int",
-                "pointer": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "call",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "file",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "line",
+                    "field-type": "int"
+                },
+                {
+                    "field-name": "pointer",
+                    "field-type": "string"
+                }
+            ]
         },
         "util.FileOperation": {
             "category": "array",
@@ -1152,14 +2869,32 @@
         },
         "util.FileSpec": {
             "category": "struct",
-            "fields": {
-                "dest": "string",
-                "path": "string",
-                "reference": "string",
-                "token": "string",
-                "type": "string",
-                "username": "string"
-            }
+            "fields": [
+                {
+                    "field-name": "dest",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "path",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "reference",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "token",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "type",
+                    "field-type": "string"
+                },
+                {
+                    "field-name": "username",
+                    "field-type": "string"
+                }
+            ]
         },
         "util.FileSpecType": {
             "alias-type": "string",


### PR DESCRIPTION
This PR adds descriptions of structs to the API type descriptions.

When given a `reflect.Type`, describe can parse the comment off of the type declaration in the source code. This way, we can automatically add custom descriptions to types in the API description's type map.

As not all types that appear in the type map have comments, many still do not have a description.

This PR also improves the structure of the description of struct fields in preparation to include field descriptions, required fields, default field values, etc. 