### PR TITLE
Created jobmanager package to abstract some infrastructure from analysis.

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -14,7 +14,7 @@ All these packages (except cmd) live in `internal`.
  3. util
  4. config
  5. lockmanager
- 6. common, systemserver, stats
+ 6. common, systemserver, stats, jobmanager
  7. email
  8. docker
  9. model

--- a/internal/analysis/common.go
+++ b/internal/analysis/common.go
@@ -16,7 +16,10 @@ import (
 )
 
 type AnalysisOptions struct {
-	JobOptions *jobmanager.JobOptions `json:"job-options"`
+	jobmanager.JobOptions
+
+	// Don't save anything.
+	DryRun bool `json:"dry-run"`
 
 	// The raw submission specifications to analyze.
 	RawSubmissionSpecs []string `json:"submissions"`

--- a/internal/analysis/common.go
+++ b/internal/analysis/common.go
@@ -1,13 +1,13 @@
 package analysis
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
 
 	"github.com/edulinq/autograder/internal/common"
 	"github.com/edulinq/autograder/internal/db"
+	"github.com/edulinq/autograder/internal/jobmanager"
 	"github.com/edulinq/autograder/internal/log"
 	"github.com/edulinq/autograder/internal/model"
 	"github.com/edulinq/autograder/internal/stats"
@@ -16,30 +16,13 @@ import (
 )
 
 type AnalysisOptions struct {
-	// Don't save anything.
-	DryRun bool `json:"dry-run"`
-
-	// Replace any entries currently in the cache,
-	// and do not return any cached entries (when not waiting for completion).
-	OverwriteCache bool `json:"overwrite-cache"`
+	JobOptions *jobmanager.JobOptions `json:"job-options"`
 
 	// The raw submission specifications to analyze.
 	RawSubmissionSpecs []string `json:"submissions"`
 
-	// Wait for the entire analysis to complete and return all results.
-	WaitForCompletion bool `json:"wait-for-completion"`
-
 	// Email of the person making the request for logging/stats purposes.
 	InitiatorEmail string `json:"-"`
-
-	// A context that can be used to cancel the analysis.
-	Context context.Context `json:"-"`
-
-	// If true, do not swap the context to the background context when running.
-	// By default (when this is false), the context will be swapped to the background context when !WaitForCompletion.
-	// The swap is so that analysis does not get canceled when an HTTP request is complete.
-	// Setting this true is useful for testing (as one round of analysis tests can be wrapped up).
-	RetainOriginalContext bool `json:"-"`
 
 	ResolvedSubmissionIDs []string `json:"-"`
 }

--- a/internal/analysis/common.go
+++ b/internal/analysis/common.go
@@ -18,14 +18,17 @@ import (
 type AnalysisOptions struct {
 	jobmanager.JobOptions
 
-	// Don't save anything.
-	DryRun bool `json:"dry-run"`
-
 	// The raw submission specifications to analyze.
 	RawSubmissionSpecs []string `json:"submissions"`
 
 	// Email of the person making the request for logging/stats purposes.
 	InitiatorEmail string `json:"-"`
+
+	// If true, do not swap the context to the background context when running.
+	// By default (when this is false), the context will be swapped to the background context when !WaitForCompletion.
+	// The swap is so that analysis does not get canceled when an HTTP request is complete.
+	// Setting this true is useful for testing (as one round of analysis tests can be wrapped up).
+	RetainOriginalContext bool `json:"-"`
 
 	ResolvedSubmissionIDs []string `json:"-"`
 }

--- a/internal/analysis/core/engine.go
+++ b/internal/analysis/core/engine.go
@@ -15,9 +15,10 @@ type SimilarityEngine interface {
 	// The engine must not modify the existing template file.
 	// Working on two files (submissions) at a time will typically be less efficient than working on all files at the same time,
 	// but a lot of shorter jobs is more flexible than one large job.
+	// TODO: Out of date.
 	// In additional to similarity, the engine should also return the time it took (in milliseconds) to run
 	// (not counting any time locked/waiting).
 	// On an error, 0 should be returned for run time.
 	// On a timeout, (nil, 0, nil) should be returned.
-	ComputeFileSimilarity(paths [2]string, templatePath string, ctx context.Context) (*model.FileSimilarity, int64, error)
+	ComputeFileSimilarity(paths [2]string, templatePath string, ctx context.Context) (*model.FileSimilarity, error)
 }

--- a/internal/analysis/core/engine.go
+++ b/internal/analysis/core/engine.go
@@ -15,10 +15,6 @@ type SimilarityEngine interface {
 	// The engine must not modify the existing template file.
 	// Working on two files (submissions) at a time will typically be less efficient than working on all files at the same time,
 	// but a lot of shorter jobs is more flexible than one large job.
-	// TODO: Out of date.
-	// In additional to similarity, the engine should also return the time it took (in milliseconds) to run
-	// (not counting any time locked/waiting).
-	// On an error, 0 should be returned for run time.
-	// On a timeout, (nil, 0, nil) should be returned.
+	// On a timeout, (nil, nil) should be returned.
 	ComputeFileSimilarity(paths [2]string, templatePath string, ctx context.Context) (*model.FileSimilarity, error)
 }

--- a/internal/analysis/core/test.go
+++ b/internal/analysis/core/test.go
@@ -31,7 +31,7 @@ func RunEngineTestComputeFileSimilarityBase(test *testing.T, engine SimilarityEn
 		templatePath = filepath.Join(util.RootDirForTesting(), notImplementedRelPath)
 	}
 
-	result, runTime, err := engine.ComputeFileSimilarity(paths, templatePath, context.Background())
+	result, err := engine.ComputeFileSimilarity(paths, templatePath, context.Background())
 	if err != nil {
 		test.Fatalf("Failed to compute similarity: '%v'.", err)
 	}
@@ -49,9 +49,5 @@ func RunEngineTestComputeFileSimilarityBase(test *testing.T, engine SimilarityEn
 
 	if !util.IsClose(expectedScore, actualScore) {
 		test.Fatalf("Score not as expected. Expected: %f, Actual: %f.", expectedScore, actualScore)
-	}
-
-	if runTime <= 0 {
-		test.Fatalf("Run time is too small. It should be at least 1 ms, but is %d ms.", runTime)
 	}
 }

--- a/internal/analysis/individual.go
+++ b/internal/analysis/individual.go
@@ -33,7 +33,6 @@ func IndividualAnalysis(options AnalysisOptions) ([]*model.IndividualAnalysis, i
 		return nil, 0, fmt.Errorf("Unable to get locking course: '%w'.", err)
 	}
 
-	// TODO: Will be overwritten by options.Validate() (it will set to background on only !WaitForCompletion).
 	if !options.RetainOriginalContext && !options.WaitForCompletion {
 		options.Context = context.Background()
 	}

--- a/internal/analysis/individual.go
+++ b/internal/analysis/individual.go
@@ -2,7 +2,6 @@ package analysis
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"slices"
@@ -65,12 +64,7 @@ func IndividualAnalysis(options AnalysisOptions) (map[string]*model.IndividualAn
 
 	output := job.Run()
 	if output.Error != nil {
-		errs := output.Error
-		for _, err := range output.WorkErrors {
-			errs = errors.Join(errs, err)
-		}
-
-		return nil, 0, fmt.Errorf("Failed to run individual analysis job: '%v'.", errs)
+		return nil, 0, fmt.Errorf("Failed to run individual analysis job with '%d' work errors: '%v'.", len(output.WorkErrors), output.Error)
 	}
 
 	return output.ResultItems, len(output.RemainingItems), nil

--- a/internal/analysis/individual.go
+++ b/internal/analysis/individual.go
@@ -40,7 +40,7 @@ func IndividualAnalysis(options AnalysisOptions) ([]*model.IndividualAnalysis, i
 		RetrieveFunc:      getCachedIndividualResults,
 		RemoveStorageFunc: db.RemoveIndividualAnalysis,
 		WorkFunc: func(fullSubmissionID string) (*model.IndividualAnalysis, error) {
-            // TODO: Investigate if these options get the updates from validation on line 57.
+			// TODO: Investigate if these options get the updates from validation on line 57.
 			return runSingleIndividualAnalysis(options, fullSubmissionID)
 		},
 		WorkItemKeyFunc: func(fullSubmissionID string) string {
@@ -56,9 +56,9 @@ func IndividualAnalysis(options AnalysisOptions) ([]*model.IndividualAnalysis, i
 	// Capture any updates from validating the job.
 	options.JobOptions = job.JobOptions
 
-	output, err := job.Run()
-	if err != nil {
-		return nil, 0, fmt.Errorf("Failed to run individual analysis job: '%v'.", err)
+	output := job.Run()
+	if output.Error != nil {
+		return nil, 0, fmt.Errorf("Failed to run individual analysis job: '%v'.", output.Error)
 	}
 
 	collectIndividualStats(fullSubmissionIDs, output.RunTime, options.InitiatorEmail)

--- a/internal/analysis/individual.go
+++ b/internal/analysis/individual.go
@@ -33,14 +33,13 @@ func IndividualAnalysis(options AnalysisOptions) ([]*model.IndividualAnalysis, i
 	}
 
 	job := jobmanager.Job[string, *model.IndividualAnalysis]{
-		JobOptions:        options.JobOptions,
+		JobOptions:        &options.JobOptions,
 		LockKey:           fmt.Sprintf("analysis-individual-course-%s", lockCourseID),
 		PoolSize:          config.ANALYSIS_INDIVIDUAL_COURSE_POOL_SIZE.Get(),
 		WorkItems:         fullSubmissionIDs,
 		RetrieveFunc:      getCachedIndividualResults,
 		RemoveStorageFunc: db.RemoveIndividualAnalysis,
 		WorkFunc: func(fullSubmissionID string) (*model.IndividualAnalysis, error) {
-			// TODO: Investigate if these options get the updates from validation on line 57.
 			return runSingleIndividualAnalysis(options, fullSubmissionID)
 		},
 		WorkItemKeyFunc: func(fullSubmissionID string) string {
@@ -52,9 +51,6 @@ func IndividualAnalysis(options AnalysisOptions) ([]*model.IndividualAnalysis, i
 	if err != nil {
 		return nil, 0, fmt.Errorf("Failed to validate job.: '%v'.", err)
 	}
-
-	// Capture any updates from validating the job.
-	options.JobOptions = job.JobOptions
 
 	output := job.Run()
 	if output.Error != nil {

--- a/internal/analysis/individual.go
+++ b/internal/analysis/individual.go
@@ -60,7 +60,7 @@ func IndividualAnalysis(options AnalysisOptions) ([]*model.IndividualAnalysis, i
 
 	err = job.Validate()
 	if err != nil {
-		return nil, 0, fmt.Errorf("Failed to validate job.: '%v'.", err)
+		return nil, 0, fmt.Errorf("Failed to validate job: '%v'.", err)
 	}
 
 	output := job.Run()

--- a/internal/analysis/individual.go
+++ b/internal/analysis/individual.go
@@ -18,7 +18,7 @@ import (
 var testFailIndividualAnalysis bool = false
 
 func IndividualAnalysis(options AnalysisOptions) (map[string]*model.IndividualAnalysis, int, error) {
-	// Sort the ids so the result will be consistently ordered.
+	// Sort the ids so the locking key will be consistent.
 	fullSubmissionIDs := slices.Clone(options.ResolvedSubmissionIDs)
 	slices.Sort(fullSubmissionIDs)
 

--- a/internal/analysis/individual.go
+++ b/internal/analysis/individual.go
@@ -59,13 +59,16 @@ func IndividualAnalysis(options AnalysisOptions) ([]*model.IndividualAnalysis, i
 	}
 
 	output := job.Run()
-	if output.Error != nil {
-		return nil, 0, fmt.Errorf("Failed to run individual analysis job: '%v'.", output.Error)
+
+	err = output.GetError()
+	if err != nil {
+		return nil, 0, fmt.Errorf("Failed to run individual analysis job: '%v'.", err)
 	}
 
-	collectIndividualStats(fullSubmissionIDs, output.RunTime, options.InitiatorEmail)
+	// TODO: Pass a function to collect stats that takes an int64 (run time) and attributes run time.
+	collectIndividualStats(fullSubmissionIDs, output.GetRunTime(), options.InitiatorEmail)
 
-	return output.ResultItems, len(output.RemainingItems), nil
+	return output.GetResultItems(), len(output.GetRemainingItems()), nil
 }
 
 func getCachedIndividualResults(fullSubmissionIDs []string) ([]*model.IndividualAnalysis, []string, error) {

--- a/internal/analysis/individual.go
+++ b/internal/analysis/individual.go
@@ -52,7 +52,7 @@ func IndividualAnalysis(options AnalysisOptions) (map[string]*model.IndividualAn
 		WorkItemKeyFunc: func(fullSubmissionID string) string {
 			return fmt.Sprintf("analysis-individual-%s", fullSubmissionID)
 		},
-		OnComplete: func(result jobmanager.JobOutput[string, *model.IndividualAnalysis]) {
+		OnSuccess: func(result jobmanager.JobOutput[string, *model.IndividualAnalysis]) {
 			collectIndividualStats(fullSubmissionIDs, result.RunTime, options.InitiatorEmail)
 		},
 	}

--- a/internal/analysis/individual_test.go
+++ b/internal/analysis/individual_test.go
@@ -426,6 +426,7 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 			expectedPendingCount:      0,
 			expectedCacheCount:        1,
 		},
+		// TODO: Fix dry run test case.
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: []string{

--- a/internal/analysis/individual_test.go
+++ b/internal/analysis/individual_test.go
@@ -25,8 +25,8 @@ func TestIndividualAnalysisBase(test *testing.T) {
 		"course101::hw0::course-student@test.edulinq.org::1697406265",
 	}
 
-	expected := []*model.IndividualAnalysis{
-		&model.IndividualAnalysis{
+	expected := map[string]*model.IndividualAnalysis{
+		ids[0]: &model.IndividualAnalysis{
 			AnalysisTimestamp: timestamp.Zero(),
 			Options:           assignment.AssignmentAnalysisOptions,
 
@@ -105,7 +105,7 @@ func TestIndividualAnalysisBase(test *testing.T) {
 	}
 }
 
-func testIndividual(test *testing.T, ids []string, expected []*model.IndividualAnalysis, expectedInitialCacheCount int) {
+func testIndividual(test *testing.T, ids []string, expected map[string]*model.IndividualAnalysis, expectedInitialCacheCount int) {
 	queryResult, err := db.GetIndividualAnalysis(ids)
 	if err != nil {
 		test.Fatalf("Failed to do initial query for cached anslysis: '%v'.", err)
@@ -241,22 +241,22 @@ func TestIndividualAnalysisIncludeExclude(test *testing.T) {
 			continue
 		}
 
-		if testCase.expectedCount != len(results[0].Files) {
+		if testCase.expectedCount != len(results[submissionIDs[0]].Files) {
 			test.Errorf("Case %d: Unexpected number of result files. Expected: %d, Actual: %d.",
-				i, testCase.expectedCount, len(results[0].Files))
+				i, testCase.expectedCount, len(results[submissionIDs[0]].Files))
 			continue
 		}
 
-		if (baseCount - testCase.expectedCount) != len(results[0].SkippedFiles) {
+		if (baseCount - testCase.expectedCount) != len(results[submissionIDs[0]].SkippedFiles) {
 			test.Errorf("Case %d: Unexpected number of skipped files. Expected: %d, Actual: %d.",
-				i, (baseCount - testCase.expectedCount), len(results[0].SkippedFiles))
+				i, (baseCount - testCase.expectedCount), len(results[submissionIDs[0]].SkippedFiles))
 			continue
 		}
 
 		if testCase.expectedCount == 0 {
-			if relpath != results[0].SkippedFiles[0] {
+			if relpath != results[submissionIDs[0]].SkippedFiles[0] {
 				test.Errorf("Case %d: Unexpected skipped file. Expected: '%s', Actual: '%s'.",
-					i, relpath, results[0].SkippedFiles[0])
+					i, relpath, results[submissionIDs[0]].SkippedFiles[0])
 				continue
 			}
 		}
@@ -512,7 +512,7 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 
 		// Check if the result was from the cache using the start time.
 		if len(results) > 0 {
-			resultTime := results[0].AnalysisTimestamp
+			resultTime := results[testCase.options.ResolvedSubmissionIDs[0]].AnalysisTimestamp
 			resultIsFromCache := (resultTime <= startTime)
 
 			if testCase.expectedResultIsFromCache != resultIsFromCache {
@@ -586,11 +586,12 @@ func TestIndividualAnalysisFailureBase(test *testing.T) {
 		test.Fatalf("Found %d results, when 1 was expected.", len(results))
 	}
 
-	if !results[0].Failure {
+	if !results[options.ResolvedSubmissionIDs[0]].Failure {
 		test.Fatalf("Result is not a failure, when it should be.")
 	}
 
-	if !strings.Contains(results[0].FailureMessage, expectedMessageSubstring) {
-		test.Fatalf("Failure message does not contain expected substring. Expected Substring: '%s', Actual: '%s'.", expectedMessageSubstring, results[0].FailureMessage)
+	if !strings.Contains(results[options.ResolvedSubmissionIDs[0]].FailureMessage, expectedMessageSubstring) {
+		test.Fatalf("Failure message does not contain expected substring. Expected Substring: '%s', Actual: '%s'.",
+			expectedMessageSubstring, results[options.ResolvedSubmissionIDs[0]].FailureMessage)
 	}
 }

--- a/internal/analysis/individual_test.go
+++ b/internal/analysis/individual_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/edulinq/autograder/internal/db"
+	"github.com/edulinq/autograder/internal/jobmanager"
 	"github.com/edulinq/autograder/internal/model"
 	"github.com/edulinq/autograder/internal/stats"
 	"github.com/edulinq/autograder/internal/timestamp"
@@ -117,7 +118,9 @@ func testIndividual(test *testing.T, ids []string, expected []*model.IndividualA
 	options := AnalysisOptions{
 		ResolvedSubmissionIDs: ids,
 		InitiatorEmail:        "server-admin@test.edulinq.org",
-		WaitForCompletion:     true,
+		JobOptions: &jobmanager.JobOptions{
+			WaitForCompletion: true,
+		},
 	}
 
 	results, pendingCount, err := IndividualAnalysis(options)
@@ -217,7 +220,9 @@ func TestIndividualAnalysisIncludeExclude(test *testing.T) {
 		options := AnalysisOptions{
 			ResolvedSubmissionIDs: submissionIDs,
 			InitiatorEmail:        "server-admin@test.edulinq.org",
-			WaitForCompletion:     true,
+			JobOptions: &jobmanager.JobOptions{
+				WaitForCompletion: true,
+			},
 		}
 
 		results, pendingCount, err := IndividualAnalysis(options)
@@ -278,7 +283,9 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: []string{},
-				WaitForCompletion:     true,
+				JobOptions: &jobmanager.JobOptions{
+					WaitForCompletion: true,
+				},
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -295,9 +302,11 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 				ResolvedSubmissionIDs: []string{
 					submissionID,
 				},
-				DryRun:            false,
-				OverwriteCache:    false,
-				WaitForCompletion: true,
+				JobOptions: &jobmanager.JobOptions{
+					DryRun:            false,
+					OverwriteCache:    false,
+					WaitForCompletion: true,
+				},
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -311,9 +320,11 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 				ResolvedSubmissionIDs: []string{
 					submissionID,
 				},
-				DryRun:            true,
-				OverwriteCache:    false,
-				WaitForCompletion: true,
+				JobOptions: &jobmanager.JobOptions{
+					DryRun:            true,
+					OverwriteCache:    false,
+					WaitForCompletion: true,
+				},
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -327,9 +338,11 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 				ResolvedSubmissionIDs: []string{
 					submissionID,
 				},
-				DryRun:            false,
-				OverwriteCache:    true,
-				WaitForCompletion: true,
+				JobOptions: &jobmanager.JobOptions{
+					DryRun:            false,
+					OverwriteCache:    true,
+					WaitForCompletion: true,
+				},
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -343,9 +356,11 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 				ResolvedSubmissionIDs: []string{
 					submissionID,
 				},
-				DryRun:            true,
-				OverwriteCache:    true,
-				WaitForCompletion: true,
+				JobOptions: &jobmanager.JobOptions{
+					DryRun:            true,
+					OverwriteCache:    true,
+					WaitForCompletion: true,
+				},
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -362,9 +377,11 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 				ResolvedSubmissionIDs: []string{
 					submissionID,
 				},
-				DryRun:            false,
-				OverwriteCache:    false,
-				WaitForCompletion: true,
+				JobOptions: &jobmanager.JobOptions{
+					DryRun:            false,
+					OverwriteCache:    false,
+					WaitForCompletion: true,
+				},
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
@@ -378,9 +395,11 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 				ResolvedSubmissionIDs: []string{
 					submissionID,
 				},
-				DryRun:            true,
-				OverwriteCache:    false,
-				WaitForCompletion: true,
+				JobOptions: &jobmanager.JobOptions{
+					DryRun:            true,
+					OverwriteCache:    false,
+					WaitForCompletion: true,
+				},
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
@@ -394,9 +413,11 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 				ResolvedSubmissionIDs: []string{
 					submissionID,
 				},
-				DryRun:            false,
-				OverwriteCache:    true,
-				WaitForCompletion: true,
+				JobOptions: &jobmanager.JobOptions{
+					DryRun:            false,
+					OverwriteCache:    true,
+					WaitForCompletion: true,
+				},
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: false,
@@ -410,9 +431,11 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 				ResolvedSubmissionIDs: []string{
 					submissionID,
 				},
-				DryRun:            true,
-				OverwriteCache:    true,
-				WaitForCompletion: true,
+				JobOptions: &jobmanager.JobOptions{
+					DryRun:            true,
+					OverwriteCache:    true,
+					WaitForCompletion: true,
+				},
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
@@ -445,7 +468,9 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 			preloadOptions := AnalysisOptions{
 				ResolvedSubmissionIDs: testCase.options.ResolvedSubmissionIDs,
 				InitiatorEmail:        "server-admin@test.edulinq.org",
-				WaitForCompletion:     true,
+				JobOptions: &jobmanager.JobOptions{
+					WaitForCompletion: true,
+				},
 			}
 
 			_, _, err := IndividualAnalysis(preloadOptions)
@@ -464,8 +489,8 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 		ctx, contextCancelFunc = context.WithCancel(context.Background())
 
 		testCase.options.InitiatorEmail = "server-admin@test.edulinq.org"
-		testCase.options.Context = ctx
-		testCase.options.RetainOriginalContext = false
+		testCase.options.JobOptions.Context = ctx
+		testCase.options.JobOptions.RetainOriginalContext = false
 
 		results, pendingCount, err := IndividualAnalysis(testCase.options)
 		if err != nil {
@@ -543,7 +568,9 @@ func TestIndividualAnalysisFailureBase(test *testing.T) {
 	options := AnalysisOptions{
 		ResolvedSubmissionIDs: []string{"course101::hw0::course-student@test.edulinq.org::1697406265"},
 		InitiatorEmail:        "server-admin@test.edulinq.org",
-		WaitForCompletion:     true,
+		JobOptions: &jobmanager.JobOptions{
+			WaitForCompletion: true,
+		},
 	}
 
 	results, pendingCount, err := IndividualAnalysis(options)

--- a/internal/analysis/individual_test.go
+++ b/internal/analysis/individual_test.go
@@ -118,7 +118,7 @@ func testIndividual(test *testing.T, ids []string, expected []*model.IndividualA
 	options := AnalysisOptions{
 		ResolvedSubmissionIDs: ids,
 		InitiatorEmail:        "server-admin@test.edulinq.org",
-		JobOptions: &jobmanager.JobOptions{
+		JobOptions: jobmanager.JobOptions{
 			WaitForCompletion: true,
 		},
 	}
@@ -220,7 +220,7 @@ func TestIndividualAnalysisIncludeExclude(test *testing.T) {
 		options := AnalysisOptions{
 			ResolvedSubmissionIDs: submissionIDs,
 			InitiatorEmail:        "server-admin@test.edulinq.org",
-			JobOptions: &jobmanager.JobOptions{
+			JobOptions: jobmanager.JobOptions{
 				WaitForCompletion: true,
 			},
 		}
@@ -283,7 +283,7 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: []string{},
-				JobOptions: &jobmanager.JobOptions{
+				JobOptions: jobmanager.JobOptions{
 					WaitForCompletion: true,
 				},
 			},
@@ -302,11 +302,11 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 				ResolvedSubmissionIDs: []string{
 					submissionID,
 				},
-				JobOptions: &jobmanager.JobOptions{
-					DryRun:            false,
-					OverwriteCache:    false,
+				JobOptions: jobmanager.JobOptions{
+					OverwriteRecords:  false,
 					WaitForCompletion: true,
 				},
+				DryRun: false,
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -320,11 +320,11 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 				ResolvedSubmissionIDs: []string{
 					submissionID,
 				},
-				JobOptions: &jobmanager.JobOptions{
-					DryRun:            true,
-					OverwriteCache:    false,
+				JobOptions: jobmanager.JobOptions{
+					OverwriteRecords:  false,
 					WaitForCompletion: true,
 				},
+				DryRun: true,
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -338,11 +338,11 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 				ResolvedSubmissionIDs: []string{
 					submissionID,
 				},
-				JobOptions: &jobmanager.JobOptions{
-					DryRun:            false,
-					OverwriteCache:    true,
+				JobOptions: jobmanager.JobOptions{
+					OverwriteRecords:  true,
 					WaitForCompletion: true,
 				},
+				DryRun: false,
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -356,11 +356,11 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 				ResolvedSubmissionIDs: []string{
 					submissionID,
 				},
-				JobOptions: &jobmanager.JobOptions{
-					DryRun:            true,
-					OverwriteCache:    true,
+				JobOptions: jobmanager.JobOptions{
+					OverwriteRecords:  true,
 					WaitForCompletion: true,
 				},
+				DryRun: true,
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -377,11 +377,11 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 				ResolvedSubmissionIDs: []string{
 					submissionID,
 				},
-				JobOptions: &jobmanager.JobOptions{
-					DryRun:            false,
-					OverwriteCache:    false,
+				JobOptions: jobmanager.JobOptions{
+					OverwriteRecords:  false,
 					WaitForCompletion: true,
 				},
+				DryRun: false,
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
@@ -395,11 +395,11 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 				ResolvedSubmissionIDs: []string{
 					submissionID,
 				},
-				JobOptions: &jobmanager.JobOptions{
-					DryRun:            true,
-					OverwriteCache:    false,
+				JobOptions: jobmanager.JobOptions{
+					OverwriteRecords:  false,
 					WaitForCompletion: true,
 				},
+				DryRun: true,
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
@@ -413,11 +413,11 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 				ResolvedSubmissionIDs: []string{
 					submissionID,
 				},
-				JobOptions: &jobmanager.JobOptions{
-					DryRun:            false,
-					OverwriteCache:    true,
+				JobOptions: jobmanager.JobOptions{
+					OverwriteRecords:  true,
 					WaitForCompletion: true,
 				},
+				DryRun: false,
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: false,
@@ -431,11 +431,11 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 				ResolvedSubmissionIDs: []string{
 					submissionID,
 				},
-				JobOptions: &jobmanager.JobOptions{
-					DryRun:            true,
-					OverwriteCache:    true,
+				JobOptions: jobmanager.JobOptions{
+					OverwriteRecords:  true,
 					WaitForCompletion: true,
 				},
+				DryRun: true,
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
@@ -468,7 +468,7 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 			preloadOptions := AnalysisOptions{
 				ResolvedSubmissionIDs: testCase.options.ResolvedSubmissionIDs,
 				InitiatorEmail:        "server-admin@test.edulinq.org",
-				JobOptions: &jobmanager.JobOptions{
+				JobOptions: jobmanager.JobOptions{
 					WaitForCompletion: true,
 				},
 			}
@@ -568,7 +568,7 @@ func TestIndividualAnalysisFailureBase(test *testing.T) {
 	options := AnalysisOptions{
 		ResolvedSubmissionIDs: []string{"course101::hw0::course-student@test.edulinq.org::1697406265"},
 		InitiatorEmail:        "server-admin@test.edulinq.org",
-		JobOptions: &jobmanager.JobOptions{
+		JobOptions: jobmanager.JobOptions{
 			WaitForCompletion: true,
 		},
 	}

--- a/internal/analysis/individual_test.go
+++ b/internal/analysis/individual_test.go
@@ -426,7 +426,6 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 			expectedPendingCount:      0,
 			expectedCacheCount:        1,
 		},
-		// TODO: Fix dry run test case.
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: []string{
@@ -440,7 +439,7 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
-			expectedResultIsFromCache: false,
+			expectedResultIsFromCache: true,
 			expectedResultCount:       1,
 			expectedPendingCount:      0,
 			expectedCacheCount:        1,

--- a/internal/analysis/individual_test.go
+++ b/internal/analysis/individual_test.go
@@ -303,10 +303,10 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 					submissionID,
 				},
 				JobOptions: jobmanager.JobOptions{
+					DryRun:            false,
 					OverwriteRecords:  false,
 					WaitForCompletion: true,
 				},
-				DryRun: false,
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -321,10 +321,10 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 					submissionID,
 				},
 				JobOptions: jobmanager.JobOptions{
+					DryRun:            true,
 					OverwriteRecords:  false,
 					WaitForCompletion: true,
 				},
-				DryRun: true,
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -339,10 +339,10 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 					submissionID,
 				},
 				JobOptions: jobmanager.JobOptions{
+					DryRun:            false,
 					OverwriteRecords:  true,
 					WaitForCompletion: true,
 				},
-				DryRun: false,
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -357,10 +357,10 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 					submissionID,
 				},
 				JobOptions: jobmanager.JobOptions{
+					DryRun:            true,
 					OverwriteRecords:  true,
 					WaitForCompletion: true,
 				},
-				DryRun: true,
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -378,10 +378,10 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 					submissionID,
 				},
 				JobOptions: jobmanager.JobOptions{
+					DryRun:            false,
 					OverwriteRecords:  false,
 					WaitForCompletion: true,
 				},
-				DryRun: false,
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
@@ -396,10 +396,10 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 					submissionID,
 				},
 				JobOptions: jobmanager.JobOptions{
+					DryRun:            true,
 					OverwriteRecords:  false,
 					WaitForCompletion: true,
 				},
-				DryRun: true,
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
@@ -414,10 +414,10 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 					submissionID,
 				},
 				JobOptions: jobmanager.JobOptions{
+					DryRun:            false,
 					OverwriteRecords:  true,
 					WaitForCompletion: true,
 				},
-				DryRun: false,
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: false,
@@ -432,10 +432,10 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 					submissionID,
 				},
 				JobOptions: jobmanager.JobOptions{
+					DryRun:            true,
 					OverwriteRecords:  true,
 					WaitForCompletion: true,
 				},
-				DryRun: true,
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
@@ -490,7 +490,7 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 
 		testCase.options.InitiatorEmail = "server-admin@test.edulinq.org"
 		testCase.options.JobOptions.Context = ctx
-		testCase.options.JobOptions.RetainOriginalContext = false
+		testCase.options.RetainOriginalContext = false
 
 		results, pendingCount, err := IndividualAnalysis(testCase.options)
 		if err != nil {

--- a/internal/analysis/pairwise.go
+++ b/internal/analysis/pairwise.go
@@ -104,7 +104,7 @@ func PairwiseAnalysis(options AnalysisOptions) (model.PairwiseAnalysisMap, int, 
 }
 
 func createPairwiseKeys(fullSubmissionIDs []string) []model.PairwiseKey {
-	// Sort the ids so the result will be consistently ordered.
+	// Sort the ids so the locking key will be consistent.
 	fullSubmissionIDs = slices.Clone(fullSubmissionIDs)
 	slices.Sort(fullSubmissionIDs)
 

--- a/internal/analysis/pairwise.go
+++ b/internal/analysis/pairwise.go
@@ -97,12 +97,7 @@ func PairwiseAnalysis(options AnalysisOptions) (model.PairwiseAnalysisMap, int, 
 
 	output := job.Run()
 	if output.Error != nil {
-		errs := output.Error
-		for _, err := range output.WorkErrors {
-			errs = errors.Join(errs, err)
-		}
-
-		return nil, 0, fmt.Errorf("Failed to run pairwise analysis job: '%v'.", errs)
+		return nil, 0, fmt.Errorf("Failed to run pairwise analysis job with '%d' work errors: '%v'.", len(output.WorkErrors), output.Error)
 	}
 
 	return output.ResultItems, len(output.RemainingItems), nil

--- a/internal/analysis/pairwise.go
+++ b/internal/analysis/pairwise.go
@@ -85,7 +85,7 @@ func PairwiseAnalysis(options AnalysisOptions) (model.PairwiseAnalysisMap, int, 
 		WorkItemKeyFunc: func(key model.PairwiseKey) string {
 			return fmt.Sprintf("analysis-pairwise-single-%s", key.String())
 		},
-		OnComplete: func(result jobmanager.JobOutput[model.PairwiseKey, *model.PairwiseAnalysis]) {
+		OnSuccess: func(result jobmanager.JobOutput[model.PairwiseKey, *model.PairwiseAnalysis]) {
 			collectPairwiseStats(allKeys, result.RunTime, options.InitiatorEmail)
 		},
 	}

--- a/internal/analysis/pairwise.go
+++ b/internal/analysis/pairwise.go
@@ -88,9 +88,9 @@ func PairwiseAnalysis(options AnalysisOptions) ([]*model.PairwiseAnalysis, int, 
 	// Capture any updates from validating the job.
 	options.JobOptions = job.JobOptions
 
-	output, err := job.Run()
-	if err != nil {
-		return nil, 0, fmt.Errorf("Failed to run pairwise analysis job: '%v'.", err)
+	output := job.Run()
+	if output.Error != nil {
+		return nil, 0, fmt.Errorf("Failed to run pairwise analysis job: '%v'.", output.Error)
 	}
 
 	collectPairwiseStats(allKeys, output.RunTime, options.InitiatorEmail)

--- a/internal/analysis/pairwise.go
+++ b/internal/analysis/pairwise.go
@@ -66,7 +66,7 @@ func PairwiseAnalysis(options AnalysisOptions) ([]*model.PairwiseAnalysis, int, 
 	defer templateFileStore.Close()
 
 	job := jobmanager.Job[model.PairwiseKey, *model.PairwiseAnalysis]{
-		JobOptions:        options.JobOptions,
+		JobOptions:        &options.JobOptions,
 		LockKey:           fmt.Sprintf("analysis-pairwise-course-%s", lockCourseID),
 		PoolSize:          config.ANALYSIS_PAIRWISE_COURSE_POOL_SIZE.Get(),
 		WorkItems:         allKeys,
@@ -84,9 +84,6 @@ func PairwiseAnalysis(options AnalysisOptions) ([]*model.PairwiseAnalysis, int, 
 	if err != nil {
 		return nil, 0, fmt.Errorf("Failed to validate job: '%v'.", err)
 	}
-
-	// Capture any updates from validating the job.
-	options.JobOptions = job.JobOptions
 
 	output := job.Run()
 	if output.Error != nil {

--- a/internal/analysis/pairwise.go
+++ b/internal/analysis/pairwise.go
@@ -92,13 +92,15 @@ func PairwiseAnalysis(options AnalysisOptions) ([]*model.PairwiseAnalysis, int, 
 	}
 
 	output := job.Run()
-	if output.Error != nil {
-		return nil, 0, fmt.Errorf("Failed to run pairwise analysis job: '%v'.", output.Error)
+
+	err = output.GetError()
+	if err != nil {
+		return nil, 0, fmt.Errorf("Failed to run pairwise analysis job: '%v'.", err)
 	}
 
-	collectPairwiseStats(allKeys, output.RunTime, options.InitiatorEmail)
+	collectPairwiseStats(allKeys, output.GetRunTime(), options.InitiatorEmail)
 
-	return output.ResultItems, len(output.RemainingItems), nil
+	return output.GetResultItems(), len(output.GetRemainingItems()), nil
 }
 
 func createPairwiseKeys(fullSubmissionIDs []string) []model.PairwiseKey {

--- a/internal/analysis/pairwise_test.go
+++ b/internal/analysis/pairwise_test.go
@@ -607,7 +607,7 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
-			expectedResultIsFromCache: false,
+			expectedResultIsFromCache: true,
 			expectedResultCount:       1,
 			expectedPendingCount:      0,
 			expectedCacheCount:        1,

--- a/internal/analysis/pairwise_test.go
+++ b/internal/analysis/pairwise_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/edulinq/autograder/internal/analysis/jplag"
 	"github.com/edulinq/autograder/internal/db"
 	"github.com/edulinq/autograder/internal/docker"
+	"github.com/edulinq/autograder/internal/jobmanager"
 	"github.com/edulinq/autograder/internal/model"
 	"github.com/edulinq/autograder/internal/stats"
 	"github.com/edulinq/autograder/internal/timestamp"
@@ -160,7 +161,9 @@ func testPairwise(test *testing.T, ids []string, expected []*model.PairwiseAnaly
 	options := AnalysisOptions{
 		ResolvedSubmissionIDs: ids,
 		InitiatorEmail:        "server-admin@test.edulinq.org",
-		WaitForCompletion:     true,
+		JobOptions: &jobmanager.JobOptions{
+			WaitForCompletion: true,
+		},
 	}
 
 	results, pendingCount, err := PairwiseAnalysis(options)
@@ -225,7 +228,9 @@ func TestPairwiseWithPythonNotebook(test *testing.T) {
 	defer cancelFunc()
 
 	options := AnalysisOptions{
-		Context: ctx,
+		JobOptions: &jobmanager.JobOptions{
+			Context: ctx,
+		},
 	}
 
 	sims, unmatches, _, _, err := computeFileSims(options, paths, nil, nil)
@@ -277,7 +282,9 @@ func TestPairwiseAnalysisDefaultEnginesBase(test *testing.T) {
 	options := AnalysisOptions{
 		ResolvedSubmissionIDs: ids,
 		InitiatorEmail:        "server-admin@test.edulinq.org",
-		WaitForCompletion:     true,
+		JobOptions: &jobmanager.JobOptions{
+			WaitForCompletion: true,
+		},
 	}
 
 	results, pendingCount, err := PairwiseAnalysis(options)
@@ -393,7 +400,9 @@ func TestPairwiseAnalysisIncludeExclude(test *testing.T) {
 		options := AnalysisOptions{
 			ResolvedSubmissionIDs: ids,
 			InitiatorEmail:        "server-admin@test.edulinq.org",
-			WaitForCompletion:     true,
+			JobOptions: &jobmanager.JobOptions{
+				WaitForCompletion: true,
+			},
 		}
 
 		results, pendingCount, err := PairwiseAnalysis(options)
@@ -456,7 +465,9 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: []string{},
-				WaitForCompletion:     true,
+				JobOptions: &jobmanager.JobOptions{
+					WaitForCompletion: true,
+				},
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -471,9 +482,11 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
-				DryRun:                false,
-				OverwriteCache:        false,
-				WaitForCompletion:     true,
+				JobOptions: &jobmanager.JobOptions{
+					DryRun:            false,
+					OverwriteCache:    false,
+					WaitForCompletion: true,
+				},
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -485,9 +498,11 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
-				DryRun:                true,
-				OverwriteCache:        false,
-				WaitForCompletion:     true,
+				JobOptions: &jobmanager.JobOptions{
+					DryRun:            true,
+					OverwriteCache:    false,
+					WaitForCompletion: true,
+				},
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -499,9 +514,11 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
-				DryRun:                false,
-				OverwriteCache:        true,
-				WaitForCompletion:     true,
+				JobOptions: &jobmanager.JobOptions{
+					DryRun:            false,
+					OverwriteCache:    true,
+					WaitForCompletion: true,
+				},
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -513,9 +530,11 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
-				DryRun:                true,
-				OverwriteCache:        true,
-				WaitForCompletion:     true,
+				JobOptions: &jobmanager.JobOptions{
+					DryRun:            true,
+					OverwriteCache:    true,
+					WaitForCompletion: true,
+				},
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -530,9 +549,11 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
-				DryRun:                false,
-				OverwriteCache:        false,
-				WaitForCompletion:     true,
+				JobOptions: &jobmanager.JobOptions{
+					DryRun:            false,
+					OverwriteCache:    false,
+					WaitForCompletion: true,
+				},
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
@@ -544,9 +565,11 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
-				DryRun:                true,
-				OverwriteCache:        false,
-				WaitForCompletion:     true,
+				JobOptions: &jobmanager.JobOptions{
+					DryRun:            true,
+					OverwriteCache:    false,
+					WaitForCompletion: true,
+				},
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
@@ -558,9 +581,11 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
-				DryRun:                false,
-				OverwriteCache:        true,
-				WaitForCompletion:     true,
+				JobOptions: &jobmanager.JobOptions{
+					DryRun:            false,
+					OverwriteCache:    true,
+					WaitForCompletion: true,
+				},
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: false,
@@ -572,9 +597,11 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
-				DryRun:                true,
-				OverwriteCache:        true,
-				WaitForCompletion:     true,
+				JobOptions: &jobmanager.JobOptions{
+					DryRun:            true,
+					OverwriteCache:    true,
+					WaitForCompletion: true,
+				},
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
@@ -607,7 +634,9 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 			preloadOptions := AnalysisOptions{
 				ResolvedSubmissionIDs: testCase.options.ResolvedSubmissionIDs,
 				InitiatorEmail:        "server-admin@test.edulinq.org",
-				WaitForCompletion:     true,
+				JobOptions: &jobmanager.JobOptions{
+					WaitForCompletion: true,
+				},
 			}
 
 			_, _, err := PairwiseAnalysis(preloadOptions)
@@ -626,8 +655,8 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		ctx, contextCancelFunc = context.WithCancel(context.Background())
 
 		testCase.options.InitiatorEmail = "server-admin@test.edulinq.org"
-		testCase.options.Context = ctx
-		testCase.options.RetainOriginalContext = false
+		testCase.options.JobOptions.Context = ctx
+		testCase.options.JobOptions.RetainOriginalContext = false
 
 		results, pendingCount, err := PairwiseAnalysis(testCase.options)
 		if err != nil {
@@ -711,7 +740,9 @@ func TestPairwiseAnalysisFailureBase(test *testing.T) {
 	options := AnalysisOptions{
 		ResolvedSubmissionIDs: ids,
 		InitiatorEmail:        "server-admin@test.edulinq.org",
-		WaitForCompletion:     true,
+		JobOptions: &jobmanager.JobOptions{
+			WaitForCompletion: true,
+		},
 	}
 
 	results, pendingCount, err := PairwiseAnalysis(options)

--- a/internal/analysis/pairwise_test.go
+++ b/internal/analysis/pairwise_test.go
@@ -161,7 +161,7 @@ func testPairwise(test *testing.T, ids []string, expected []*model.PairwiseAnaly
 	options := AnalysisOptions{
 		ResolvedSubmissionIDs: ids,
 		InitiatorEmail:        "server-admin@test.edulinq.org",
-		JobOptions: &jobmanager.JobOptions{
+		JobOptions: jobmanager.JobOptions{
 			WaitForCompletion: true,
 		},
 	}
@@ -228,7 +228,7 @@ func TestPairwiseWithPythonNotebook(test *testing.T) {
 	defer cancelFunc()
 
 	options := AnalysisOptions{
-		JobOptions: &jobmanager.JobOptions{
+		JobOptions: jobmanager.JobOptions{
 			Context: ctx,
 		},
 	}
@@ -282,7 +282,7 @@ func TestPairwiseAnalysisDefaultEnginesBase(test *testing.T) {
 	options := AnalysisOptions{
 		ResolvedSubmissionIDs: ids,
 		InitiatorEmail:        "server-admin@test.edulinq.org",
-		JobOptions: &jobmanager.JobOptions{
+		JobOptions: jobmanager.JobOptions{
 			WaitForCompletion: true,
 		},
 	}
@@ -400,7 +400,7 @@ func TestPairwiseAnalysisIncludeExclude(test *testing.T) {
 		options := AnalysisOptions{
 			ResolvedSubmissionIDs: ids,
 			InitiatorEmail:        "server-admin@test.edulinq.org",
-			JobOptions: &jobmanager.JobOptions{
+			JobOptions: jobmanager.JobOptions{
 				WaitForCompletion: true,
 			},
 		}
@@ -465,7 +465,7 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: []string{},
-				JobOptions: &jobmanager.JobOptions{
+				JobOptions: jobmanager.JobOptions{
 					WaitForCompletion: true,
 				},
 			},
@@ -482,11 +482,11 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
-				JobOptions: &jobmanager.JobOptions{
-					DryRun:            false,
-					OverwriteCache:    false,
+				JobOptions: jobmanager.JobOptions{
+					OverwriteRecords:  false,
 					WaitForCompletion: true,
 				},
+				DryRun: false,
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -498,11 +498,11 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
-				JobOptions: &jobmanager.JobOptions{
-					DryRun:            true,
-					OverwriteCache:    false,
+				JobOptions: jobmanager.JobOptions{
+					OverwriteRecords:  false,
 					WaitForCompletion: true,
 				},
+				DryRun: true,
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -514,11 +514,11 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
-				JobOptions: &jobmanager.JobOptions{
-					DryRun:            false,
-					OverwriteCache:    true,
+				JobOptions: jobmanager.JobOptions{
+					OverwriteRecords:  true,
 					WaitForCompletion: true,
 				},
+				DryRun: false,
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -530,11 +530,11 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
-				JobOptions: &jobmanager.JobOptions{
-					DryRun:            true,
-					OverwriteCache:    true,
+				JobOptions: jobmanager.JobOptions{
+					OverwriteRecords:  true,
 					WaitForCompletion: true,
 				},
+				DryRun: true,
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -549,11 +549,11 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
-				JobOptions: &jobmanager.JobOptions{
-					DryRun:            false,
-					OverwriteCache:    false,
+				JobOptions: jobmanager.JobOptions{
+					OverwriteRecords:  false,
 					WaitForCompletion: true,
 				},
+				DryRun: false,
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
@@ -565,11 +565,11 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
-				JobOptions: &jobmanager.JobOptions{
-					DryRun:            true,
-					OverwriteCache:    false,
+				JobOptions: jobmanager.JobOptions{
+					OverwriteRecords:  false,
 					WaitForCompletion: true,
 				},
+				DryRun: true,
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
@@ -581,11 +581,11 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
-				JobOptions: &jobmanager.JobOptions{
-					DryRun:            false,
-					OverwriteCache:    true,
+				JobOptions: jobmanager.JobOptions{
+					OverwriteRecords:  true,
 					WaitForCompletion: true,
 				},
+				DryRun: false,
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: false,
@@ -597,11 +597,11 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 		{
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
-				JobOptions: &jobmanager.JobOptions{
-					DryRun:            true,
-					OverwriteCache:    true,
+				JobOptions: jobmanager.JobOptions{
+					OverwriteRecords:  true,
 					WaitForCompletion: true,
 				},
+				DryRun: true,
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
@@ -634,7 +634,7 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 			preloadOptions := AnalysisOptions{
 				ResolvedSubmissionIDs: testCase.options.ResolvedSubmissionIDs,
 				InitiatorEmail:        "server-admin@test.edulinq.org",
-				JobOptions: &jobmanager.JobOptions{
+				JobOptions: jobmanager.JobOptions{
 					WaitForCompletion: true,
 				},
 			}
@@ -740,7 +740,7 @@ func TestPairwiseAnalysisFailureBase(test *testing.T) {
 	options := AnalysisOptions{
 		ResolvedSubmissionIDs: ids,
 		InitiatorEmail:        "server-admin@test.edulinq.org",
-		JobOptions: &jobmanager.JobOptions{
+		JobOptions: jobmanager.JobOptions{
 			WaitForCompletion: true,
 		},
 	}

--- a/internal/analysis/pairwise_test.go
+++ b/internal/analysis/pairwise_test.go
@@ -121,7 +121,7 @@ func TestPairwiseAnalysisFake(test *testing.T) {
 		&stats.Metric{
 			Timestamp: timestamp.Zero(),
 			Type:      stats.MetricTypeCodeAnalysisTime,
-			Value:     float64(3), // 1 for each run of the fake engine.
+			Value:     float64(0),
 			Attributes: map[stats.MetricAttribute]any{
 				stats.MetricAttributeAnalysisType: "pairwise",
 				stats.MetricAttributeCourseID:     "course101",
@@ -134,6 +134,8 @@ func TestPairwiseAnalysisFake(test *testing.T) {
 	// Zero out the query results.
 	for _, result := range results {
 		result.Timestamp = timestamp.Zero()
+
+		result.Value = 0
 	}
 
 	if !reflect.DeepEqual(expectedStats, results) {

--- a/internal/analysis/pairwise_test.go
+++ b/internal/analysis/pairwise_test.go
@@ -483,10 +483,10 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
 				JobOptions: jobmanager.JobOptions{
+					DryRun:            false,
 					OverwriteRecords:  false,
 					WaitForCompletion: true,
 				},
-				DryRun: false,
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -499,10 +499,10 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
 				JobOptions: jobmanager.JobOptions{
+					DryRun:            true,
 					OverwriteRecords:  false,
 					WaitForCompletion: true,
 				},
-				DryRun: true,
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -515,10 +515,10 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
 				JobOptions: jobmanager.JobOptions{
+					DryRun:            false,
 					OverwriteRecords:  true,
 					WaitForCompletion: true,
 				},
-				DryRun: false,
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -531,10 +531,10 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
 				JobOptions: jobmanager.JobOptions{
+					DryRun:            true,
 					OverwriteRecords:  true,
 					WaitForCompletion: true,
 				},
-				DryRun: true,
 			},
 			preload:                   false,
 			expectedCacheSetOnPreload: false,
@@ -550,10 +550,10 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
 				JobOptions: jobmanager.JobOptions{
+					DryRun:            false,
 					OverwriteRecords:  false,
 					WaitForCompletion: true,
 				},
-				DryRun: false,
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
@@ -566,10 +566,10 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
 				JobOptions: jobmanager.JobOptions{
+					DryRun:            true,
 					OverwriteRecords:  false,
 					WaitForCompletion: true,
 				},
-				DryRun: true,
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
@@ -582,10 +582,10 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
 				JobOptions: jobmanager.JobOptions{
+					DryRun:            false,
 					OverwriteRecords:  true,
 					WaitForCompletion: true,
 				},
-				DryRun: false,
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: false,
@@ -598,10 +598,10 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 			options: AnalysisOptions{
 				ResolvedSubmissionIDs: ids,
 				JobOptions: jobmanager.JobOptions{
+					DryRun:            true,
 					OverwriteRecords:  true,
 					WaitForCompletion: true,
 				},
-				DryRun: true,
 			},
 			preload:                   true,
 			expectedCacheSetOnPreload: true,
@@ -656,7 +656,7 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 
 		testCase.options.InitiatorEmail = "server-admin@test.edulinq.org"
 		testCase.options.JobOptions.Context = ctx
-		testCase.options.JobOptions.RetainOriginalContext = false
+		testCase.options.RetainOriginalContext = false
 
 		results, pendingCount, err := PairwiseAnalysis(testCase.options)
 		if err != nil {

--- a/internal/analysis/pairwise_test.go
+++ b/internal/analysis/pairwise_test.go
@@ -233,7 +233,7 @@ func TestPairwiseWithPythonNotebook(test *testing.T) {
 		},
 	}
 
-	sims, unmatches, _, _, err := computeFileSims(options, paths, nil, nil)
+	sims, unmatches, _, err := computeFileSims(options, paths, nil, nil)
 	if err != nil {
 		test.Fatalf("Failed to compute file similarity: '%v'.", err)
 	}
@@ -320,7 +320,7 @@ func TestPairwiseAnalysisDefaultEnginesSpecificFiles(test *testing.T) {
 
 	for _, path := range testPaths {
 		for _, engine := range defaultSimilarityEngines {
-			sim, _, err := engine.ComputeFileSimilarity([2]string{path, path}, "", ctx)
+			sim, err := engine.ComputeFileSimilarity([2]string{path, path}, "", ctx)
 			if err != nil {
 				test.Errorf("Engine '%s' failed to compute similarity on '%s': '%v'.",
 					engine.GetName(), path, err)

--- a/internal/analysis/pairwise_test.go
+++ b/internal/analysis/pairwise_test.go
@@ -30,13 +30,13 @@ func TestPairwiseAnalysisFake(test *testing.T) {
 		"course101::hw0::course-student@test.edulinq.org::1697406272",
 	}
 
-	expected := []*model.PairwiseAnalysis{
-		&model.PairwiseAnalysis{
+	expected := model.PairwiseAnalysisMap{
+		model.NewPairwiseKey(ids[0], ids[1]): &model.PairwiseAnalysis{
 			Options:           assignment.AssignmentAnalysisOptions,
 			AnalysisTimestamp: timestamp.Zero(),
 			SubmissionIDs: model.NewPairwiseKey(
-				"course101::hw0::course-student@test.edulinq.org::1697406256",
-				"course101::hw0::course-student@test.edulinq.org::1697406265",
+				ids[0],
+				ids[1],
 			),
 			Similarities: map[string][]*model.FileSimilarity{
 				"submission.py": []*model.FileSimilarity{
@@ -53,12 +53,12 @@ func TestPairwiseAnalysisFake(test *testing.T) {
 			},
 			TotalMeanSimilarity: 0.13,
 		},
-		&model.PairwiseAnalysis{
+		model.NewPairwiseKey(ids[0], ids[2]): &model.PairwiseAnalysis{
 			Options:           assignment.AssignmentAnalysisOptions,
 			AnalysisTimestamp: timestamp.Zero(),
 			SubmissionIDs: model.NewPairwiseKey(
-				"course101::hw0::course-student@test.edulinq.org::1697406256",
-				"course101::hw0::course-student@test.edulinq.org::1697406272",
+				ids[0],
+				ids[2],
 			),
 			Similarities: map[string][]*model.FileSimilarity{
 				"submission.py": []*model.FileSimilarity{
@@ -75,12 +75,12 @@ func TestPairwiseAnalysisFake(test *testing.T) {
 			},
 			TotalMeanSimilarity: 0.13,
 		},
-		&model.PairwiseAnalysis{
+		model.NewPairwiseKey(ids[1], ids[2]): &model.PairwiseAnalysis{
 			Options:           assignment.AssignmentAnalysisOptions,
 			AnalysisTimestamp: timestamp.Zero(),
 			SubmissionIDs: model.NewPairwiseKey(
-				"course101::hw0::course-student@test.edulinq.org::1697406265",
-				"course101::hw0::course-student@test.edulinq.org::1697406272",
+				ids[1],
+				ids[2],
 			),
 			Similarities: map[string][]*model.FileSimilarity{
 				"submission.py": []*model.FileSimilarity{
@@ -144,7 +144,7 @@ func TestPairwiseAnalysisFake(test *testing.T) {
 	}
 }
 
-func testPairwise(test *testing.T, ids []string, expected []*model.PairwiseAnalysis, expectedInitialCacheCount int) {
+func testPairwise(test *testing.T, ids []string, expected model.PairwiseAnalysisMap, expectedInitialCacheCount int) {
 	// Check for records in the DB.
 	queryKeys := make([]model.PairwiseKey, 0, len(expected))
 	for _, analysis := range expected {
@@ -423,22 +423,24 @@ func TestPairwiseAnalysisIncludeExclude(test *testing.T) {
 			continue
 		}
 
-		if testCase.expectedCount != len(results[0].Similarities) {
+		key := model.NewPairwiseKey(options.ResolvedSubmissionIDs[0], options.ResolvedSubmissionIDs[1])
+
+		if testCase.expectedCount != len(results[key].Similarities) {
 			test.Errorf("Case %d: Unexpected number of result similarities. Expected: %d, Actual: %d.",
-				i, testCase.expectedCount, len(results[0].Similarities))
+				i, testCase.expectedCount, len(results[key].Similarities))
 			continue
 		}
 
-		if (baseCount - testCase.expectedCount) != len(results[0].SkippedFiles) {
+		if (baseCount - testCase.expectedCount) != len(results[key].SkippedFiles) {
 			test.Errorf("Case %d: Unexpected number of skipped files. Expected: %d, Actual: %d.",
-				i, (baseCount - testCase.expectedCount), len(results[0].SkippedFiles))
+				i, (baseCount - testCase.expectedCount), len(results[key].SkippedFiles))
 			continue
 		}
 
 		if testCase.expectedCount == 0 {
-			if relpath != results[0].SkippedFiles[0] {
+			if relpath != results[key].SkippedFiles[0] {
 				test.Errorf("Case %d: Unexpected skipped file. Expected: '%s', Actual: '%s'.",
-					i, relpath, results[0].SkippedFiles[0])
+					i, relpath, results[key].SkippedFiles[0])
 			}
 		}
 	}
@@ -680,7 +682,9 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 
 		// Check if the result was from the cache using the start time.
 		if len(results) > 0 {
-			resultTime := results[0].AnalysisTimestamp
+			key := model.NewPairwiseKey(testCase.options.ResolvedSubmissionIDs[0], testCase.options.ResolvedSubmissionIDs[1])
+
+			resultTime := results[key].AnalysisTimestamp
 			resultIsFromCache := (resultTime <= startTime)
 
 			if testCase.expectedResultIsFromCache != resultIsFromCache {
@@ -760,11 +764,14 @@ func TestPairwiseAnalysisFailureBase(test *testing.T) {
 		test.Fatalf("Number of results not as expected. Expected: %d, Actual: %d.", 1, len(results))
 	}
 
-	if !results[0].Failure {
+	key := model.NewPairwiseKey(options.ResolvedSubmissionIDs[0], options.ResolvedSubmissionIDs[1])
+
+	if !results[key].Failure {
 		test.Fatalf("Result is not a failure, when it should be.")
 	}
 
-	if !strings.Contains(results[0].FailureMessage, expectedMessageSubstring) {
-		test.Fatalf("Failure message does not contain expected substring. Expected Substring: '%s', Actual: '%s'.", expectedMessageSubstring, results[0].FailureMessage)
+	if !strings.Contains(results[key].FailureMessage, expectedMessageSubstring) {
+		test.Fatalf("Failure message does not contain expected substring. Expected Substring: '%s', Actual: '%s'.",
+			expectedMessageSubstring, results[key].FailureMessage)
 	}
 }

--- a/internal/analysis/test.go
+++ b/internal/analysis/test.go
@@ -21,7 +21,7 @@ func (this *fakeSimiliartyEngine) IsAvailable() bool {
 	return true
 }
 
-func (this *fakeSimiliartyEngine) ComputeFileSimilarity(paths [2]string, templatePath string, ctx context.Context) (*model.FileSimilarity, int64, error) {
+func (this *fakeSimiliartyEngine) ComputeFileSimilarity(paths [2]string, templatePath string, ctx context.Context) (*model.FileSimilarity, error) {
 	similarity := model.FileSimilarity{
 		Filename: filepath.Base(paths[0]),
 		Tool:     this.GetName(),
@@ -29,7 +29,7 @@ func (this *fakeSimiliartyEngine) ComputeFileSimilarity(paths [2]string, templat
 		Score:    float64(len(filepath.Base(paths[0]))) / 100.0,
 	}
 
-	return &similarity, 1, nil
+	return &similarity, nil
 }
 
 func AddTestSubmissions(test *testing.T) {

--- a/internal/analysis/test.go
+++ b/internal/analysis/test.go
@@ -1,14 +1,9 @@
 package analysis
 
 import (
-	// TEST
-	"fmt"
-	"os"
-
 	"context"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/edulinq/autograder/internal/db"
 	"github.com/edulinq/autograder/internal/model"
@@ -33,10 +28,6 @@ func (this *fakeSimiliartyEngine) ComputeFileSimilarity(paths [2]string, templat
 		Version:  "0.0.1",
 		Score:    float64(len(filepath.Base(paths[0]))) / 100.0,
 	}
-
-	// Sleep for a small amount of time to differentiate from cached results.
-	fmt.Fprintf(os.Stderr, "sleeping...\n")
-	time.Sleep(time.Duration(500) * time.Millisecond)
 
 	return &similarity, nil
 }

--- a/internal/analysis/test.go
+++ b/internal/analysis/test.go
@@ -1,9 +1,14 @@
 package analysis
 
 import (
+	// TEST
+	"fmt"
+	"os"
+
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/edulinq/autograder/internal/db"
 	"github.com/edulinq/autograder/internal/model"
@@ -28,6 +33,10 @@ func (this *fakeSimiliartyEngine) ComputeFileSimilarity(paths [2]string, templat
 		Version:  "0.0.1",
 		Score:    float64(len(filepath.Base(paths[0]))) / 100.0,
 	}
+
+	// Sleep for a small amount of time to differentiate from cached results.
+	fmt.Fprintf(os.Stderr, "sleeping...\n")
+	time.Sleep(time.Duration(500) * time.Millisecond)
 
 	return &similarity, nil
 }

--- a/internal/api/core/describe.go
+++ b/internal/api/core/describe.go
@@ -50,8 +50,8 @@ type TypeDescription struct {
 	AliasType   string             `json:"alias-type,omitempty"`
 	Fields      []FieldDescription `json:"fields,omitempty"`
 	ElementType string             `json:"element-type,omitempty"`
-	KeyType     string             `json:"-"`
-	ValueType   string             `json:"-"`
+	KeyType     string             `json:"key-type,omitempty"`
+	ValueType   string             `json:"value-type,omitempty"`
 }
 
 type StructDescription map[string]string

--- a/internal/api/courses/assignments/submissions/analysis/individual.go
+++ b/internal/api/courses/assignments/submissions/analysis/individual.go
@@ -44,7 +44,7 @@ func HandleIndividual(request *IndividualRequest) (*IndividualResponse, *core.AP
 
 	request.ResolvedSubmissionIDs = fullSubmissionIDs
 	request.InitiatorEmail = request.ServerUser.Email
-	request.AnalysisOptions.JobOptions.Context = request.Context
+	request.AnalysisOptions.Context = request.APIRequestUserContext.Context
 
 	results, pendingCount, err := analysis.IndividualAnalysis(request.AnalysisOptions)
 	if err != nil {

--- a/internal/api/courses/assignments/submissions/analysis/individual.go
+++ b/internal/api/courses/assignments/submissions/analysis/individual.go
@@ -16,10 +16,10 @@ type IndividualRequest struct {
 }
 
 type IndividualResponse struct {
-	Complete bool                             `json:"complete"`
-	Options  analysis.AnalysisOptions         `json:"options"`
-	Summary  *model.IndividualAnalysisSummary `json:"summary"`
-	Results  []*model.IndividualAnalysis      `json:"results"`
+	Complete bool                                 `json:"complete"`
+	Options  analysis.AnalysisOptions             `json:"options"`
+	Summary  *model.IndividualAnalysisSummary     `json:"summary"`
+	Results  map[string]*model.IndividualAnalysis `json:"results"`
 }
 
 // Get the result of a individual analysis for the specified submissions.

--- a/internal/api/courses/assignments/submissions/analysis/individual.go
+++ b/internal/api/courses/assignments/submissions/analysis/individual.go
@@ -44,7 +44,7 @@ func HandleIndividual(request *IndividualRequest) (*IndividualResponse, *core.AP
 
 	request.ResolvedSubmissionIDs = fullSubmissionIDs
 	request.InitiatorEmail = request.ServerUser.Email
-	request.AnalysisOptions.Context = request.Context
+	request.AnalysisOptions.JobOptions.Context = request.Context
 
 	results, pendingCount, err := analysis.IndividualAnalysis(request.AnalysisOptions)
 	if err != nil {

--- a/internal/api/courses/assignments/submissions/analysis/individual_test.go
+++ b/internal/api/courses/assignments/submissions/analysis/individual_test.go
@@ -29,10 +29,8 @@ func TestIndividualBase(test *testing.T) {
 
 	email := "server-admin"
 	fields := map[string]any{
-		"submissions": submissions,
-		"job-options": &jobmanager.JobOptions{
-			WaitForCompletion: false,
-		},
+		"submissions":         submissions,
+		"wait-for-completion": false,
 	}
 
 	response := core.SendTestAPIRequestFull(test, `courses/assignments/submissions/analysis/individual`, fields, nil, email)
@@ -47,7 +45,7 @@ func TestIndividualBase(test *testing.T) {
 	expected := IndividualResponse{
 		Complete: false,
 		Options: analysis.AnalysisOptions{
-			JobOptions:         &jobmanager.JobOptions{},
+			JobOptions:         jobmanager.JobOptions{},
 			RawSubmissionSpecs: submissions,
 		},
 		Summary: &model.IndividualAnalysisSummary{
@@ -67,9 +65,7 @@ func TestIndividualBase(test *testing.T) {
 
 	// Make another request, but wait for the analysis.
 	time.Sleep(100 * time.Millisecond)
-	fields["job-options"] = &jobmanager.JobOptions{
-		WaitForCompletion: true,
-	}
+	fields["wait-for-completion"] = true
 
 	response = core.SendTestAPIRequestFull(test, `courses/assignments/submissions/analysis/individual`, fields, nil, email)
 	if !response.Success {
@@ -83,7 +79,7 @@ func TestIndividualBase(test *testing.T) {
 		Complete: true,
 		Options: analysis.AnalysisOptions{
 			RawSubmissionSpecs: submissions,
-			JobOptions: &jobmanager.JobOptions{
+			JobOptions: jobmanager.JobOptions{
 				WaitForCompletion: true,
 			},
 		},

--- a/internal/api/courses/assignments/submissions/analysis/individual_test.go
+++ b/internal/api/courses/assignments/submissions/analysis/individual_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/edulinq/autograder/internal/analysis"
 	"github.com/edulinq/autograder/internal/api/core"
 	"github.com/edulinq/autograder/internal/db"
+	"github.com/edulinq/autograder/internal/jobmanager"
 	"github.com/edulinq/autograder/internal/model"
 	"github.com/edulinq/autograder/internal/timestamp"
 	"github.com/edulinq/autograder/internal/util"
@@ -28,8 +29,10 @@ func TestIndividualBase(test *testing.T) {
 
 	email := "server-admin"
 	fields := map[string]any{
-		"submissions":         submissions,
-		"wait-for-completion": false,
+		"submissions": submissions,
+		"job-options": &jobmanager.JobOptions{
+			WaitForCompletion: false,
+		},
 	}
 
 	response := core.SendTestAPIRequestFull(test, `courses/assignments/submissions/analysis/individual`, fields, nil, email)
@@ -44,6 +47,7 @@ func TestIndividualBase(test *testing.T) {
 	expected := IndividualResponse{
 		Complete: false,
 		Options: analysis.AnalysisOptions{
+			JobOptions:         &jobmanager.JobOptions{},
 			RawSubmissionSpecs: submissions,
 		},
 		Summary: &model.IndividualAnalysisSummary{
@@ -63,7 +67,9 @@ func TestIndividualBase(test *testing.T) {
 
 	// Make another request, but wait for the analysis.
 	time.Sleep(100 * time.Millisecond)
-	fields["wait-for-completion"] = true
+	fields["job-options"] = &jobmanager.JobOptions{
+		WaitForCompletion: true,
+	}
 
 	response = core.SendTestAPIRequestFull(test, `courses/assignments/submissions/analysis/individual`, fields, nil, email)
 	if !response.Success {
@@ -77,7 +83,9 @@ func TestIndividualBase(test *testing.T) {
 		Complete: true,
 		Options: analysis.AnalysisOptions{
 			RawSubmissionSpecs: submissions,
-			WaitForCompletion:  true,
+			JobOptions: &jobmanager.JobOptions{
+				WaitForCompletion: true,
+			},
 		},
 		Summary: &model.IndividualAnalysisSummary{
 			AnalysisSummary: model.AnalysisSummary{

--- a/internal/api/courses/assignments/submissions/analysis/individual_test.go
+++ b/internal/api/courses/assignments/submissions/analysis/individual_test.go
@@ -55,7 +55,7 @@ func TestIndividualBase(test *testing.T) {
 				PendingCount:  2,
 			},
 		},
-		Results: []*model.IndividualAnalysis{},
+		Results: map[string]*model.IndividualAnalysis{},
 	}
 
 	if !reflect.DeepEqual(expected, responseContent) {
@@ -150,8 +150,8 @@ func TestIndividualBase(test *testing.T) {
 				},
 			},
 		},
-		Results: []*model.IndividualAnalysis{
-			&model.IndividualAnalysis{
+		Results: map[string]*model.IndividualAnalysis{
+			"course101::hw0::course-student@test.edulinq.org::1697406256": &model.IndividualAnalysis{
 				Options:             assignment.AssignmentAnalysisOptions,
 				AnalysisTimestamp:   timestamp.Zero(),
 				FullID:              "course101::hw0::course-student@test.edulinq.org::1697406256",
@@ -174,7 +174,7 @@ func TestIndividualBase(test *testing.T) {
 					},
 				},
 			},
-			&model.IndividualAnalysis{
+			"course101::hw0::course-student@test.edulinq.org::1697406265": &model.IndividualAnalysis{
 				Options:             assignment.AssignmentAnalysisOptions,
 				AnalysisTimestamp:   timestamp.Zero(),
 				FullID:              "course101::hw0::course-student@test.edulinq.org::1697406265",

--- a/internal/api/courses/assignments/submissions/analysis/pairwise.go
+++ b/internal/api/courses/assignments/submissions/analysis/pairwise.go
@@ -44,7 +44,7 @@ func HandlePairwise(request *PairwiseRequest) (*PairwiseResponse, *core.APIError
 
 	request.ResolvedSubmissionIDs = fullSubmissionIDs
 	request.InitiatorEmail = request.ServerUser.Email
-	request.AnalysisOptions.JobOptions.Context = request.Context
+	request.AnalysisOptions.Context = request.APIRequestUserContext.Context
 
 	results, pendingCount, err := analysis.PairwiseAnalysis(request.AnalysisOptions)
 	if err != nil {

--- a/internal/api/courses/assignments/submissions/analysis/pairwise.go
+++ b/internal/api/courses/assignments/submissions/analysis/pairwise.go
@@ -19,7 +19,7 @@ type PairwiseResponse struct {
 	Complete bool                           `json:"complete"`
 	Options  analysis.AnalysisOptions       `json:"options"`
 	Summary  *model.PairwiseAnalysisSummary `json:"summary"`
-	Results  []*model.PairwiseAnalysis      `json:"results"`
+	Results  model.PairwiseAnalysisMap      `json:"results"`
 }
 
 // Get the result of a pairwise analysis for the specified submissions.

--- a/internal/api/courses/assignments/submissions/analysis/pairwise.go
+++ b/internal/api/courses/assignments/submissions/analysis/pairwise.go
@@ -44,7 +44,7 @@ func HandlePairwise(request *PairwiseRequest) (*PairwiseResponse, *core.APIError
 
 	request.ResolvedSubmissionIDs = fullSubmissionIDs
 	request.InitiatorEmail = request.ServerUser.Email
-	request.AnalysisOptions.Context = request.Context
+	request.AnalysisOptions.JobOptions.Context = request.Context
 
 	results, pendingCount, err := analysis.PairwiseAnalysis(request.AnalysisOptions)
 	if err != nil {

--- a/internal/api/courses/assignments/submissions/analysis/pairwise_test.go
+++ b/internal/api/courses/assignments/submissions/analysis/pairwise_test.go
@@ -29,10 +29,8 @@ func TestPairwiseBase(test *testing.T) {
 
 	email := "server-admin"
 	fields := map[string]any{
-		"submissions": submissions,
-		"job-options": &jobmanager.JobOptions{
-			WaitForCompletion: false,
-		},
+		"submissions":         submissions,
+		"wait-for-completion": false,
 	}
 
 	response := core.SendTestAPIRequestFull(test, `courses/assignments/submissions/analysis/pairwise`, fields, nil, email)
@@ -47,7 +45,7 @@ func TestPairwiseBase(test *testing.T) {
 	expected := PairwiseResponse{
 		Complete: false,
 		Options: analysis.AnalysisOptions{
-			JobOptions:         &jobmanager.JobOptions{},
+			JobOptions:         jobmanager.JobOptions{},
 			RawSubmissionSpecs: submissions,
 		},
 		Summary: &model.PairwiseAnalysisSummary{
@@ -67,9 +65,7 @@ func TestPairwiseBase(test *testing.T) {
 
 	// Make another request, but wait for the analysis.
 	time.Sleep(100 * time.Millisecond)
-	fields["job-options"] = &jobmanager.JobOptions{
-		WaitForCompletion: true,
-	}
+	fields["wait-for-completion"] = true
 
 	response = core.SendTestAPIRequestFull(test, `courses/assignments/submissions/analysis/pairwise`, fields, nil, email)
 	if !response.Success {
@@ -83,7 +79,7 @@ func TestPairwiseBase(test *testing.T) {
 		Complete: true,
 		Options: analysis.AnalysisOptions{
 			RawSubmissionSpecs: submissions,
-			JobOptions: &jobmanager.JobOptions{
+			JobOptions: jobmanager.JobOptions{
 				WaitForCompletion: true,
 			},
 		},

--- a/internal/api/courses/assignments/submissions/analysis/pairwise_test.go
+++ b/internal/api/courses/assignments/submissions/analysis/pairwise_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/edulinq/autograder/internal/analysis"
 	"github.com/edulinq/autograder/internal/api/core"
 	"github.com/edulinq/autograder/internal/db"
+	"github.com/edulinq/autograder/internal/jobmanager"
 	"github.com/edulinq/autograder/internal/model"
 	"github.com/edulinq/autograder/internal/timestamp"
 	"github.com/edulinq/autograder/internal/util"
@@ -28,8 +29,10 @@ func TestPairwiseBase(test *testing.T) {
 
 	email := "server-admin"
 	fields := map[string]any{
-		"submissions":         submissions,
-		"wait-for-completion": false,
+		"submissions": submissions,
+		"job-options": &jobmanager.JobOptions{
+			WaitForCompletion: false,
+		},
 	}
 
 	response := core.SendTestAPIRequestFull(test, `courses/assignments/submissions/analysis/pairwise`, fields, nil, email)
@@ -44,6 +47,7 @@ func TestPairwiseBase(test *testing.T) {
 	expected := PairwiseResponse{
 		Complete: false,
 		Options: analysis.AnalysisOptions{
+			JobOptions:         &jobmanager.JobOptions{},
 			RawSubmissionSpecs: submissions,
 		},
 		Summary: &model.PairwiseAnalysisSummary{
@@ -63,7 +67,9 @@ func TestPairwiseBase(test *testing.T) {
 
 	// Make another request, but wait for the analysis.
 	time.Sleep(100 * time.Millisecond)
-	fields["wait-for-completion"] = true
+	fields["job-options"] = &jobmanager.JobOptions{
+		WaitForCompletion: true,
+	}
 
 	response = core.SendTestAPIRequestFull(test, `courses/assignments/submissions/analysis/pairwise`, fields, nil, email)
 	if !response.Success {
@@ -77,7 +83,9 @@ func TestPairwiseBase(test *testing.T) {
 		Complete: true,
 		Options: analysis.AnalysisOptions{
 			RawSubmissionSpecs: submissions,
-			WaitForCompletion:  true,
+			JobOptions: &jobmanager.JobOptions{
+				WaitForCompletion: true,
+			},
 		},
 		Summary: &model.PairwiseAnalysisSummary{
 			AnalysisSummary: model.AnalysisSummary{

--- a/internal/api/courses/assignments/submissions/analysis/pairwise_test.go
+++ b/internal/api/courses/assignments/submissions/analysis/pairwise_test.go
@@ -55,7 +55,7 @@ func TestPairwiseBase(test *testing.T) {
 				PendingCount:  1,
 			},
 		},
-		Results: []*model.PairwiseAnalysis{},
+		Results: model.PairwiseAnalysisMap{},
 	}
 
 	if !reflect.DeepEqual(expected, responseContent) {
@@ -73,6 +73,9 @@ func TestPairwiseBase(test *testing.T) {
 	}
 
 	util.MustJSONFromString(util.MustToJSON(response.Content), &responseContent)
+
+	submissionID1 := "course101::hw0::course-student@test.edulinq.org::1697406256"
+	submissionID2 := "course101::hw0::course-student@test.edulinq.org::1697406265"
 
 	// Second round should be complete.
 	expected = PairwiseResponse{
@@ -108,13 +111,13 @@ func TestPairwiseBase(test *testing.T) {
 				Max:    0.13,
 			},
 		},
-		Results: []*model.PairwiseAnalysis{
-			&model.PairwiseAnalysis{
+		Results: model.PairwiseAnalysisMap{
+			model.NewPairwiseKey(submissionID1, submissionID2): &model.PairwiseAnalysis{
 				Options:           assignment.AssignmentAnalysisOptions,
 				AnalysisTimestamp: timestamp.Zero(),
 				SubmissionIDs: model.NewPairwiseKey(
-					"course101::hw0::course-student@test.edulinq.org::1697406256",
-					"course101::hw0::course-student@test.edulinq.org::1697406265",
+					submissionID1,
+					submissionID2,
 				),
 				Similarities: map[string][]*model.FileSimilarity{
 					"submission.py": []*model.FileSimilarity{

--- a/internal/api/metadata/describe_test.go
+++ b/internal/api/metadata/describe_test.go
@@ -98,6 +98,14 @@ func TestMetadataDescribe(test *testing.T) {
 						Name: "fields",
 						Type: "[]core.FieldDescription",
 					},
+					{
+						Name: "key-type",
+						Type: "string",
+					},
+					{
+						Name: "value-type",
+						Type: "string",
+					},
 				},
 			},
 		},

--- a/internal/db/analysis.go
+++ b/internal/db/analysis.go
@@ -22,32 +22,6 @@ func GetPairwiseAnalysis(keys []model.PairwiseKey) (map[model.PairwiseKey]*model
 	return backend.GetPairwiseAnalysis(keys)
 }
 
-// Get a single individual analysis result.
-// If the id is not matched, return nil.
-func GetSingleIndividualAnalysis(fullSubmissionID string) (*model.IndividualAnalysis, bool, error) {
-	results, err := GetIndividualAnalysis([]string{fullSubmissionID})
-	if err != nil {
-		return nil, false, err
-	}
-
-	result, ok := results[fullSubmissionID]
-
-	return result, ok, nil
-}
-
-// Get a single pairwise analysis result.
-// If the key is not matched, return nil.
-func GetSinglePairwiseAnalysis(key model.PairwiseKey) (*model.PairwiseAnalysis, bool, error) {
-	results, err := GetPairwiseAnalysis([]model.PairwiseKey{key})
-	if err != nil {
-		return nil, false, err
-	}
-
-	result, ok := results[key]
-
-	return result, ok, nil
-}
-
 func RemoveIndividualAnalysis(fullSubmissionIDs []string) error {
 	if backend == nil {
 		return fmt.Errorf("Database has not been opened.")

--- a/internal/db/analysis.go
+++ b/internal/db/analysis.go
@@ -24,24 +24,28 @@ func GetPairwiseAnalysis(keys []model.PairwiseKey) (map[model.PairwiseKey]*model
 
 // Get a single individual analysis result.
 // If the id is not matched, return nil.
-func GetSingleIndividualAnalysis(fullSubmissionID string) (*model.IndividualAnalysis, error) {
+func GetSingleIndividualAnalysis(fullSubmissionID string) (*model.IndividualAnalysis, bool, error) {
 	results, err := GetIndividualAnalysis([]string{fullSubmissionID})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	return results[fullSubmissionID], nil
+	result, ok := results[fullSubmissionID]
+
+	return result, ok, nil
 }
 
 // Get a single pairwise analysis result.
 // If the key is not matched, return nil.
-func GetSinglePairwiseAnalysis(key model.PairwiseKey) (*model.PairwiseAnalysis, error) {
+func GetSinglePairwiseAnalysis(key model.PairwiseKey) (*model.PairwiseAnalysis, bool, error) {
 	results, err := GetPairwiseAnalysis([]model.PairwiseKey{key})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	return results[key], nil
+	result, ok := results[key]
+
+	return result, ok, nil
 }
 
 func RemoveIndividualAnalysis(fullSubmissionIDs []string) error {

--- a/internal/jobmanager/jobmanager.go
+++ b/internal/jobmanager/jobmanager.go
@@ -39,7 +39,7 @@ type JobOptions struct {
 // Provide an input key generation function to synchronize at the input item level.
 type Job[InputType any, OutputType any] struct {
 	// The user level options for a Job.
-	JobOptions
+	*JobOptions
 
 	// The current state of the output.
 	// Only access the state of the output when JobOutput.Done signals.
@@ -116,6 +116,11 @@ func (this *Job[InputType, OutputType]) validateFull(setChannel bool) error {
 		return fmt.Errorf("Job cannot have a nil work function.")
 	}
 
+	err := this.JobOptions.Validate()
+	if err != nil {
+		return err
+	}
+
 	if setChannel {
 		if this.done != nil {
 			return fmt.Errorf("Job is actively running and cannot be run again.")
@@ -131,7 +136,7 @@ func (this *Job[InputType, OutputType]) validateFull(setChannel bool) error {
 		return fmt.Errorf("Pool size must be positive, got %d.", this.PoolSize)
 	}
 
-	return this.JobOptions.Validate()
+	return nil
 }
 
 func (this *JobOptions) Validate() error {

--- a/internal/jobmanager/jobmanager.go
+++ b/internal/jobmanager/jobmanager.go
@@ -1,9 +1,6 @@
 package jobmanager
 
 import (
-	// TEST
-	"os"
-
 	"context"
 	"fmt"
 
@@ -346,8 +343,6 @@ func (this *Job[InputType, OutputType]) runParallelPoolMap(output *JobOutput[Inp
 		}
 
 		if this.Context.Err() != nil {
-			// TODO: select on done channel happens before returning canceled pool item?
-			fmt.Fprintf(os.Stderr, "returning a pool item from ctx cancellation: '%v'.\n", workItem)
 			return poolResult[InputType, OutputType]{
 				Input: workItem,
 			}, nil
@@ -381,7 +376,6 @@ func (this *Job[InputType, OutputType]) runParallelPoolMap(output *JobOutput[Inp
 		}
 
 		if this.Context.Err() != nil {
-			fmt.Fprintf(os.Stderr, "returning a pool item from ctx cancellation: '%v'.", workItem)
 			return poolResult[InputType, OutputType]{
 				Input: workItem,
 			}, nil

--- a/internal/jobmanager/jobmanager.go
+++ b/internal/jobmanager/jobmanager.go
@@ -52,6 +52,7 @@ type Job[InputType comparable, OutputType any] struct {
 	// Allow in progress workers to finish upon cancellation.
 	// After a cancellation, new work will not be started.
 	// A soft cancel should be used when cleaning up partial work is essential.
+	// TODO: Create an issue to add these features (soft and OnCancellation).
 	SoftCancel bool
 
 	// The number of workers in the parallel pool.
@@ -90,6 +91,7 @@ type Job[InputType comparable, OutputType any] struct {
 	// An optional function to clean up partial results after a cancellation.
 	// TODO: Could we just remove partial artifacts using remove func if soft cancel == true?
 	// TODO: flexibility vs ease of use
+	// Only used if SoftCancel is true.
 	OnCancellation func(JobOutput[InputType, OutputType])
 }
 

--- a/internal/jobmanager/jobmanager.go
+++ b/internal/jobmanager/jobmanager.go
@@ -1,0 +1,187 @@
+package jobmanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/edulinq/autograder/internal/lockmanager"
+	"github.com/edulinq/autograder/internal/log"
+	"github.com/edulinq/autograder/internal/util"
+)
+
+type JobOptions struct {
+	// Don't save anything.
+	DryRun bool `json:"dry-run"`
+
+	// Replace any entries currently in the cache,
+	// and do not return any cached entries (when not waiting for completion).
+	OverwriteCache bool `json:"overwrite-cache"`
+
+	// Wait for the entire job to complete and return all results.
+	WaitForCompletion bool `json:"wait-for-completion"`
+
+	// A context that can be used to cancel the job.
+	Context context.Context `json:"-"`
+
+	// If true, do not swap the context to the background context when running.
+	// By default (when this is false), the context will be swapped to the background context when !WaitForCompletion.
+	// The swap is so that jobs do not get canceled when an HTTP request is complete.
+	// Setting this true is useful for testing (as one round of job tests can be wrapped up).
+	RetainOriginalContext bool `json:"-"`
+
+	PoolSize int `json:"-"`
+
+	LockKey string `json:"-"`
+}
+
+func (this *JobOptions) Validate() error {
+	if this == nil {
+		return fmt.Errorf("Job options are nil.")
+	}
+
+	if this.LockKey == "" {
+		return fmt.Errorf("Cannot have an empty lock key.")
+	}
+
+	if this.PoolSize <= 0 {
+		return fmt.Errorf("Pool size must be positive, got %d.", this.PoolSize)
+	}
+
+	if this.Context == nil {
+		this.Context = context.Background()
+	}
+
+	if !this.WaitForCompletion && !this.RetainOriginalContext {
+		this.Context = context.Background()
+	}
+
+	return nil
+}
+
+// TODO: expand usage
+// Returns runtime, output, numRemaining, err
+func RunJob[InputType any, OutputType any](options *JobOptions, workItems []InputType, cacheFunc func([]InputType) ([]OutputType, []InputType, error), removeCacheFunc func([]InputType) error, workFunc func(InputType) (OutputType, int64, error)) ([]OutputType, int, int64, error) {
+	err := options.Validate()
+	if err != nil {
+		return []OutputType{}, len(workItems), 0, fmt.Errorf("Failed to validate job options: '%v'.", err)
+	}
+
+	completeItems := make([]OutputType, 0)
+	remainingItems := workItems
+
+	// If we are not overwriting the cache, query for cached results.
+	if !options.OverwriteCache && cacheFunc != nil {
+		completeItems, remainingItems, err = cacheFunc(workItems)
+		if err != nil {
+			return []OutputType{}, len(workItems), 0, err
+		}
+	}
+
+	runTime := int64(0)
+	results := make([]OutputType, 0)
+
+	if options.WaitForCompletion {
+		results, runTime, err = runJob(options, remainingItems, cacheFunc, removeCacheFunc, workFunc)
+		if err != nil {
+			return []OutputType{}, len(workItems), 0, err
+		}
+
+		completeItems = append(completeItems, results...)
+		remainingItems = nil
+	} else {
+		go func() {
+			_, _, err := runJob(options, remainingItems, cacheFunc, removeCacheFunc, workFunc)
+			if err != nil {
+				log.Error("Failure while running asynchronous job.")
+			}
+		}()
+	}
+
+	return completeItems, len(remainingItems), runTime, nil
+}
+
+func runJob[InputType any, OutputType any](options *JobOptions, workItems []InputType, cacheFunc func([]InputType) ([]OutputType, []InputType, error), removeCacheFunc func([]InputType) error, workFunc func(InputType) (OutputType, int64, error)) ([]OutputType, int64, error) {
+	if len(workItems) == 0 {
+		return nil, 0, nil
+	}
+
+	err := options.Validate()
+	if err != nil {
+		return []OutputType{}, 0, fmt.Errorf("Failed to validate job options: '%v'.", err)
+	}
+
+	noLockWait := lockmanager.Lock(options.LockKey)
+	defer lockmanager.Unlock(options.LockKey)
+
+	// The context has been canceled while waiting for a lock, abandon this job.
+	if options.Context.Err() != nil {
+		return nil, 0, nil
+	}
+
+	results := make([]OutputType, 0, len(workItems))
+
+	// If we had to wait for the lock, then check again for cached results.
+	// If there are multiple requests queued up,
+	// it will be faster to do a bulk check for cached results instead of checking each one individually.
+	if !noLockWait && cacheFunc != nil {
+		var partialResults []OutputType = nil
+		partialResults, workItems, err = cacheFunc(workItems)
+		if err != nil {
+			return nil, 0, fmt.Errorf("Failed to re-check result cache before run: '%w'.", err)
+		}
+
+		// Collect the partial results from the cache.
+		results = append(results, partialResults...)
+	}
+
+	if len(workItems) == 0 {
+		return results, 0, nil
+	}
+
+	// If we are overwriting the cache, then remove all the old entries.
+	if options.OverwriteCache && removeCacheFunc != nil && !options.DryRun {
+		err = removeCacheFunc(workItems)
+		if err != nil {
+			return nil, 0, fmt.Errorf("Failed to remove old job cache entries: '%w'.", err)
+		}
+	}
+
+	type PoolResult struct {
+		Result  OutputType
+		RunTime int64
+		Error   error
+	}
+
+	poolResults, _, err := util.RunParallelPoolMap(options.PoolSize, workItems, options.Context, func(workItem InputType) (PoolResult, error) {
+		result, runTime, err := workFunc(workItem)
+		if err != nil {
+			err = fmt.Errorf("Failed to perform individual work on item %v: '%w'.", workItem, err)
+		}
+
+		return PoolResult{result, runTime, err}, nil
+	})
+
+	if err != nil {
+		return nil, 0, fmt.Errorf("Failed to run job in a parallel pool: '%w'.", err)
+	}
+
+	// If the job was canceled, exit right away.
+	if options.Context.Err() != nil {
+		return nil, 0, nil
+	}
+
+	var errs error = nil
+	totalRunTime := int64(0)
+
+	for _, poolResult := range poolResults {
+		if poolResult.Error != nil {
+			errs = errors.Join(errs, poolResult.Error)
+		} else {
+			results = append(results, poolResult.Result)
+			totalRunTime += poolResult.RunTime
+		}
+	}
+
+	return results, totalRunTime, errs
+}

--- a/internal/jobmanager/jobmanager.go
+++ b/internal/jobmanager/jobmanager.go
@@ -54,6 +54,7 @@ type Job[InputType any, OutputType any] struct {
 	PoolSize int
 
 	// An optional key to lock on.
+	// TODO: Try again
 	// This locks at the job level whereas the function generates locks at the item level.
 	LockKey string
 
@@ -62,7 +63,7 @@ type Job[InputType any, OutputType any] struct {
 
 	// An optional function to retrieve existing records that should not be processed.
 	// Returns a list of processed records, remaining items, and an error.
-	// Utilize this function to reduce the amount of computation when previous results are stored in a cache.
+	// E.g. This function could be used to retrieve completed items from a cache.
 	RetrieveFunc func([]InputType) ([]OutputType, []InputType, error)
 
 	// An optional function to store the result.
@@ -229,6 +230,7 @@ func (this *Job[InputType, OutputType]) Run() *JobOutput[InputType, OutputType] 
 }
 
 // Job.run() processes the remaining items and updates the partial job output.
+// TODO: Reduce awkwardness
 // The updateOutput parameter signals if the output will be accessible outside of the scope of Run().
 // When the result is not needed, Job.run() will not update the result to reduce memory usage.
 // However, the run time and error will be updated for stats and logging purposes.
@@ -371,6 +373,8 @@ func (this *Job[InputType, OutputType]) run(output *JobOutput[InputType, OutputT
 			}
 		}
 	}
+
+	// TODO: Check if there are work errors, set job error to signal there are work errors.
 
 	if this.OnComplete != nil {
 		this.OnComplete(*output)

--- a/internal/jobmanager/jobmanager.go
+++ b/internal/jobmanager/jobmanager.go
@@ -290,7 +290,7 @@ func (this *Job[InputType, OutputType]) run(output *JobOutput[InputType, OutputT
 		return
 	}
 
-	poolResults, err := this.runParallelPoolMap(output)
+	poolResults, _, err := this.runParallelPoolMap(output)
 	if err != nil {
 		output.Error = fmt.Errorf("Failed to run job in a parallel pool: '%w'.", err)
 		return
@@ -329,8 +329,8 @@ func (this *Job[InputType, OutputType]) run(output *JobOutput[InputType, OutputT
 	}
 }
 
-func (this *Job[InputType, OutputType]) runParallelPoolMap(output *JobOutput[InputType, OutputType]) ([]poolResult[InputType, OutputType], error) {
-	poolResults, _, err := util.RunParallelPoolMap(this.PoolSize, output.RemainingItems, this.Context, func(workItem InputType) (poolResult[InputType, OutputType], error) {
+func (this *Job[InputType, OutputType]) runParallelPoolMap(output *JobOutput[InputType, OutputType]) ([]poolResult[InputType, OutputType], map[int]error, error) {
+	return util.RunParallelPoolMap(this.PoolSize, output.RemainingItems, this.Context, func(workItem InputType) (poolResult[InputType, OutputType], error) {
 		workItemKey := ""
 		if this.WorkItemKeyFunc != nil {
 			workItemKey = this.WorkItemKeyFunc(workItem)
@@ -396,8 +396,6 @@ func (this *Job[InputType, OutputType]) runParallelPoolMap(output *JobOutput[Inp
 
 		return poolResult[InputType, OutputType]{workItem, result, runTime, nil}, nil
 	})
-
-	return poolResults, err
 }
 
 func getRemainingItems[InputType comparable, OutputType any](workItems []InputType, results map[InputType]OutputType) []InputType {

--- a/internal/jobmanager/jobmanager.go
+++ b/internal/jobmanager/jobmanager.go
@@ -288,7 +288,6 @@ func (this *Job[InputType, OutputType]) run(output *JobOutput[InputType, OutputT
 		return
 	}
 
-	// If the job was canceled, return after collecting partial results.
 	if this.Context.Err() != nil {
 		output.Error = fmt.Errorf("Job was canceled: '%v'.", this.Context.Err())
 		output.Canceled = true

--- a/internal/jobmanager/jobmanager.go
+++ b/internal/jobmanager/jobmanager.go
@@ -270,8 +270,8 @@ func (this JobOutput[InputType, OutputType]) SetRunTime(runTime int64) {
 // Given a customized Job, Job.Run() processes input items in a parallel pool of workers.
 // Returns the collected results in a JobOutput.
 // If the context is canceled during execution, returns nil.
-// When not waiting for completion, Job.JobOutput will be populated with the results when the JobOutput.Done channel is closed.
-// When returning a copy of results, the Job.JobOutput can be accessed immediately but will not be populated with the final results.
+// When not waiting for completion, the JobOutput may still be modified until the Done channel is closed.
+// Returning a copy of results gives immediate access to stable results but the final results will not be accessible later.
 func (this *Job[InputType, OutputType]) Run() *JobOutput[InputType, OutputType] {
 	done := make(chan any)
 

--- a/internal/jobmanager/jobmanager.go
+++ b/internal/jobmanager/jobmanager.go
@@ -365,7 +365,9 @@ func (this *Job[InputType, OutputType]) runParallelPoolMap(output *JobOutput[Inp
 		return resultItem{result, runTime}, nil
 	})
 
-	// Return quickly upon cancellation.
+	output.RemainingItems = []InputType{}
+
+	// The job was canceled so return without collecting results.
 	if results.Canceled {
 		output.Canceled = true
 		return nil
@@ -373,7 +375,6 @@ func (this *Job[InputType, OutputType]) runParallelPoolMap(output *JobOutput[Inp
 
 	results.IsDone()
 
-	output.RemainingItems = []InputType{}
 	output.WorkErrors = results.WorkErrors
 
 	for input, result := range results.Results {

--- a/internal/jobmanager/jobmanager_test.go
+++ b/internal/jobmanager/jobmanager_test.go
@@ -745,8 +745,9 @@ func TestRunJobBase(test *testing.T) {
 			continue
 		}
 
-		// Set the done channel and job ID to pass the equality check.
-		testCase.finalOutput.Done = output.Done
+		// Clear channel and run time for comparison.
+		output.Done = nil
+		output.RunTime = 0
 
 		if !reflect.DeepEqual(output, testCase.finalOutput) {
 			test.Errorf("Case %d: Unexpected final results. Expected: '%s', actual: '%s'.",
@@ -761,6 +762,9 @@ func TestRunJobBase(test *testing.T) {
 				"BB": 2,
 			}
 		}
+
+		// Sleep to let the writes to the storage complete.
+		time.Sleep(time.Duration(2) * time.Millisecond)
 
 		if !reflect.DeepEqual(storage, testCase.expectedStorage) {
 			test.Errorf("Case %d: Unexpected storage results after final run. Expected: '%v', actual: '%v'.", i, testCase.expectedStorage, storage)

--- a/internal/jobmanager/jobmanager_test.go
+++ b/internal/jobmanager/jobmanager_test.go
@@ -1,0 +1,383 @@
+package jobmanager
+
+import (
+	"context"
+	// "fmt"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/edulinq/autograder/internal/util"
+)
+
+var testLockKey string = "test_key"
+var testPoolSize int = 1
+
+func TestJobOptionsValidateBase(test *testing.T) {
+	testCases := []struct {
+		input       *JobOptions
+		expected    *JobOptions
+		errorString string
+	}{
+		// Success
+
+		// No context provided
+		{
+			&JobOptions{
+				LockKey:  testLockKey,
+				PoolSize: testPoolSize,
+			},
+			&JobOptions{
+				Context:  context.Background(),
+				LockKey:  testLockKey,
+				PoolSize: testPoolSize,
+			},
+			"",
+		},
+		{
+			&JobOptions{
+				WaitForCompletion: true,
+				LockKey:           testLockKey,
+				PoolSize:          testPoolSize,
+			},
+			&JobOptions{
+				WaitForCompletion: true,
+				Context:           context.Background(),
+				LockKey:           testLockKey,
+				PoolSize:          testPoolSize,
+			},
+			"",
+		},
+		{
+			&JobOptions{
+				RetainOriginalContext: true,
+				LockKey:               testLockKey,
+				PoolSize:              testPoolSize,
+			},
+			&JobOptions{
+				RetainOriginalContext: true,
+				Context:               context.Background(),
+				LockKey:               testLockKey,
+				PoolSize:              testPoolSize,
+			},
+			"",
+		},
+		// Nil context provided
+		{
+			&JobOptions{
+				Context:  nil,
+				LockKey:  testLockKey,
+				PoolSize: testPoolSize,
+			},
+			&JobOptions{
+				Context:  context.Background(),
+				LockKey:  testLockKey,
+				PoolSize: testPoolSize,
+			},
+			"",
+		},
+		{
+			&JobOptions{
+				Context:           nil,
+				WaitForCompletion: true,
+				LockKey:           testLockKey,
+				PoolSize:          testPoolSize,
+			},
+			&JobOptions{
+				Context:           context.Background(),
+				WaitForCompletion: true,
+				LockKey:           testLockKey,
+				PoolSize:          testPoolSize,
+			},
+			"",
+		},
+		{
+			&JobOptions{
+				Context:               nil,
+				RetainOriginalContext: true,
+				LockKey:               testLockKey,
+				PoolSize:              testPoolSize,
+			},
+			&JobOptions{
+				Context:               context.Background(),
+				RetainOriginalContext: true,
+				LockKey:               testLockKey,
+				PoolSize:              testPoolSize,
+			},
+			"",
+		},
+		// Context provided
+		{
+			&JobOptions{
+				Context:  context.TODO(),
+				LockKey:  testLockKey,
+				PoolSize: testPoolSize,
+			},
+			&JobOptions{
+				Context:  context.Background(),
+				LockKey:  testLockKey,
+				PoolSize: testPoolSize,
+			},
+			"",
+		},
+		{
+			&JobOptions{
+				Context:           context.TODO(),
+				WaitForCompletion: true,
+				LockKey:           testLockKey,
+				PoolSize:          testPoolSize,
+			},
+			&JobOptions{
+				Context:           context.TODO(),
+				WaitForCompletion: true,
+				LockKey:           testLockKey,
+				PoolSize:          testPoolSize,
+			},
+			"",
+		},
+		{
+			&JobOptions{
+				Context:               context.TODO(),
+				RetainOriginalContext: true,
+				LockKey:               testLockKey,
+				PoolSize:              testPoolSize,
+			},
+			&JobOptions{
+				Context:               context.TODO(),
+				RetainOriginalContext: true,
+				LockKey:               testLockKey,
+				PoolSize:              testPoolSize,
+			},
+			"",
+		},
+
+		// Errors
+
+		// Nil
+		{
+			nil,
+			nil,
+			"Job options are nil.",
+		},
+		// Bad lock key
+		{
+			&JobOptions{},
+			nil,
+			"Cannot have an empty lock key.",
+		},
+		{
+			&JobOptions{
+				LockKey: "",
+			},
+			nil,
+			"Cannot have an empty lock key.",
+		},
+		// Bad pool size
+		{
+			&JobOptions{
+				LockKey: testLockKey,
+			},
+			nil,
+			"Pool size must be positive, got 0.",
+		},
+		{
+			&JobOptions{
+				LockKey:  testLockKey,
+				PoolSize: 0,
+			},
+			nil,
+			"Pool size must be positive, got 0.",
+		},
+		{
+			&JobOptions{
+				LockKey:  testLockKey,
+				PoolSize: -1,
+			},
+			nil,
+			"Pool size must be positive, got -1.",
+		},
+	}
+
+	for i, testCase := range testCases {
+		err := testCase.input.Validate()
+		if err != nil {
+			if testCase.errorString != "" {
+				if err.Error() != testCase.errorString {
+					test.Errorf("Case %d: Did not get expected error outpout. Expected substring '%s', actual error: '%v'.", i, testCase.errorString, err)
+				}
+			} else {
+				test.Errorf("Case %d: Failed to validate '%+v': '%v'.", i, testCase.input, err)
+			}
+
+			continue
+		}
+
+		if testCase.errorString != "" {
+			test.Errorf("Case %d: Did not get expected error: '%s'.", i, testCase.errorString)
+			continue
+		}
+
+		if !reflect.DeepEqual(testCase.expected, testCase.input) {
+			test.Errorf("Case %d: Unexpected result. Expected: '%+v', actual: '%+v'.",
+				i, testCase.expected, testCase.input)
+			continue
+		}
+	}
+}
+
+// TODO: Test caching functions and cache removal functions.
+func TestRunJobBase(test *testing.T) {
+	input := []string{
+		"A",
+		"BB",
+		"CCC",
+	}
+
+	finalExpected := []int{
+		1,
+		2,
+		3,
+	}
+
+	workFunc := func(input string) (int, int64, error) {
+		return len(input), int64(1), nil
+	}
+
+	testCases := []struct {
+		input       []string
+		output      []int
+		workFunc    func(input string) (int, int64, error)
+		errorString string
+	}{
+		// Success
+		{input, finalExpected, workFunc, ""},
+		{nil, []int{}, workFunc, ""},
+		{[]string{}, []int{}, workFunc, ""},
+
+		// Errors
+		{input, nil, nil, "Cannot run job with a nil work function."},
+		{nil, nil, nil, "Cannot run job with a nil work function."},
+	}
+
+	for i, testCase := range testCases {
+		options := &JobOptions{
+			LockKey:  testLockKey,
+			PoolSize: testPoolSize,
+		}
+
+		output, numRemaining, runTime, err := RunJob(options, testCase.input, nil, nil, testCase.workFunc)
+		if err != nil {
+			if testCase.errorString != "" {
+				if err.Error() != testCase.errorString {
+					test.Errorf("Case %d: Did not get expected error outpout. Expected substring '%s', actual error: '%v'.", i, testCase.errorString, err)
+				}
+			} else {
+				test.Errorf("Case %d: Failed to run initial job: '%v'.", i, err)
+			}
+
+			continue
+		}
+
+		if testCase.errorString != "" {
+			test.Errorf("Case %d: Did not get expected error: '%s'.", i, testCase.errorString)
+			continue
+		}
+
+		if len(output) != 0 {
+			test.Errorf("Case %d: Unexpected number of initial results. Expected: '0', actual: '%d'.", i, len(output))
+			continue
+		}
+
+		if numRemaining != len(testCase.input) {
+			test.Errorf("Case %d: Unexpected number of initial items remaining. Expected: '%d', actual: '%d'.", i, len(testCase.input), numRemaining)
+			continue
+		}
+
+		if runTime != 0 {
+			test.Errorf("Case %d: Unexpected initial run time. Expected: '0', actual: '%d'.", i, runTime)
+			continue
+		}
+
+		options.WaitForCompletion = true
+
+		output, numRemaining, runTime, err = RunJob(options, testCase.input, nil, nil, testCase.workFunc)
+		if err != nil {
+			test.Errorf("Case %d: Failed to run final job: '%v'.", i, err)
+			continue
+		}
+
+		if numRemaining != 0 {
+			test.Errorf("Case %d: Unexpected number of final items remaining. Expected: '0', actual: '%d'.", i, numRemaining)
+			continue
+		}
+
+		expectedRunTime := int64(len(testCase.input))
+		if runTime != expectedRunTime {
+			test.Errorf("Case %d: Unexpected final run time. Expected: '%d', actual: '%d'.", i, expectedRunTime, runTime)
+			continue
+		}
+
+		if !reflect.DeepEqual(testCase.output, output) {
+			test.Errorf("Case %d: Unexpected final results. Expected: '%s', actual: '%s'.",
+				i, util.MustToJSONIndent(testCase.output), util.MustToJSONIndent(output))
+			continue
+		}
+	}
+}
+
+func TestRunJobCancel(test *testing.T) {
+	input := []string{
+		"A",
+		"BB",
+		"CCC",
+	}
+
+	// Block until the first worker has started.
+	workWaitGroup := sync.WaitGroup{}
+	workWaitGroup.Add(1)
+
+	workFunc := func(input string) (int, int64, error) {
+		// Signal on the first piece of work that we can make sure the workers have started up before we cancel.
+		if input == "A" {
+			workWaitGroup.Done()
+		}
+
+		// Sleep for a really long time (for a test).
+		time.Sleep(1 * time.Hour)
+
+		return len(input), int64(1), nil
+	}
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+
+	options := &JobOptions{
+		Context:           ctx,
+		WaitForCompletion: true,
+		LockKey:           testLockKey,
+		PoolSize:          testPoolSize,
+	}
+
+	// Cancel the context as soon as the first worker signals it.
+	go func() {
+		workWaitGroup.Wait()
+		cancelFunc()
+	}()
+
+	output, numRemaining, runTime, err := RunJob(options, input, nil, nil, workFunc)
+	if err != nil {
+		test.Fatalf("Got an unexpected error: '%v'.", err)
+	}
+
+	if output != nil {
+		test.Fatalf("Got a result when it should have been nil.")
+	}
+
+	if numRemaining != 0 {
+		test.Fatalf("Got jobs remaining when it should be 0.")
+	}
+
+	if runTime != 0 {
+		test.Fatalf("Got run time when it should be 0.")
+	}
+}

--- a/internal/jobmanager/jobmanager_test.go
+++ b/internal/jobmanager/jobmanager_test.go
@@ -15,8 +15,11 @@ import (
 var testLockKey string = "test_key"
 var testPoolSize int = 1
 
-var workFunc = func(input string) (int, int64, error) {
-	return len(input), int64(1), nil
+var workFunc = func(input string) (int, error) {
+	// Sleep for a millisecond so there is run time.
+	time.Sleep(1 * time.Millisecond)
+
+	return len(input), nil
 }
 
 func TestJobValidateBase(test *testing.T) {
@@ -30,18 +33,17 @@ func TestJobValidateBase(test *testing.T) {
 		// No Context Provided
 		{
 			&Job[string, int]{
-				WorkFunc: workFunc,
-				JobOptions: JobOptions{
-					PoolSize: testPoolSize,
-					LockKey:  testLockKey,
-				},
+				WorkFunc:   workFunc,
+				PoolSize:   testPoolSize,
+				LockKey:    testLockKey,
+				JobOptions: JobOptions{},
 			},
 			&Job[string, int]{
 				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
 				JobOptions: JobOptions{
-					Context:  context.Background(),
-					PoolSize: testPoolSize,
-					LockKey:  testLockKey,
+					Context: context.Background(),
 				},
 			},
 			"",
@@ -49,19 +51,19 @@ func TestJobValidateBase(test *testing.T) {
 		{
 			&Job[string, int]{
 				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
 				JobOptions: JobOptions{
 					WaitForCompletion: true,
-					PoolSize:          testPoolSize,
-					LockKey:           testLockKey,
 				},
 			},
 			&Job[string, int]{
 				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
 				JobOptions: JobOptions{
 					Context:           context.Background(),
 					WaitForCompletion: true,
-					PoolSize:          testPoolSize,
-					LockKey:           testLockKey,
 				},
 			},
 			"",
@@ -69,19 +71,19 @@ func TestJobValidateBase(test *testing.T) {
 		{
 			&Job[string, int]{
 				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
 				JobOptions: JobOptions{
 					RetainOriginalContext: true,
-					PoolSize:              testPoolSize,
-					LockKey:               testLockKey,
 				},
 			},
 			&Job[string, int]{
 				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
 				JobOptions: JobOptions{
 					Context:               context.Background(),
 					RetainOriginalContext: true,
-					PoolSize:              testPoolSize,
-					LockKey:               testLockKey,
 				},
 			},
 			"",
@@ -90,18 +92,18 @@ func TestJobValidateBase(test *testing.T) {
 		{
 			&Job[string, int]{
 				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
 				JobOptions: JobOptions{
-					Context:  nil,
-					PoolSize: testPoolSize,
-					LockKey:  testLockKey,
+					Context: nil,
 				},
 			},
 			&Job[string, int]{
 				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
 				JobOptions: JobOptions{
-					Context:  context.Background(),
-					PoolSize: testPoolSize,
-					LockKey:  testLockKey,
+					Context: context.Background(),
 				},
 			},
 			"",
@@ -109,20 +111,20 @@ func TestJobValidateBase(test *testing.T) {
 		{
 			&Job[string, int]{
 				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
 				JobOptions: JobOptions{
 					Context:           nil,
 					WaitForCompletion: true,
-					PoolSize:          testPoolSize,
-					LockKey:           testLockKey,
 				},
 			},
 			&Job[string, int]{
 				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
 				JobOptions: JobOptions{
 					Context:           context.Background(),
 					WaitForCompletion: true,
-					PoolSize:          testPoolSize,
-					LockKey:           testLockKey,
 				},
 			},
 			"",
@@ -130,20 +132,20 @@ func TestJobValidateBase(test *testing.T) {
 		{
 			&Job[string, int]{
 				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
 				JobOptions: JobOptions{
 					Context:               nil,
 					RetainOriginalContext: true,
-					PoolSize:              testPoolSize,
-					LockKey:               testLockKey,
 				},
 			},
 			&Job[string, int]{
 				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
 				JobOptions: JobOptions{
 					Context:               context.Background(),
 					RetainOriginalContext: true,
-					PoolSize:              testPoolSize,
-					LockKey:               testLockKey,
 				},
 			},
 			"",
@@ -152,19 +154,19 @@ func TestJobValidateBase(test *testing.T) {
 		{
 			&Job[string, int]{
 				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
 				JobOptions: JobOptions{
-					Context:  context.TODO(),
-					PoolSize: testPoolSize,
-					LockKey:  testLockKey,
+					Context: context.TODO(),
 				},
 			},
 			&Job[string, int]{
 				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
 				JobOptions: JobOptions{
 					// Swap the context to background when not waiting for completion.
-					Context:  context.Background(),
-					PoolSize: testPoolSize,
-					LockKey:  testLockKey,
+					Context: context.Background(),
 				},
 			},
 			"",
@@ -172,20 +174,20 @@ func TestJobValidateBase(test *testing.T) {
 		{
 			&Job[string, int]{
 				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
 				JobOptions: JobOptions{
 					Context:           context.TODO(),
 					WaitForCompletion: true,
-					PoolSize:          testPoolSize,
-					LockKey:           testLockKey,
 				},
 			},
 			&Job[string, int]{
 				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
 				JobOptions: JobOptions{
 					Context:           context.TODO(),
 					WaitForCompletion: true,
-					PoolSize:          testPoolSize,
-					LockKey:           testLockKey,
 				},
 			},
 			"",
@@ -193,20 +195,20 @@ func TestJobValidateBase(test *testing.T) {
 		{
 			&Job[string, int]{
 				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
 				JobOptions: JobOptions{
 					Context:               context.TODO(),
 					RetainOriginalContext: true,
-					PoolSize:              testPoolSize,
-					LockKey:               testLockKey,
 				},
 			},
 			&Job[string, int]{
 				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
 				JobOptions: JobOptions{
 					Context:               context.TODO(),
 					RetainOriginalContext: true,
-					PoolSize:              testPoolSize,
-					LockKey:               testLockKey,
 				},
 			},
 			"",
@@ -244,9 +246,7 @@ func TestJobValidateBase(test *testing.T) {
 		{
 			&Job[string, int]{
 				WorkFunc: workFunc,
-				JobOptions: JobOptions{
-					PoolSize: 0,
-				},
+				PoolSize: 0,
 			},
 			nil,
 			"Pool size must be positive, got 0.",
@@ -254,9 +254,7 @@ func TestJobValidateBase(test *testing.T) {
 		{
 			&Job[string, int]{
 				WorkFunc: workFunc,
-				JobOptions: JobOptions{
-					PoolSize: -1,
-				},
+				PoolSize: -1,
 			},
 			nil,
 			"Pool size must be positive, got -1.",
@@ -283,7 +281,7 @@ func TestJobValidateBase(test *testing.T) {
 		}
 
 		if testCase.input.WorkFunc == nil {
-			test.Errorf("Case %d: Found non nil work func.", i)
+			test.Errorf("Case %d: Found a nil work func after validation.", i)
 			continue
 		}
 
@@ -314,8 +312,9 @@ func TestRunJobBase(test *testing.T) {
 
 	storage := resetStorage()
 
-	retrieveFunc := func(inputs []string) ([]int, []string, error) {
+	retrieveFunc := func(inputs []string) ([]int, []string, []string, error) {
 		outputs := make([]int, 0, len(storage))
+		complete := make([]string, 0, len(storage))
 		remaining := make([]string, 0, len(inputs))
 
 		for _, input := range inputs {
@@ -326,13 +325,14 @@ func TestRunJobBase(test *testing.T) {
 			}
 
 			outputs = append(outputs, output)
+			complete = append(complete, input)
 		}
 
-		return outputs, remaining, nil
+		return outputs, complete, remaining, nil
 	}
 
-	errorRetrieveFunc := func(_ []string) ([]int, []string, error) {
-		return nil, nil, fmt.Errorf("Crazy retrieval error!")
+	errorRetrieveFunc := func(_ []string) ([]int, []string, []string, error) {
+		return nil, nil, nil, fmt.Errorf("Crazy retrieval error!")
 	}
 
 	removeStorageFunc := func(inputs []string) error {
@@ -347,10 +347,13 @@ func TestRunJobBase(test *testing.T) {
 		return fmt.Errorf("Insane storage removal error!")
 	}
 
-	workFuncWithStorage := func(input string) (int, int64, error) {
+	workFuncWithStorage := func(input string) (int, error) {
 		storage[input] = len(input)
 
-		return len(input), int64(1), nil
+		// Sleep for a millisecond so there is run time.
+		time.Sleep(1 * time.Millisecond)
+
+		return len(input), nil
 	}
 
 	testCases := []struct {
@@ -370,62 +373,65 @@ func TestRunJobBase(test *testing.T) {
 		// Base Options
 		{
 			job: Job[string, int]{
-				WorkItems: input,
-				WorkFunc:  workFunc,
-				JobOptions: JobOptions{
-					PoolSize: testPoolSize,
-					LockKey:  testLockKey,
-				},
+				WorkItems:  input,
+				WorkFunc:   workFunc,
+				PoolSize:   testPoolSize,
+				LockKey:    testLockKey,
+				JobOptions: JobOptions{},
 			},
 			initialOutput: JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: input,
 				RunTime:        int64(0),
+				WorkErrors:     map[int]error{},
 			},
 			finalOutput: JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
 				RunTime:        int64(len(input)),
+				WorkErrors:     map[int]error{},
 			},
 		},
 		{
 			job: Job[string, int]{
-				WorkItems: nil,
-				WorkFunc:  workFunc,
-				JobOptions: JobOptions{
-					PoolSize: testPoolSize,
-					LockKey:  testLockKey,
-				},
+				WorkItems:  nil,
+				WorkFunc:   workFunc,
+				PoolSize:   testPoolSize,
+				LockKey:    testLockKey,
+				JobOptions: JobOptions{},
 			},
 			initialOutput: JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: nil,
 				RunTime:        int64(0),
+				WorkErrors:     map[int]error{},
 			},
 			finalOutput: JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: nil,
 				RunTime:        int64(0),
+				WorkErrors:     map[int]error{},
 			},
 		},
 		{
 			job: Job[string, int]{
-				WorkItems: []string{},
-				WorkFunc:  workFunc,
-				JobOptions: JobOptions{
-					PoolSize: testPoolSize,
-					LockKey:  testLockKey,
-				},
+				WorkItems:  []string{},
+				WorkFunc:   workFunc,
+				PoolSize:   testPoolSize,
+				LockKey:    testLockKey,
+				JobOptions: JobOptions{},
 			},
 			initialOutput: JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: []string{},
 				RunTime:        int64(0),
+				WorkErrors:     map[int]error{},
 			},
 			finalOutput: JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: []string{},
 				RunTime:        int64(0),
+				WorkErrors:     map[int]error{},
 			},
 		},
 
@@ -434,66 +440,71 @@ func TestRunJobBase(test *testing.T) {
 			job: Job[string, int]{
 				WorkItems:    input,
 				WorkFunc:     workFunc,
+				PoolSize:     testPoolSize,
+				LockKey:      testLockKey,
 				RetrieveFunc: retrieveFunc,
-				JobOptions: JobOptions{
-					PoolSize: testPoolSize,
-					LockKey:  testLockKey,
-				},
+				JobOptions:   JobOptions{},
 			},
 			initialOutput: JobOutput[string, int]{
 				ResultItems:    []int{1, 2},
 				RemainingItems: []string{"CCC"},
 				RunTime:        int64(0),
+				WorkErrors:     map[int]error{},
 			},
 			finalOutput: JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
 				RunTime:        int64(1),
+				WorkErrors:     map[int]error{},
 			},
 		},
 		{
 			job: Job[string, int]{
 				WorkItems:    input,
 				WorkFunc:     workFunc,
+				PoolSize:     testPoolSize,
+				LockKey:      testLockKey,
 				RetrieveFunc: retrieveFunc,
 				JobOptions: JobOptions{
 					OverwriteRecords: true,
-					PoolSize:         testPoolSize,
-					LockKey:          testLockKey,
 				},
 			},
 			initialOutput: JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: input,
 				RunTime:        int64(0),
+				WorkErrors:     map[int]error{},
 			},
 			finalOutput: JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
 				RunTime:        int64(len(input)),
+				WorkErrors:     map[int]error{},
 			},
 		},
 		{
 			job: Job[string, int]{
 				WorkItems: input,
 				WorkFunc:  workFunc,
+				PoolSize:  testPoolSize,
+				LockKey:   testLockKey,
 				// Won't cause an error because it won't be called.
 				RetrieveFunc: errorRetrieveFunc,
 				JobOptions: JobOptions{
 					OverwriteRecords: true,
-					PoolSize:         testPoolSize,
-					LockKey:          testLockKey,
 				},
 			},
 			initialOutput: JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: input,
 				RunTime:        int64(0),
+				WorkErrors:     map[int]error{},
 			},
 			finalOutput: JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
 				RunTime:        int64(len(input)),
+				WorkErrors:     map[int]error{},
 			},
 		},
 
@@ -502,43 +513,45 @@ func TestRunJobBase(test *testing.T) {
 			job: Job[string, int]{
 				WorkItems:         input,
 				WorkFunc:          workFunc,
+				PoolSize:          testPoolSize,
+				LockKey:           testLockKey,
 				RemoveStorageFunc: removeStorageFunc,
-				JobOptions: JobOptions{
-					PoolSize: testPoolSize,
-					LockKey:  testLockKey,
-				},
+				JobOptions:        JobOptions{},
 			},
 			initialOutput: JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: input,
 				RunTime:        int64(0),
+				WorkErrors:     map[int]error{},
 			},
 			finalOutput: JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
 				RunTime:        int64(len(input)),
+				WorkErrors:     map[int]error{},
 			},
 		},
 		{
 			job: Job[string, int]{
 				WorkItems: input,
 				WorkFunc:  workFunc,
+				PoolSize:  testPoolSize,
+				LockKey:   testLockKey,
 				// Won't cause an error because it won't be called.
 				RemoveStorageFunc: errorRemoveStorageFunc,
-				JobOptions: JobOptions{
-					PoolSize: testPoolSize,
-					LockKey:  testLockKey,
-				},
+				JobOptions:        JobOptions{},
 			},
 			initialOutput: JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: input,
 				RunTime:        int64(0),
+				WorkErrors:     map[int]error{},
 			},
 			finalOutput: JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
 				RunTime:        int64(len(input)),
+				WorkErrors:     map[int]error{},
 			},
 		},
 
@@ -547,45 +560,48 @@ func TestRunJobBase(test *testing.T) {
 			job: Job[string, int]{
 				WorkItems:         input,
 				WorkFunc:          workFunc,
+				PoolSize:          testPoolSize,
+				LockKey:           testLockKey,
 				RetrieveFunc:      retrieveFunc,
 				RemoveStorageFunc: removeStorageFunc,
-				JobOptions: JobOptions{
-					PoolSize: testPoolSize,
-					LockKey:  testLockKey,
-				},
+				JobOptions:        JobOptions{},
 			},
 			initialOutput: JobOutput[string, int]{
 				ResultItems:    []int{1, 2},
 				RemainingItems: []string{"CCC"},
 				RunTime:        int64(0),
+				WorkErrors:     map[int]error{},
 			},
 			finalOutput: JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
 				RunTime:        int64(1),
+				WorkErrors:     map[int]error{},
 			},
 		},
 		{
 			job: Job[string, int]{
 				WorkItems:         input,
 				WorkFunc:          workFunc,
+				PoolSize:          testPoolSize,
+				LockKey:           testLockKey,
 				RetrieveFunc:      retrieveFunc,
 				RemoveStorageFunc: removeStorageFunc,
 				JobOptions: JobOptions{
 					OverwriteRecords: true,
-					PoolSize:         testPoolSize,
-					LockKey:          testLockKey,
 				},
 			},
 			initialOutput: JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: input,
 				RunTime:        int64(0),
+				WorkErrors:     map[int]error{},
 			},
 			finalOutput: JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
 				RunTime:        int64(len(input)),
+				WorkErrors:     map[int]error{},
 			},
 			resetStorage:      true,
 			checkEmptyStorage: true,
@@ -594,22 +610,23 @@ func TestRunJobBase(test *testing.T) {
 			job: Job[string, int]{
 				WorkItems:         input,
 				WorkFunc:          workFuncWithStorage,
+				PoolSize:          testPoolSize,
+				LockKey:           testLockKey,
 				RetrieveFunc:      retrieveFunc,
 				RemoveStorageFunc: removeStorageFunc,
-				JobOptions: JobOptions{
-					PoolSize: testPoolSize,
-					LockKey:  testLockKey,
-				},
+				JobOptions:        JobOptions{},
 			},
 			initialOutput: JobOutput[string, int]{
 				ResultItems:    []int{1, 2},
 				RemainingItems: []string{"CCC"},
 				RunTime:        int64(0),
+				WorkErrors:     map[int]error{},
 			},
 			finalOutput: JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
 				RunTime:        int64(1),
+				WorkErrors:     map[int]error{},
 			},
 			resetStorage: true,
 		},
@@ -617,23 +634,25 @@ func TestRunJobBase(test *testing.T) {
 			job: Job[string, int]{
 				WorkItems:         input,
 				WorkFunc:          workFuncWithStorage,
+				PoolSize:          testPoolSize,
+				LockKey:           testLockKey,
 				RetrieveFunc:      retrieveFunc,
 				RemoveStorageFunc: removeStorageFunc,
 				JobOptions: JobOptions{
 					OverwriteRecords: true,
-					PoolSize:         testPoolSize,
-					LockKey:          testLockKey,
 				},
 			},
 			initialOutput: JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: input,
 				RunTime:        int64(0),
+				WorkErrors:     map[int]error{},
 			},
 			finalOutput: JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
 				RunTime:        int64(len(input)),
+				WorkErrors:     map[int]error{},
 			},
 			resetStorage:      true,
 			checkEmptyStorage: true,
@@ -662,10 +681,10 @@ func TestRunJobBase(test *testing.T) {
 			job: Job[string, int]{
 				WorkItems:    input,
 				WorkFunc:     workFunc,
+				PoolSize:     testPoolSize,
+				LockKey:      testLockKey,
 				RetrieveFunc: errorRetrieveFunc,
-				JobOptions: JobOptions{
-					PoolSize: testPoolSize,
-				},
+				JobOptions:   JobOptions{},
 			},
 			initialErrorSubstring: "Crazy retrieval error!",
 		},
@@ -675,16 +694,18 @@ func TestRunJobBase(test *testing.T) {
 			job: Job[string, int]{
 				WorkItems:         input,
 				WorkFunc:          workFunc,
+				PoolSize:          testPoolSize,
+				LockKey:           testLockKey,
 				RemoveStorageFunc: errorRemoveStorageFunc,
 				JobOptions: JobOptions{
 					OverwriteRecords: true,
-					PoolSize:         testPoolSize,
 				},
 			},
 			initialOutput: JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: input,
 				RunTime:        int64(0),
+				WorkErrors:     map[int]error{},
 			},
 			finalErrorSubstring: "Insane storage removal error!",
 		},
@@ -713,6 +734,24 @@ func TestRunJobBase(test *testing.T) {
 
 		// Set the done channel to pass the equality check.
 		testCase.initialOutput.Done = output.Done
+		// Check for exact matches when we expect no run time.
+		if testCase.initialOutput.RunTime == 0 {
+			if testCase.initialOutput.RunTime != output.RunTime {
+				test.Errorf("Case %d: Unexpected run time. Expected: '%d', actual: '%d'.", i, testCase.initialOutput.RunTime, output.RunTime)
+				continue
+			}
+		} else {
+			// Non-zero expected run time is a minimum threshold due to variable overhead.
+			if output.RunTime < testCase.initialOutput.RunTime {
+				test.Errorf("Case %d: Unexpected run time. Expected a minimum run time of: '%d', actual: '%d'.",
+					i, testCase.initialOutput.RunTime, output.RunTime)
+				continue
+			}
+		}
+
+		// Zero out run time for future equality checks.
+		testCase.initialOutput.RunTime = 0
+		output.RunTime = 0
 
 		if !reflect.DeepEqual(output, testCase.initialOutput) {
 			test.Errorf("Case %d: Unexpected initial results. Expected: '%s', actual: '%s'.",
@@ -742,6 +781,24 @@ func TestRunJobBase(test *testing.T) {
 
 		// Set the done channel to pass the equality check.
 		testCase.finalOutput.Done = output.Done
+		// Check for exact matches when we expect no run time.
+		if testCase.finalOutput.RunTime == 0 {
+			if testCase.finalOutput.RunTime != output.RunTime {
+				test.Errorf("Case %d: Unexpected run time. Expected: '%d', actual: '%d'.", i, testCase.finalOutput.RunTime, output.RunTime)
+				continue
+			}
+		} else {
+			// Non-zero expected run time is a minimum threshold due to variable overhead.
+			if output.RunTime < testCase.finalOutput.RunTime {
+				test.Errorf("Case %d: Unexpected run time. Expected a minimum run time of: '%d', actual: '%d'.",
+					i, testCase.finalOutput.RunTime, output.RunTime)
+				continue
+			}
+		}
+
+		// Zero out run time for future equality checks.
+		testCase.finalOutput.RunTime = 0
+		output.RunTime = 0
 
 		if !reflect.DeepEqual(output, testCase.finalOutput) {
 			test.Errorf("Case %d: Unexpected final results. Expected: '%s', actual: '%s'.",
@@ -770,6 +827,7 @@ func TestRunJobBase(test *testing.T) {
 					ResultItems:    []int{},
 					RemainingItems: input,
 					RunTime:        int64(0),
+					WorkErrors:     map[int]error{},
 					// Set the done channel to pass the equality check.
 					Done: output.Done,
 				}
@@ -797,7 +855,7 @@ func TestRunJobCancel(test *testing.T) {
 	workWaitGroup := sync.WaitGroup{}
 	workWaitGroup.Add(1)
 
-	sleepWorkFunc := func(input string) (int, int64, error) {
+	sleepWorkFunc := func(input string) (int, error) {
 		// Signal on the initial piece of work that we can make sure the workers have started up before we cancel.
 		if input == "A" {
 			workWaitGroup.Done()
@@ -806,7 +864,7 @@ func TestRunJobCancel(test *testing.T) {
 		// Sleep for a really long time (for a test).
 		time.Sleep(1 * time.Hour)
 
-		return len(input), int64(1), nil
+		return len(input), nil
 	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
@@ -814,11 +872,11 @@ func TestRunJobCancel(test *testing.T) {
 	job := &Job[string, int]{
 		WorkItems: input,
 		WorkFunc:  sleepWorkFunc,
+		PoolSize:  testPoolSize,
+		LockKey:   testLockKey,
 		JobOptions: JobOptions{
 			Context:           ctx,
 			WaitForCompletion: true,
-			PoolSize:          testPoolSize,
-			LockKey:           testLockKey,
 		},
 	}
 
@@ -849,12 +907,14 @@ func TestRunJobChannel(test *testing.T) {
 	job := &Job[string, int]{
 		WorkItems: input,
 		WorkFunc:  workFunc,
+		PoolSize:  testPoolSize,
+		LockKey:   testLockKey,
 		JobOptions: JobOptions{
 			WaitForCompletion: false,
-			PoolSize:          testPoolSize,
-			LockKey:           testLockKey,
 		},
 	}
+
+	test.Fatalf("test: '%s'.", util.MustToJSONIndent(job))
 
 	output, err := job.Run()
 	if err != nil {
@@ -868,8 +928,18 @@ func TestRunJobChannel(test *testing.T) {
 		ResultItems:    []int{1, 2, 3},
 		RemainingItems: []string{},
 		RunTime:        int64(len(input)),
+		WorkErrors:     map[int]error{},
 		Done:           job.Done,
 	}
+
+	// Non-zero expected run time is a minimum threshold due to variable overhead.
+	if job.RunTime < expected.RunTime {
+		test.Fatalf("Unexpected run time. Expected a minimum run time of: '%d', actual: '%d'.", expected.RunTime, job.RunTime)
+	}
+
+	// Zero out run time for future equality checks.
+	expected.RunTime = 0
+	job.RunTime = 0
 
 	// Must check the job object itself for updates.
 	// The output variable is returned before the work is done.
@@ -877,6 +947,16 @@ func TestRunJobChannel(test *testing.T) {
 		test.Fatalf("Unexpected output. Expected: '%s', actual: '%s'.",
 			util.MustToJSONIndent(expected), util.MustToJSONIndent(job.JobOutput))
 	}
+}
+
+// TODO: Find a way to pretty print Job struct.
+func clearUnsupportedJSONFields[InputType any, OutputType any](job Job[InputType, OutputType]) {
+	job.WorkFunc = nil
+	job.RetrieveFunc = nil
+	job.RemoveStorageFunc = nil
+	job.WorkItemKeyFunc = nil
+	job.done = nil
+	job.Done = nil
 }
 
 func resetStorage() map[string]int {

--- a/internal/jobmanager/jobmanager_test.go
+++ b/internal/jobmanager/jobmanager_test.go
@@ -20,7 +20,7 @@ var workFunc = func(input string) (int, error) {
 }
 
 type printableJob[InputType any, OutputType any] struct {
-	JobOptions
+	*JobOptions
 
 	Context context.Context `json:"context"`
 
@@ -88,13 +88,13 @@ func TestJobValidateBase(test *testing.T) {
 				WorkFunc:   workFunc,
 				PoolSize:   testPoolSize,
 				LockKey:    testLockKey,
-				JobOptions: JobOptions{},
+				JobOptions: &JobOptions{},
 			},
 			&Job[string, int]{
 				WorkFunc: workFunc,
 				PoolSize: testPoolSize,
 				LockKey:  testLockKey,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					Context: context.Background(),
 				},
 			},
@@ -105,7 +105,7 @@ func TestJobValidateBase(test *testing.T) {
 				WorkFunc: workFunc,
 				PoolSize: testPoolSize,
 				LockKey:  testLockKey,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					WaitForCompletion: true,
 				},
 			},
@@ -113,7 +113,7 @@ func TestJobValidateBase(test *testing.T) {
 				WorkFunc: workFunc,
 				PoolSize: testPoolSize,
 				LockKey:  testLockKey,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					Context:           context.Background(),
 					WaitForCompletion: true,
 				},
@@ -125,7 +125,7 @@ func TestJobValidateBase(test *testing.T) {
 				WorkFunc: workFunc,
 				PoolSize: testPoolSize,
 				LockKey:  testLockKey,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					RetainOriginalContext: true,
 				},
 			},
@@ -133,20 +133,21 @@ func TestJobValidateBase(test *testing.T) {
 				WorkFunc: workFunc,
 				PoolSize: testPoolSize,
 				LockKey:  testLockKey,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					Context:               context.Background(),
 					RetainOriginalContext: true,
 				},
 			},
 			"",
 		},
+
 		// Nil context provided
 		{
 			&Job[string, int]{
 				WorkFunc: workFunc,
 				PoolSize: testPoolSize,
 				LockKey:  testLockKey,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					Context: nil,
 				},
 			},
@@ -154,7 +155,7 @@ func TestJobValidateBase(test *testing.T) {
 				WorkFunc: workFunc,
 				PoolSize: testPoolSize,
 				LockKey:  testLockKey,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					Context: context.Background(),
 				},
 			},
@@ -165,7 +166,7 @@ func TestJobValidateBase(test *testing.T) {
 				WorkFunc: workFunc,
 				PoolSize: testPoolSize,
 				LockKey:  testLockKey,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					Context:           nil,
 					WaitForCompletion: true,
 				},
@@ -174,7 +175,7 @@ func TestJobValidateBase(test *testing.T) {
 				WorkFunc: workFunc,
 				PoolSize: testPoolSize,
 				LockKey:  testLockKey,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					Context:           context.Background(),
 					WaitForCompletion: true,
 				},
@@ -186,7 +187,7 @@ func TestJobValidateBase(test *testing.T) {
 				WorkFunc: workFunc,
 				PoolSize: testPoolSize,
 				LockKey:  testLockKey,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					Context:               nil,
 					RetainOriginalContext: true,
 				},
@@ -195,20 +196,21 @@ func TestJobValidateBase(test *testing.T) {
 				WorkFunc: workFunc,
 				PoolSize: testPoolSize,
 				LockKey:  testLockKey,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					Context:               context.Background(),
 					RetainOriginalContext: true,
 				},
 			},
 			"",
 		},
+
 		// Context provided
 		{
 			&Job[string, int]{
 				WorkFunc: workFunc,
 				PoolSize: testPoolSize,
 				LockKey:  testLockKey,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					Context: context.TODO(),
 				},
 			},
@@ -216,7 +218,7 @@ func TestJobValidateBase(test *testing.T) {
 				WorkFunc: workFunc,
 				PoolSize: testPoolSize,
 				LockKey:  testLockKey,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					// Swap the context to background when not waiting for completion.
 					Context: context.Background(),
 				},
@@ -228,7 +230,7 @@ func TestJobValidateBase(test *testing.T) {
 				WorkFunc: workFunc,
 				PoolSize: testPoolSize,
 				LockKey:  testLockKey,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					Context:           context.TODO(),
 					WaitForCompletion: true,
 				},
@@ -237,7 +239,7 @@ func TestJobValidateBase(test *testing.T) {
 				WorkFunc: workFunc,
 				PoolSize: testPoolSize,
 				LockKey:  testLockKey,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					Context:           context.TODO(),
 					WaitForCompletion: true,
 				},
@@ -249,7 +251,7 @@ func TestJobValidateBase(test *testing.T) {
 				WorkFunc: workFunc,
 				PoolSize: testPoolSize,
 				LockKey:  testLockKey,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					Context:               context.TODO(),
 					RetainOriginalContext: true,
 				},
@@ -258,7 +260,7 @@ func TestJobValidateBase(test *testing.T) {
 				WorkFunc: workFunc,
 				PoolSize: testPoolSize,
 				LockKey:  testLockKey,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					Context:               context.TODO(),
 					RetainOriginalContext: true,
 				},
@@ -287,26 +289,45 @@ func TestJobValidateBase(test *testing.T) {
 			nil,
 			"Job cannot have a nil work function.",
 		},
+		// Nil Job Options
+		{
+			&Job[string, int]{
+				WorkFunc: workFunc,
+			},
+			nil,
+			"Job options are nil.",
+		},
+		{
+			&Job[string, int]{
+				WorkFunc:   workFunc,
+				JobOptions: nil,
+			},
+			nil,
+			"Job options are nil.",
+		},
 		// Bad Pool Size
 		{
 			&Job[string, int]{
-				WorkFunc: workFunc,
+				WorkFunc:   workFunc,
+				JobOptions: &JobOptions{},
 			},
 			nil,
 			"Pool size must be positive, got 0.",
 		},
 		{
 			&Job[string, int]{
-				WorkFunc: workFunc,
-				PoolSize: 0,
+				WorkFunc:   workFunc,
+				JobOptions: &JobOptions{},
+				PoolSize:   0,
 			},
 			nil,
 			"Pool size must be positive, got 0.",
 		},
 		{
 			&Job[string, int]{
-				WorkFunc: workFunc,
-				PoolSize: -1,
+				WorkFunc:   workFunc,
+				JobOptions: &JobOptions{},
+				PoolSize:   -1,
 			},
 			nil,
 			"Pool size must be positive, got -1.",
@@ -429,7 +450,7 @@ func TestRunJobBase(test *testing.T) {
 				WorkFunc:   workFunc,
 				PoolSize:   testPoolSize,
 				LockKey:    testLockKey,
-				JobOptions: JobOptions{},
+				JobOptions: &JobOptions{},
 			},
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{},
@@ -450,7 +471,7 @@ func TestRunJobBase(test *testing.T) {
 				WorkFunc:   workFunc,
 				PoolSize:   testPoolSize,
 				LockKey:    testLockKey,
-				JobOptions: JobOptions{},
+				JobOptions: &JobOptions{},
 			},
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{},
@@ -471,7 +492,7 @@ func TestRunJobBase(test *testing.T) {
 				WorkFunc:   workFunc,
 				PoolSize:   testPoolSize,
 				LockKey:    testLockKey,
-				JobOptions: JobOptions{},
+				JobOptions: &JobOptions{},
 			},
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{},
@@ -495,7 +516,7 @@ func TestRunJobBase(test *testing.T) {
 				PoolSize:     testPoolSize,
 				LockKey:      testLockKey,
 				RetrieveFunc: retrieveFunc,
-				JobOptions:   JobOptions{},
+				JobOptions:   &JobOptions{},
 			},
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{1, 2},
@@ -517,7 +538,7 @@ func TestRunJobBase(test *testing.T) {
 				PoolSize:     testPoolSize,
 				LockKey:      testLockKey,
 				RetrieveFunc: retrieveFunc,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					OverwriteRecords: true,
 				},
 			},
@@ -543,7 +564,7 @@ func TestRunJobBase(test *testing.T) {
 				PoolSize:          testPoolSize,
 				LockKey:           testLockKey,
 				RemoveStorageFunc: removeStorageFunc,
-				JobOptions:        JobOptions{},
+				JobOptions:        &JobOptions{},
 			},
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{},
@@ -566,7 +587,7 @@ func TestRunJobBase(test *testing.T) {
 				LockKey:   testLockKey,
 				// Won't cause an error because it won't be called.
 				RemoveStorageFunc: errorRemoveStorageFunc,
-				JobOptions:        JobOptions{},
+				JobOptions:        &JobOptions{},
 			},
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{},
@@ -592,7 +613,7 @@ func TestRunJobBase(test *testing.T) {
 				RetrieveFunc: retrieveFunc,
 				// Storage removal is not called.
 				RemoveStorageFunc: removeStorageFunc,
-				JobOptions:        JobOptions{},
+				JobOptions:        &JobOptions{},
 			},
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{1, 2},
@@ -615,7 +636,7 @@ func TestRunJobBase(test *testing.T) {
 				LockKey:           testLockKey,
 				RetrieveFunc:      retrieveFunc,
 				RemoveStorageFunc: removeStorageFunc,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					OverwriteRecords: true,
 				},
 			},
@@ -643,7 +664,7 @@ func TestRunJobBase(test *testing.T) {
 				RetrieveFunc: retrieveFunc,
 				// Storage removal is not called.
 				RemoveStorageFunc: removeStorageFunc,
-				JobOptions:        JobOptions{},
+				JobOptions:        &JobOptions{},
 			},
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{1, 2},
@@ -668,7 +689,7 @@ func TestRunJobBase(test *testing.T) {
 				LockKey:           testLockKey,
 				RetrieveFunc:      retrieveFunc,
 				RemoveStorageFunc: removeStorageFunc,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					OverwriteRecords: true,
 				},
 			},
@@ -693,15 +714,17 @@ func TestRunJobBase(test *testing.T) {
 		// Nil Work Function
 		{
 			job: Job[string, int]{
-				WorkItems: input,
-				WorkFunc:  nil,
+				WorkItems:  input,
+				WorkFunc:   nil,
+				JobOptions: &JobOptions{},
 			},
 			errorSubstring: "Job cannot have a nil work function.",
 		},
 		{
 			job: Job[string, int]{
-				WorkItems: nil,
-				WorkFunc:  nil,
+				WorkItems:  nil,
+				WorkFunc:   nil,
+				JobOptions: &JobOptions{},
 			},
 			errorSubstring: "Job cannot have a nil work function.",
 		},
@@ -714,7 +737,7 @@ func TestRunJobBase(test *testing.T) {
 				PoolSize:     testPoolSize,
 				LockKey:      testLockKey,
 				RetrieveFunc: errorRetrieveFunc,
-				JobOptions:   JobOptions{},
+				JobOptions:   &JobOptions{},
 			},
 			errorSubstring: "Crazy retrieval error!",
 		},
@@ -725,7 +748,7 @@ func TestRunJobBase(test *testing.T) {
 				PoolSize:     testPoolSize,
 				LockKey:      testLockKey,
 				RetrieveFunc: errorRetrieveFunc,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					OverwriteRecords: true,
 				},
 			},
@@ -741,7 +764,7 @@ func TestRunJobBase(test *testing.T) {
 				PoolSize:          testPoolSize,
 				LockKey:           testLockKey,
 				RemoveStorageFunc: errorRemoveStorageFunc,
-				JobOptions: JobOptions{
+				JobOptions: &JobOptions{
 					OverwriteRecords: true,
 				},
 			},
@@ -866,7 +889,7 @@ func TestRunJobCancel(test *testing.T) {
 		WorkFunc:  sleepWorkFunc,
 		PoolSize:  testPoolSize,
 		LockKey:   testLockKey,
-		JobOptions: JobOptions{
+		JobOptions: &JobOptions{
 			Context:           ctx,
 			WaitForCompletion: true,
 		},
@@ -897,7 +920,7 @@ func TestRunJobChannel(test *testing.T) {
 		WorkFunc:  workFunc,
 		PoolSize:  testPoolSize,
 		LockKey:   testLockKey,
-		JobOptions: JobOptions{
+		JobOptions: &JobOptions{
 			WaitForCompletion: false,
 		},
 	}

--- a/internal/jobmanager/jobmanager_test.go
+++ b/internal/jobmanager/jobmanager_test.go
@@ -800,8 +800,9 @@ func TestRunJobBase(test *testing.T) {
 			continue
 		}
 
-		// Set the done channel to pass the equality check.
+		// Set the done channel and job ID to pass the equality check.
 		testCase.initialOutput.Done = output.Done
+		testCase.initialOutput.JobID = output.JobID
 
 		if !reflect.DeepEqual(output, testCase.initialOutput) {
 			test.Errorf("Case %d: Unexpected initial results. Expected: '%s', actual: '%s'.",
@@ -818,8 +819,9 @@ func TestRunJobBase(test *testing.T) {
 			continue
 		}
 
-		// Set the done channel to pass the equality check.
+		// Set the done channel and job ID to pass the equality check.
 		testCase.finalOutput.Done = output.Done
+		testCase.finalOutput.JobID = output.JobID
 
 		if !reflect.DeepEqual(output, testCase.finalOutput) {
 			test.Errorf("Case %d: Unexpected final results. Expected: '%s', actual: '%s'.",
@@ -924,6 +926,7 @@ func TestRunJobChannel(test *testing.T) {
 		RunTime:        int64(len(input)),
 		WorkErrors:     map[int]error{},
 		Done:           output.Done,
+		JobID:          output.JobID,
 	}
 
 	if !reflect.DeepEqual(output, expected) {

--- a/internal/jobmanager/jobmanager_test.go
+++ b/internal/jobmanager/jobmanager_test.go
@@ -871,10 +871,11 @@ func TestRunJobCancel(test *testing.T) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 
 	job := &Job[string, int]{
-		WorkItems: input,
-		WorkFunc:  sleepWorkFunc,
-		PoolSize:  testPoolSize,
-		LockKey:   testLockKey,
+		WorkItems:  input,
+		WorkFunc:   sleepWorkFunc,
+		SoftCancel: false,
+		PoolSize:   testPoolSize,
+		LockKey:    testLockKey,
 		JobOptions: &JobOptions{
 			Context:           ctx,
 			WaitForCompletion: true,
@@ -896,6 +897,85 @@ func TestRunJobCancel(test *testing.T) {
 	}
 
 	output := job.Run()
+	if output.Error.Error() != expectedOutput.Error.Error() {
+		test.Fatalf("Unexpected error. Expected: '%s', actual: '%s'.",
+			expectedOutput.Error.Error(), output.Error.Error())
+	}
+
+	// Clear done channel and errors for comparison check.
+	output.Done = nil
+	output.Error = nil
+	expectedOutput.Error = nil
+
+	if !reflect.DeepEqual(output, expectedOutput) {
+		test.Fatalf("Unexpected result. Expected: '%s', actual: '%s'.",
+			util.MustToJSONIndent(expectedOutput.toPrintableJobOutput()), util.MustToJSONIndent(output.toPrintableJobOutput()))
+	}
+}
+
+func TestRunJobSoftCancel(test *testing.T) {
+	// A channel to know which jobs started.
+	startedChan := make(chan string, len(input))
+
+	// Block until the first worker has started.
+	workWaitGroup := sync.WaitGroup{}
+	workWaitGroup.Add(1)
+
+	sleepWorkFunc := func(input string) (int, error) {
+		startedChan <- input
+
+		// Signal on the first piece of work so that we can make sure the workers have started up before we cancel.
+		if input == "A" {
+			workWaitGroup.Done()
+			time.Sleep(time.Duration(5) * time.Millisecond)
+			return len(input), nil
+		}
+
+		time.Sleep(time.Duration(5) * time.Millisecond)
+
+		return len(input), nil
+	}
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+
+	job := &Job[string, int]{
+		WorkItems:  input,
+		WorkFunc:   sleepWorkFunc,
+		SoftCancel: true,
+		PoolSize:   testPoolSize,
+		LockKey:    testLockKey,
+		JobOptions: &JobOptions{
+			Context:           ctx,
+			WaitForCompletion: true,
+		},
+	}
+
+	// Cancel the context as soon as the worker signals it.
+	go func() {
+		workWaitGroup.Wait()
+		cancelFunc()
+	}()
+
+	// TODO: run isn't waiting for the results to populate?
+	output := job.Run()
+
+	close(startedChan)
+
+	// Workers race to start before the cancellation.
+	// Ensure all started work is completed.
+	expectedResults := map[string]int{}
+	for input := range startedChan {
+		expectedResults[input] = len(input)
+	}
+
+	expectedOutput := &JobOutput[string, int]{
+		Canceled:       true,
+		Error:          fmt.Errorf("Job was canceled: 'context canceled'."),
+		WorkErrors:     map[string]error{},
+		ResultItems:    expectedResults,
+		RemainingItems: []string{},
+	}
+
 	if output.Error.Error() != expectedOutput.Error.Error() {
 		test.Fatalf("Unexpected error. Expected: '%s', actual: '%s'.",
 			expectedOutput.Error.Error(), output.Error.Error())

--- a/internal/jobmanager/jobmanager_test.go
+++ b/internal/jobmanager/jobmanager_test.go
@@ -2,8 +2,9 @@ package jobmanager
 
 import (
 	"context"
-	// "fmt"
+	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -204,7 +205,7 @@ func TestJobOptionsValidateBase(test *testing.T) {
 		if err != nil {
 			if testCase.errorString != "" {
 				if err.Error() != testCase.errorString {
-					test.Errorf("Case %d: Did not get expected error outpout. Expected substring '%s', actual error: '%v'.", i, testCase.errorString, err)
+					test.Errorf("Case %d: Did not get expected error output. Expected substring '%s', actual error: '%v'.", i, testCase.errorString, err)
 				}
 			} else {
 				test.Errorf("Case %d: Failed to validate '%+v': '%v'.", i, testCase.input, err)
@@ -226,7 +227,6 @@ func TestJobOptionsValidateBase(test *testing.T) {
 	}
 }
 
-// TODO: Test caching functions and cache removal functions.
 func TestRunJobBase(test *testing.T) {
 	input := []string{
 		"A",
@@ -240,37 +240,270 @@ func TestRunJobBase(test *testing.T) {
 		3,
 	}
 
+	cache := resetCache()
+
+	cacheFunc := func(inputs []string) ([]int, []string, error) {
+		outputs := make([]int, 0, len(cache))
+		remaining := make([]string, 0, len(inputs))
+
+		for _, input := range inputs {
+			output, ok := cache[input]
+			if !ok {
+				remaining = append(remaining, input)
+				continue
+			}
+
+			outputs = append(outputs, output)
+		}
+
+		return outputs, remaining, nil
+	}
+
+	errorCacheFunc := func(inputs []string) ([]int, []string, error) {
+		return nil, nil, fmt.Errorf("Crazy cache error!")
+	}
+
+	removeCacheFunc := func(inputs []string) error {
+		for _, input := range inputs {
+			delete(cache, input)
+		}
+
+		return nil
+	}
+
+	errorRemoveCacheFunc := func(inputs []string) error {
+		return fmt.Errorf("Insane cache removal error!")
+	}
+
 	workFunc := func(input string) (int, int64, error) {
 		return len(input), int64(1), nil
 	}
 
+	workFuncWithCache := func(input string) (int, int64, error) {
+		cache[input] = len(input)
+
+		return len(input), int64(1), nil
+	}
+
 	testCases := []struct {
-		input       []string
-		output      []int
-		workFunc    func(input string) (int, int64, error)
-		errorString string
+		input   []string
+		options *JobOptions
+
+		initialRemaining int
+
+		initialOutput []int
+		finalOutput   []int
+
+		finalRunTime int64
+
+		workFunc         func(input string) (int, int64, error)
+		cacheFunc        func(inputs []string) ([]int, []string, error)
+		cacheRemovalFunc func(inputs []string) error
+
+		initialErrorSubstring string
+		finalErrorSubstring   string
+
+		resetCache      bool
+		checkEmptyCache bool
 	}{
 		// Success
-		{input, finalExpected, workFunc, ""},
-		{nil, []int{}, workFunc, ""},
-		{[]string{}, []int{}, workFunc, ""},
+
+		// Base options
+		{
+			input:            input,
+			initialOutput:    []int{},
+			initialRemaining: len(input),
+			finalOutput:      finalExpected,
+			finalRunTime:     int64(len(input)),
+			workFunc:         workFunc,
+		},
+		{
+			input:         nil,
+			initialOutput: []int{},
+			finalOutput:   []int{},
+			workFunc:      workFunc,
+		},
+		{
+			input:         []string{},
+			initialOutput: []int{},
+			finalOutput:   []int{},
+			workFunc:      workFunc,
+		},
+
+		// Passing a cache function
+		{
+			input:            input,
+			initialOutput:    []int{1, 2},
+			initialRemaining: 1,
+			finalOutput:      finalExpected,
+			finalRunTime:     int64(1),
+			workFunc:         workFunc,
+			cacheFunc:        cacheFunc,
+		},
+		{
+			input: input,
+			options: &JobOptions{
+				OverwriteCache: true,
+				LockKey:        testLockKey,
+				PoolSize:       testPoolSize,
+			},
+			initialOutput:    []int{},
+			initialRemaining: len(input),
+			finalOutput:      finalExpected,
+			finalRunTime:     int64(len(input)),
+			workFunc:         workFunc,
+			cacheFunc:        cacheFunc,
+		},
+		{
+			input: input,
+			options: &JobOptions{
+				OverwriteCache: true,
+				LockKey:        testLockKey,
+				PoolSize:       testPoolSize,
+			},
+			initialOutput:    []int{},
+			initialRemaining: len(input),
+			finalOutput:      finalExpected,
+			finalRunTime:     int64(len(input)),
+			workFunc:         workFunc,
+			// Won't cause an error because it won't be called.
+			cacheFunc: errorCacheFunc,
+		},
+
+		// Passing a cache removal function
+		{
+			input:            input,
+			initialOutput:    []int{},
+			initialRemaining: len(input),
+			finalOutput:      finalExpected,
+			finalRunTime:     int64(len(input)),
+			workFunc:         workFunc,
+			cacheRemovalFunc: removeCacheFunc,
+		},
+		{
+			input:            input,
+			initialOutput:    []int{},
+			initialRemaining: len(input),
+			finalOutput:      finalExpected,
+			finalRunTime:     int64(len(input)),
+			workFunc:         workFunc,
+			// Won't cause an error because it won't be called.
+			cacheRemovalFunc: errorRemoveCacheFunc,
+		},
+
+		// Passing cache and cache removal functions
+		{
+			input:            input,
+			initialOutput:    []int{1, 2},
+			initialRemaining: 1,
+			finalOutput:      finalExpected,
+			finalRunTime:     int64(1),
+			workFunc:         workFunc,
+			cacheFunc:        cacheFunc,
+			cacheRemovalFunc: removeCacheFunc,
+		},
+		{
+			input: input,
+			options: &JobOptions{
+				OverwriteCache: true,
+				LockKey:        testLockKey,
+				PoolSize:       testPoolSize,
+			},
+			initialOutput:    []int{},
+			initialRemaining: len(input),
+			finalOutput:      finalExpected,
+			finalRunTime:     int64(len(input)),
+			workFunc:         workFunc,
+			cacheFunc:        cacheFunc,
+			cacheRemovalFunc: removeCacheFunc,
+			resetCache:       true,
+			checkEmptyCache:  true,
+		},
+		{
+			input:            input,
+			initialOutput:    []int{1, 2},
+			initialRemaining: 1,
+			finalOutput:      finalExpected,
+			finalRunTime:     int64(1),
+			workFunc:         workFuncWithCache,
+			cacheFunc:        cacheFunc,
+			cacheRemovalFunc: removeCacheFunc,
+			resetCache:       true,
+		},
+		{
+			input: input,
+			options: &JobOptions{
+				OverwriteCache: true,
+				LockKey:        testLockKey,
+				PoolSize:       testPoolSize,
+			},
+			initialOutput:    []int{},
+			initialRemaining: len(input),
+			finalOutput:      finalExpected,
+			finalRunTime:     int64(len(input)),
+			workFunc:         workFuncWithCache,
+			cacheFunc:        cacheFunc,
+			cacheRemovalFunc: removeCacheFunc,
+			resetCache:       true,
+			checkEmptyCache:  true,
+		},
 
 		// Errors
-		{input, nil, nil, "Cannot run job with a nil work function."},
-		{nil, nil, nil, "Cannot run job with a nil work function."},
+
+		// Nil work function
+		{
+			input:                 input,
+			initialOutput:         []int{},
+			workFunc:              nil,
+			initialErrorSubstring: "Cannot run job with a nil work function.",
+		},
+		{
+			input:                 nil,
+			initialOutput:         []int{},
+			workFunc:              nil,
+			initialErrorSubstring: "Cannot run job with a nil work function.",
+		},
+
+		// Bad cache function
+		{
+			input:                 input,
+			initialOutput:         []int{},
+			workFunc:              workFunc,
+			cacheFunc:             errorCacheFunc,
+			initialErrorSubstring: "Crazy cache error!",
+		},
+
+		// Bad cache removal function
+		{
+			input: input,
+			options: &JobOptions{
+				OverwriteCache: true,
+				LockKey:        testLockKey,
+				PoolSize:       testPoolSize,
+			},
+			initialOutput:       []int{},
+			initialRemaining:    len(input),
+			workFunc:            workFunc,
+			cacheRemovalFunc:    errorRemoveCacheFunc,
+			finalErrorSubstring: "Insane cache removal error!",
+		},
 	}
 
 	for i, testCase := range testCases {
-		options := &JobOptions{
-			LockKey:  testLockKey,
-			PoolSize: testPoolSize,
+		if testCase.options == nil {
+			testCase.options = &JobOptions{
+				LockKey:  testLockKey,
+				PoolSize: testPoolSize,
+			}
 		}
 
-		output, numRemaining, runTime, err := RunJob(options, testCase.input, nil, nil, testCase.workFunc)
+		testCase.options.WaitForCompletion = false
+
+		output, numRemaining, runTime, err := RunJob(testCase.options, testCase.input, testCase.cacheFunc, testCase.cacheRemovalFunc, testCase.workFunc)
 		if err != nil {
-			if testCase.errorString != "" {
-				if err.Error() != testCase.errorString {
-					test.Errorf("Case %d: Did not get expected error outpout. Expected substring '%s', actual error: '%v'.", i, testCase.errorString, err)
+			if testCase.initialErrorSubstring != "" {
+				if !strings.Contains(err.Error(), testCase.initialErrorSubstring) {
+					test.Errorf("Case %d: Did not get expected error output on initial run. Expected substring: '%s', actual error: '%v'.", i, testCase.initialErrorSubstring, err)
 				}
 			} else {
 				test.Errorf("Case %d: Failed to run initial job: '%v'.", i, err)
@@ -279,18 +512,13 @@ func TestRunJobBase(test *testing.T) {
 			continue
 		}
 
-		if testCase.errorString != "" {
-			test.Errorf("Case %d: Did not get expected error: '%s'.", i, testCase.errorString)
+		if testCase.initialErrorSubstring != "" {
+			test.Errorf("Case %d: Did not get expected initial error: '%s'.", i, testCase.initialErrorSubstring)
 			continue
 		}
 
-		if len(output) != 0 {
-			test.Errorf("Case %d: Unexpected number of initial results. Expected: '0', actual: '%d'.", i, len(output))
-			continue
-		}
-
-		if numRemaining != len(testCase.input) {
-			test.Errorf("Case %d: Unexpected number of initial items remaining. Expected: '%d', actual: '%d'.", i, len(testCase.input), numRemaining)
+		if numRemaining != testCase.initialRemaining {
+			test.Errorf("Case %d: Unexpected number of initial items remaining. Expected: '%d', actual: '%d'.", i, testCase.initialRemaining, numRemaining)
 			continue
 		}
 
@@ -299,11 +527,28 @@ func TestRunJobBase(test *testing.T) {
 			continue
 		}
 
-		options.WaitForCompletion = true
+		if !reflect.DeepEqual(output, testCase.initialOutput) {
+			test.Errorf("Case %d: Unexpected initial results. Expected: '%v', actual: '%v'.", i, testCase.initialOutput, output)
+			continue
+		}
 
-		output, numRemaining, runTime, err = RunJob(options, testCase.input, nil, nil, testCase.workFunc)
+		testCase.options.WaitForCompletion = true
+
+		output, numRemaining, runTime, err = RunJob(testCase.options, testCase.input, testCase.cacheFunc, testCase.cacheRemovalFunc, testCase.workFunc)
 		if err != nil {
-			test.Errorf("Case %d: Failed to run final job: '%v'.", i, err)
+			if testCase.finalErrorSubstring != "" {
+				if !strings.Contains(err.Error(), testCase.finalErrorSubstring) {
+					test.Errorf("Case %d: Did not get expected error output on final run. Expected substring: '%s', actual error: '%v'.", i, testCase.finalErrorSubstring, err)
+				}
+			} else {
+				test.Errorf("Case %d: Failed to run final job: '%v'.", i, err)
+			}
+
+			continue
+		}
+
+		if testCase.finalErrorSubstring != "" {
+			test.Errorf("Case %d: Did not get expected final error: '%s'.", i, testCase.finalErrorSubstring)
 			continue
 		}
 
@@ -312,16 +557,55 @@ func TestRunJobBase(test *testing.T) {
 			continue
 		}
 
-		expectedRunTime := int64(len(testCase.input))
-		if runTime != expectedRunTime {
-			test.Errorf("Case %d: Unexpected final run time. Expected: '%d', actual: '%d'.", i, expectedRunTime, runTime)
+		if runTime != testCase.finalRunTime {
+			test.Errorf("Case %d: Unexpected final run time. Expected: '%d', actual: '%d'.", i, testCase.finalRunTime, runTime)
 			continue
 		}
 
-		if !reflect.DeepEqual(testCase.output, output) {
+		if !reflect.DeepEqual(testCase.finalOutput, output) {
 			test.Errorf("Case %d: Unexpected final results. Expected: '%s', actual: '%s'.",
-				i, util.MustToJSONIndent(testCase.output), util.MustToJSONIndent(output))
+				i, util.MustToJSONIndent(testCase.finalOutput), util.MustToJSONIndent(output))
 			continue
+		}
+
+		if testCase.checkEmptyCache && !testCase.resetCache {
+			test.Errorf("Case %d: A test that checks for an empty cache must reset the cache.", i)
+			cache = resetCache()
+			continue
+		}
+
+		if testCase.resetCache {
+			if testCase.checkEmptyCache {
+				testCase.options.WaitForCompletion = false
+
+				output, numRemaining, runTime, err = RunJob(testCase.options, testCase.input, testCase.cacheFunc, testCase.cacheRemovalFunc, testCase.workFunc)
+				if err != nil {
+					test.Errorf("Case %d: Failed to check for an empty cache: '%v'.", i, err)
+					cache = resetCache()
+					continue
+				}
+
+				if runTime != 0 {
+					test.Errorf("Case %d: Unexpected run time during cache check. Expected: '0', actual: '%d'.", i, runTime)
+					cache = resetCache()
+					continue
+				}
+
+				if numRemaining != len(testCase.input) {
+					test.Errorf("Case %d: Unexpected number of items remaining during cache check. Expected: '%d', actual: '%d'.",
+						i, len(testCase.input), numRemaining)
+					cache = resetCache()
+					continue
+				}
+
+				if !reflect.DeepEqual(output, []int{}) {
+					test.Errorf("Case %d: Unexpected output during cache check. Expected: '%v', actual: '%v'.", i, []int{}, output)
+					cache = resetCache()
+					continue
+				}
+			}
+
+			cache = resetCache()
 		}
 	}
 }
@@ -333,12 +617,12 @@ func TestRunJobCancel(test *testing.T) {
 		"CCC",
 	}
 
-	// Block until the first worker has started.
+	// Block until the initial worker has started.
 	workWaitGroup := sync.WaitGroup{}
 	workWaitGroup.Add(1)
 
 	workFunc := func(input string) (int, int64, error) {
-		// Signal on the first piece of work that we can make sure the workers have started up before we cancel.
+		// Signal on the initial piece of work that we can make sure the workers have started up before we cancel.
 		if input == "A" {
 			workWaitGroup.Done()
 		}
@@ -358,7 +642,7 @@ func TestRunJobCancel(test *testing.T) {
 		PoolSize:          testPoolSize,
 	}
 
-	// Cancel the context as soon as the first worker signals it.
+	// Cancel the context as soon as the initial worker signals it.
 	go func() {
 		workWaitGroup.Wait()
 		cancelFunc()
@@ -379,5 +663,12 @@ func TestRunJobCancel(test *testing.T) {
 
 	if runTime != 0 {
 		test.Fatalf("Got run time when it should be 0.")
+	}
+}
+
+func resetCache() map[string]int {
+	return map[string]int{
+		"A":  1,
+		"BB": 2,
 	}
 }

--- a/internal/jobmanager/jobmanager_test.go
+++ b/internal/jobmanager/jobmanager_test.go
@@ -585,11 +585,12 @@ func TestRunJobBase(test *testing.T) {
 		// Passing Retrieval And Storage Removal Functions
 		{
 			job: Job[string, int]{
-				WorkItems:         input,
-				WorkFunc:          workFunc,
-				PoolSize:          testPoolSize,
-				LockKey:           testLockKey,
-				RetrieveFunc:      retrieveFunc,
+				WorkItems:    input,
+				WorkFunc:     workFunc,
+				PoolSize:     testPoolSize,
+				LockKey:      testLockKey,
+				RetrieveFunc: retrieveFunc,
+				// Storage removal is not called.
 				RemoveStorageFunc: removeStorageFunc,
 				JobOptions:        JobOptions{},
 			},
@@ -635,11 +636,12 @@ func TestRunJobBase(test *testing.T) {
 		},
 		{
 			job: Job[string, int]{
-				WorkItems:         input,
-				WorkFunc:          workFuncWithStorage,
-				PoolSize:          testPoolSize,
-				LockKey:           testLockKey,
-				RetrieveFunc:      retrieveFunc,
+				WorkItems:    input,
+				WorkFunc:     workFuncWithStorage,
+				PoolSize:     testPoolSize,
+				LockKey:      testLockKey,
+				RetrieveFunc: retrieveFunc,
+				// Storage removal is not called.
 				RemoveStorageFunc: removeStorageFunc,
 				JobOptions:        JobOptions{},
 			},
@@ -652,8 +654,9 @@ func TestRunJobBase(test *testing.T) {
 			finalOutput: &JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
-				RunTime:        int64(1),
-				WorkErrors:     map[int]error{},
+				// First run will store results, so second run will not have a run time.
+				RunTime:    int64(0),
+				WorkErrors: map[int]error{},
 			},
 			resetStorage: true,
 		},
@@ -777,6 +780,7 @@ func TestRunJobBase(test *testing.T) {
 		}
 
 		testCase.job.WaitForCompletion = true
+		<-output.Done
 
 		output = testCase.job.Run()
 		if output.Error != nil {

--- a/internal/jobmanager/jobmanager_test.go
+++ b/internal/jobmanager/jobmanager_test.go
@@ -327,7 +327,13 @@ func TestRunJobBase(test *testing.T) {
 	storage := map[string]int{}
 
 	retrieveFunc := func(_ []string) (map[string]int, error) {
-		return storage, nil
+		results := make(map[string]int, len(storage))
+
+		for input, output := range storage {
+			results[input] = output
+		}
+
+		return results, nil
 	}
 
 	removeStorageFunc := func(inputs []string) error {
@@ -849,6 +855,9 @@ func TestRunJobCancel(test *testing.T) {
 			return len(input), nil
 		}
 
+		// Sleep to allow the first result to be captured.
+		time.Sleep(time.Duration(2) * time.Millisecond)
+
 		// Signal on the second piece of work so that we can make sure the workers have started up before we cancel.
 		if input == "BB" {
 			workWaitGroup.Done()
@@ -884,7 +893,7 @@ func TestRunJobCancel(test *testing.T) {
 		Error:          fmt.Errorf("Job was canceled: 'context canceled'."),
 		WorkErrors:     map[string]error{},
 		ResultItems:    map[string]int{"A": 1},
-		RemainingItems: []string{"BB", "CCC"},
+		RemainingItems: []string{},
 	}
 
 	output := job.Run()

--- a/internal/jobmanager/jobmanager_test.go
+++ b/internal/jobmanager/jobmanager_test.go
@@ -15,140 +15,199 @@ import (
 var testLockKey string = "test_key"
 var testPoolSize int = 1
 
-func TestJobOptionsValidateBase(test *testing.T) {
+var workFunc = func(input string) (int, int64, error) {
+	return len(input), int64(1), nil
+}
+
+func TestJobValidateBase(test *testing.T) {
 	testCases := []struct {
-		input       *JobOptions
-		expected    *JobOptions
+		input       *Job[string, int]
+		expected    *Job[string, int]
 		errorString string
 	}{
 		// Success
 
-		// No context provided
+		// No Context Provided
 		{
-			&JobOptions{
-				LockKey:  testLockKey,
-				PoolSize: testPoolSize,
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					PoolSize: testPoolSize,
+					LockKey:  testLockKey,
+				},
 			},
-			&JobOptions{
-				Context:  context.Background(),
-				LockKey:  testLockKey,
-				PoolSize: testPoolSize,
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					Context:  context.Background(),
+					PoolSize: testPoolSize,
+					LockKey:  testLockKey,
+				},
 			},
 			"",
 		},
 		{
-			&JobOptions{
-				WaitForCompletion: true,
-				LockKey:           testLockKey,
-				PoolSize:          testPoolSize,
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					WaitForCompletion: true,
+					PoolSize:          testPoolSize,
+					LockKey:           testLockKey,
+				},
 			},
-			&JobOptions{
-				WaitForCompletion: true,
-				Context:           context.Background(),
-				LockKey:           testLockKey,
-				PoolSize:          testPoolSize,
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					Context:           context.Background(),
+					WaitForCompletion: true,
+					PoolSize:          testPoolSize,
+					LockKey:           testLockKey,
+				},
 			},
 			"",
 		},
 		{
-			&JobOptions{
-				RetainOriginalContext: true,
-				LockKey:               testLockKey,
-				PoolSize:              testPoolSize,
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					RetainOriginalContext: true,
+					PoolSize:              testPoolSize,
+					LockKey:               testLockKey,
+				},
 			},
-			&JobOptions{
-				RetainOriginalContext: true,
-				Context:               context.Background(),
-				LockKey:               testLockKey,
-				PoolSize:              testPoolSize,
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					Context:               context.Background(),
+					RetainOriginalContext: true,
+					PoolSize:              testPoolSize,
+					LockKey:               testLockKey,
+				},
 			},
 			"",
 		},
 		// Nil context provided
 		{
-			&JobOptions{
-				Context:  nil,
-				LockKey:  testLockKey,
-				PoolSize: testPoolSize,
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					Context:  nil,
+					PoolSize: testPoolSize,
+					LockKey:  testLockKey,
+				},
 			},
-			&JobOptions{
-				Context:  context.Background(),
-				LockKey:  testLockKey,
-				PoolSize: testPoolSize,
-			},
-			"",
-		},
-		{
-			&JobOptions{
-				Context:           nil,
-				WaitForCompletion: true,
-				LockKey:           testLockKey,
-				PoolSize:          testPoolSize,
-			},
-			&JobOptions{
-				Context:           context.Background(),
-				WaitForCompletion: true,
-				LockKey:           testLockKey,
-				PoolSize:          testPoolSize,
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					Context:  context.Background(),
+					PoolSize: testPoolSize,
+					LockKey:  testLockKey,
+				},
 			},
 			"",
 		},
 		{
-			&JobOptions{
-				Context:               nil,
-				RetainOriginalContext: true,
-				LockKey:               testLockKey,
-				PoolSize:              testPoolSize,
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					Context:           nil,
+					WaitForCompletion: true,
+					PoolSize:          testPoolSize,
+					LockKey:           testLockKey,
+				},
 			},
-			&JobOptions{
-				Context:               context.Background(),
-				RetainOriginalContext: true,
-				LockKey:               testLockKey,
-				PoolSize:              testPoolSize,
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					Context:           context.Background(),
+					WaitForCompletion: true,
+					PoolSize:          testPoolSize,
+					LockKey:           testLockKey,
+				},
+			},
+			"",
+		},
+		{
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					Context:               nil,
+					RetainOriginalContext: true,
+					PoolSize:              testPoolSize,
+					LockKey:               testLockKey,
+				},
+			},
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					Context:               context.Background(),
+					RetainOriginalContext: true,
+					PoolSize:              testPoolSize,
+					LockKey:               testLockKey,
+				},
 			},
 			"",
 		},
 		// Context provided
 		{
-			&JobOptions{
-				Context:  context.TODO(),
-				LockKey:  testLockKey,
-				PoolSize: testPoolSize,
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					Context:  context.TODO(),
+					PoolSize: testPoolSize,
+					LockKey:  testLockKey,
+				},
 			},
-			&JobOptions{
-				Context:  context.Background(),
-				LockKey:  testLockKey,
-				PoolSize: testPoolSize,
-			},
-			"",
-		},
-		{
-			&JobOptions{
-				Context:           context.TODO(),
-				WaitForCompletion: true,
-				LockKey:           testLockKey,
-				PoolSize:          testPoolSize,
-			},
-			&JobOptions{
-				Context:           context.TODO(),
-				WaitForCompletion: true,
-				LockKey:           testLockKey,
-				PoolSize:          testPoolSize,
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					// Swap the context to background when not waiting for completion.
+					Context:  context.Background(),
+					PoolSize: testPoolSize,
+					LockKey:  testLockKey,
+				},
 			},
 			"",
 		},
 		{
-			&JobOptions{
-				Context:               context.TODO(),
-				RetainOriginalContext: true,
-				LockKey:               testLockKey,
-				PoolSize:              testPoolSize,
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					Context:           context.TODO(),
+					WaitForCompletion: true,
+					PoolSize:          testPoolSize,
+					LockKey:           testLockKey,
+				},
 			},
-			&JobOptions{
-				Context:               context.TODO(),
-				RetainOriginalContext: true,
-				LockKey:               testLockKey,
-				PoolSize:              testPoolSize,
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					Context:           context.TODO(),
+					WaitForCompletion: true,
+					PoolSize:          testPoolSize,
+					LockKey:           testLockKey,
+				},
+			},
+			"",
+		},
+		{
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					Context:               context.TODO(),
+					RetainOriginalContext: true,
+					PoolSize:              testPoolSize,
+					LockKey:               testLockKey,
+				},
+			},
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					Context:               context.TODO(),
+					RetainOriginalContext: true,
+					PoolSize:              testPoolSize,
+					LockKey:               testLockKey,
+				},
 			},
 			"",
 		},
@@ -159,41 +218,45 @@ func TestJobOptionsValidateBase(test *testing.T) {
 		{
 			nil,
 			nil,
-			"Job options are nil.",
+			"Job is nil.",
 		},
-		// Bad lock key
+		// Bad Work Function
 		{
-			&JobOptions{},
+			&Job[string, int]{},
 			nil,
-			"Cannot have an empty lock key.",
+			"Job cannot have a nil work function.",
 		},
 		{
-			&JobOptions{
-				LockKey: "",
+			&Job[string, int]{
+				WorkFunc: nil,
 			},
 			nil,
-			"Cannot have an empty lock key.",
+			"Job cannot have a nil work function.",
 		},
-		// Bad pool size
+		// Bad Pool Size
 		{
-			&JobOptions{
-				LockKey: testLockKey,
-			},
-			nil,
-			"Pool size must be positive, got 0.",
-		},
-		{
-			&JobOptions{
-				LockKey:  testLockKey,
-				PoolSize: 0,
+			&Job[string, int]{
+				WorkFunc: workFunc,
 			},
 			nil,
 			"Pool size must be positive, got 0.",
 		},
 		{
-			&JobOptions{
-				LockKey:  testLockKey,
-				PoolSize: -1,
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					PoolSize: 0,
+				},
+			},
+			nil,
+			"Pool size must be positive, got 0.",
+		},
+		{
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				JobOptions: JobOptions{
+					PoolSize: -1,
+				},
 			},
 			nil,
 			"Pool size must be positive, got -1.",
@@ -219,9 +282,18 @@ func TestJobOptionsValidateBase(test *testing.T) {
 			continue
 		}
 
+		if testCase.input.WorkFunc == nil {
+			test.Errorf("Case %d: Found non nil work func.", i)
+			continue
+		}
+
+		// Clear work functions for comparison.
+		testCase.input.WorkFunc = nil
+		testCase.expected.WorkFunc = nil
+
 		if !reflect.DeepEqual(testCase.expected, testCase.input) {
-			test.Errorf("Case %d: Unexpected result. Expected: '%+v', actual: '%+v'.",
-				i, testCase.expected, testCase.input)
+			test.Errorf("Case %d: Unexpected result. Expected: '%s', actual: '%s'.",
+				i, util.MustToJSONIndent(testCase.expected), util.MustToJSONIndent(testCase.input))
 			continue
 		}
 	}
@@ -240,14 +312,14 @@ func TestRunJobBase(test *testing.T) {
 		3,
 	}
 
-	cache := resetCache()
+	storage := resetStorage()
 
-	cacheFunc := func(inputs []string) ([]int, []string, error) {
-		outputs := make([]int, 0, len(cache))
+	retrieveFunc := func(inputs []string) ([]int, []string, error) {
+		outputs := make([]int, 0, len(storage))
 		remaining := make([]string, 0, len(inputs))
 
 		for _, input := range inputs {
-			output, ok := cache[input]
+			output, ok := storage[input]
 			if !ok {
 				remaining = append(remaining, input)
 				continue
@@ -259,247 +331,369 @@ func TestRunJobBase(test *testing.T) {
 		return outputs, remaining, nil
 	}
 
-	errorCacheFunc := func(inputs []string) ([]int, []string, error) {
-		return nil, nil, fmt.Errorf("Crazy cache error!")
+	errorRetrieveFunc := func(_ []string) ([]int, []string, error) {
+		return nil, nil, fmt.Errorf("Crazy retrieval error!")
 	}
 
-	removeCacheFunc := func(inputs []string) error {
+	removeStorageFunc := func(inputs []string) error {
 		for _, input := range inputs {
-			delete(cache, input)
+			delete(storage, input)
 		}
 
 		return nil
 	}
 
-	errorRemoveCacheFunc := func(inputs []string) error {
-		return fmt.Errorf("Insane cache removal error!")
+	errorRemoveStorageFunc := func(_ []string) error {
+		return fmt.Errorf("Insane storage removal error!")
 	}
 
-	workFunc := func(input string) (int, int64, error) {
-		return len(input), int64(1), nil
-	}
-
-	workFuncWithCache := func(input string) (int, int64, error) {
-		cache[input] = len(input)
+	workFuncWithStorage := func(input string) (int, int64, error) {
+		storage[input] = len(input)
 
 		return len(input), int64(1), nil
 	}
 
 	testCases := []struct {
-		input   []string
-		options *JobOptions
+		job Job[string, int]
 
-		initialRemaining int
-
-		initialOutput []int
-		finalOutput   []int
-
-		finalRunTime int64
-
-		workFunc         func(input string) (int, int64, error)
-		cacheFunc        func(inputs []string) ([]int, []string, error)
-		cacheRemovalFunc func(inputs []string) error
+		initialOutput JobOutput[string, int]
+		finalOutput   JobOutput[string, int]
 
 		initialErrorSubstring string
 		finalErrorSubstring   string
 
-		resetCache      bool
-		checkEmptyCache bool
+		resetStorage      bool
+		checkEmptyStorage bool
 	}{
 		// Success
 
-		// Base options
+		// Base Options
 		{
-			input:            input,
-			initialOutput:    []int{},
-			initialRemaining: len(input),
-			finalOutput:      finalExpected,
-			finalRunTime:     int64(len(input)),
-			workFunc:         workFunc,
+			job: Job[string, int]{
+				WorkItems: input,
+				WorkFunc:  workFunc,
+				JobOptions: JobOptions{
+					PoolSize: testPoolSize,
+					LockKey:  testLockKey,
+				},
+			},
+			initialOutput: JobOutput[string, int]{
+				ResultItems:    []int{},
+				RemainingItems: input,
+				RunTime:        int64(0),
+			},
+			finalOutput: JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+				RunTime:        int64(len(input)),
+			},
 		},
 		{
-			input:         nil,
-			initialOutput: []int{},
-			finalOutput:   []int{},
-			workFunc:      workFunc,
+			job: Job[string, int]{
+				WorkItems: nil,
+				WorkFunc:  workFunc,
+				JobOptions: JobOptions{
+					PoolSize: testPoolSize,
+					LockKey:  testLockKey,
+				},
+			},
+			initialOutput: JobOutput[string, int]{
+				ResultItems:    []int{},
+				RemainingItems: nil,
+				RunTime:        int64(0),
+			},
+			finalOutput: JobOutput[string, int]{
+				ResultItems:    []int{},
+				RemainingItems: nil,
+				RunTime:        int64(0),
+			},
 		},
 		{
-			input:         []string{},
-			initialOutput: []int{},
-			finalOutput:   []int{},
-			workFunc:      workFunc,
+			job: Job[string, int]{
+				WorkItems: []string{},
+				WorkFunc:  workFunc,
+				JobOptions: JobOptions{
+					PoolSize: testPoolSize,
+					LockKey:  testLockKey,
+				},
+			},
+			initialOutput: JobOutput[string, int]{
+				ResultItems:    []int{},
+				RemainingItems: []string{},
+				RunTime:        int64(0),
+			},
+			finalOutput: JobOutput[string, int]{
+				ResultItems:    []int{},
+				RemainingItems: []string{},
+				RunTime:        int64(0),
+			},
 		},
 
-		// Passing a cache function
+		// Passing A Retrieval Function
 		{
-			input:            input,
-			initialOutput:    []int{1, 2},
-			initialRemaining: 1,
-			finalOutput:      finalExpected,
-			finalRunTime:     int64(1),
-			workFunc:         workFunc,
-			cacheFunc:        cacheFunc,
+			job: Job[string, int]{
+				WorkItems:    input,
+				WorkFunc:     workFunc,
+				RetrieveFunc: retrieveFunc,
+				JobOptions: JobOptions{
+					PoolSize: testPoolSize,
+					LockKey:  testLockKey,
+				},
+			},
+			initialOutput: JobOutput[string, int]{
+				ResultItems:    []int{1, 2},
+				RemainingItems: []string{"CCC"},
+				RunTime:        int64(0),
+			},
+			finalOutput: JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+				RunTime:        int64(1),
+			},
 		},
 		{
-			input: input,
-			options: &JobOptions{
-				OverwriteCache: true,
-				LockKey:        testLockKey,
-				PoolSize:       testPoolSize,
+			job: Job[string, int]{
+				WorkItems:    input,
+				WorkFunc:     workFunc,
+				RetrieveFunc: retrieveFunc,
+				JobOptions: JobOptions{
+					OverwriteRecords: true,
+					PoolSize:         testPoolSize,
+					LockKey:          testLockKey,
+				},
 			},
-			initialOutput:    []int{},
-			initialRemaining: len(input),
-			finalOutput:      finalExpected,
-			finalRunTime:     int64(len(input)),
-			workFunc:         workFunc,
-			cacheFunc:        cacheFunc,
+			initialOutput: JobOutput[string, int]{
+				ResultItems:    []int{},
+				RemainingItems: input,
+				RunTime:        int64(0),
+			},
+			finalOutput: JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+				RunTime:        int64(len(input)),
+			},
 		},
 		{
-			input: input,
-			options: &JobOptions{
-				OverwriteCache: true,
-				LockKey:        testLockKey,
-				PoolSize:       testPoolSize,
+			job: Job[string, int]{
+				WorkItems: input,
+				WorkFunc:  workFunc,
+				// Won't cause an error because it won't be called.
+				RetrieveFunc: errorRetrieveFunc,
+				JobOptions: JobOptions{
+					OverwriteRecords: true,
+					PoolSize:         testPoolSize,
+					LockKey:          testLockKey,
+				},
 			},
-			initialOutput:    []int{},
-			initialRemaining: len(input),
-			finalOutput:      finalExpected,
-			finalRunTime:     int64(len(input)),
-			workFunc:         workFunc,
-			// Won't cause an error because it won't be called.
-			cacheFunc: errorCacheFunc,
+			initialOutput: JobOutput[string, int]{
+				ResultItems:    []int{},
+				RemainingItems: input,
+				RunTime:        int64(0),
+			},
+			finalOutput: JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+				RunTime:        int64(len(input)),
+			},
 		},
 
-		// Passing a cache removal function
+		// Passing A Storage Removal Function
 		{
-			input:            input,
-			initialOutput:    []int{},
-			initialRemaining: len(input),
-			finalOutput:      finalExpected,
-			finalRunTime:     int64(len(input)),
-			workFunc:         workFunc,
-			cacheRemovalFunc: removeCacheFunc,
+			job: Job[string, int]{
+				WorkItems:         input,
+				WorkFunc:          workFunc,
+				RemoveStorageFunc: removeStorageFunc,
+				JobOptions: JobOptions{
+					PoolSize: testPoolSize,
+					LockKey:  testLockKey,
+				},
+			},
+			initialOutput: JobOutput[string, int]{
+				ResultItems:    []int{},
+				RemainingItems: input,
+				RunTime:        int64(0),
+			},
+			finalOutput: JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+				RunTime:        int64(len(input)),
+			},
 		},
 		{
-			input:            input,
-			initialOutput:    []int{},
-			initialRemaining: len(input),
-			finalOutput:      finalExpected,
-			finalRunTime:     int64(len(input)),
-			workFunc:         workFunc,
-			// Won't cause an error because it won't be called.
-			cacheRemovalFunc: errorRemoveCacheFunc,
+			job: Job[string, int]{
+				WorkItems: input,
+				WorkFunc:  workFunc,
+				// Won't cause an error because it won't be called.
+				RemoveStorageFunc: errorRemoveStorageFunc,
+				JobOptions: JobOptions{
+					PoolSize: testPoolSize,
+					LockKey:  testLockKey,
+				},
+			},
+			initialOutput: JobOutput[string, int]{
+				ResultItems:    []int{},
+				RemainingItems: input,
+				RunTime:        int64(0),
+			},
+			finalOutput: JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+				RunTime:        int64(len(input)),
+			},
 		},
 
-		// Passing cache and cache removal functions
+		// Passing Retrieval And Storage Removal Functions
 		{
-			input:            input,
-			initialOutput:    []int{1, 2},
-			initialRemaining: 1,
-			finalOutput:      finalExpected,
-			finalRunTime:     int64(1),
-			workFunc:         workFunc,
-			cacheFunc:        cacheFunc,
-			cacheRemovalFunc: removeCacheFunc,
-		},
-		{
-			input: input,
-			options: &JobOptions{
-				OverwriteCache: true,
-				LockKey:        testLockKey,
-				PoolSize:       testPoolSize,
+			job: Job[string, int]{
+				WorkItems:         input,
+				WorkFunc:          workFunc,
+				RetrieveFunc:      retrieveFunc,
+				RemoveStorageFunc: removeStorageFunc,
+				JobOptions: JobOptions{
+					PoolSize: testPoolSize,
+					LockKey:  testLockKey,
+				},
 			},
-			initialOutput:    []int{},
-			initialRemaining: len(input),
-			finalOutput:      finalExpected,
-			finalRunTime:     int64(len(input)),
-			workFunc:         workFunc,
-			cacheFunc:        cacheFunc,
-			cacheRemovalFunc: removeCacheFunc,
-			resetCache:       true,
-			checkEmptyCache:  true,
-		},
-		{
-			input:            input,
-			initialOutput:    []int{1, 2},
-			initialRemaining: 1,
-			finalOutput:      finalExpected,
-			finalRunTime:     int64(1),
-			workFunc:         workFuncWithCache,
-			cacheFunc:        cacheFunc,
-			cacheRemovalFunc: removeCacheFunc,
-			resetCache:       true,
-		},
-		{
-			input: input,
-			options: &JobOptions{
-				OverwriteCache: true,
-				LockKey:        testLockKey,
-				PoolSize:       testPoolSize,
+			initialOutput: JobOutput[string, int]{
+				ResultItems:    []int{1, 2},
+				RemainingItems: []string{"CCC"},
+				RunTime:        int64(0),
 			},
-			initialOutput:    []int{},
-			initialRemaining: len(input),
-			finalOutput:      finalExpected,
-			finalRunTime:     int64(len(input)),
-			workFunc:         workFuncWithCache,
-			cacheFunc:        cacheFunc,
-			cacheRemovalFunc: removeCacheFunc,
-			resetCache:       true,
-			checkEmptyCache:  true,
+			finalOutput: JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+				RunTime:        int64(1),
+			},
+		},
+		{
+			job: Job[string, int]{
+				WorkItems:         input,
+				WorkFunc:          workFunc,
+				RetrieveFunc:      retrieveFunc,
+				RemoveStorageFunc: removeStorageFunc,
+				JobOptions: JobOptions{
+					OverwriteRecords: true,
+					PoolSize:         testPoolSize,
+					LockKey:          testLockKey,
+				},
+			},
+			initialOutput: JobOutput[string, int]{
+				ResultItems:    []int{},
+				RemainingItems: input,
+				RunTime:        int64(0),
+			},
+			finalOutput: JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+				RunTime:        int64(len(input)),
+			},
+			resetStorage:      true,
+			checkEmptyStorage: true,
+		},
+		{
+			job: Job[string, int]{
+				WorkItems:         input,
+				WorkFunc:          workFuncWithStorage,
+				RetrieveFunc:      retrieveFunc,
+				RemoveStorageFunc: removeStorageFunc,
+				JobOptions: JobOptions{
+					PoolSize: testPoolSize,
+					LockKey:  testLockKey,
+				},
+			},
+			initialOutput: JobOutput[string, int]{
+				ResultItems:    []int{1, 2},
+				RemainingItems: []string{"CCC"},
+				RunTime:        int64(0),
+			},
+			finalOutput: JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+				RunTime:        int64(1),
+			},
+			resetStorage: true,
+		},
+		{
+			job: Job[string, int]{
+				WorkItems:         input,
+				WorkFunc:          workFuncWithStorage,
+				RetrieveFunc:      retrieveFunc,
+				RemoveStorageFunc: removeStorageFunc,
+				JobOptions: JobOptions{
+					OverwriteRecords: true,
+					PoolSize:         testPoolSize,
+					LockKey:          testLockKey,
+				},
+			},
+			initialOutput: JobOutput[string, int]{
+				ResultItems:    []int{},
+				RemainingItems: input,
+				RunTime:        int64(0),
+			},
+			finalOutput: JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+				RunTime:        int64(len(input)),
+			},
+			resetStorage:      true,
+			checkEmptyStorage: true,
 		},
 
 		// Errors
 
-		// Nil work function
+		// Nil Work Function
 		{
-			input:                 input,
-			initialOutput:         []int{},
-			workFunc:              nil,
-			initialErrorSubstring: "Cannot run job with a nil work function.",
-		},
-		{
-			input:                 nil,
-			initialOutput:         []int{},
-			workFunc:              nil,
-			initialErrorSubstring: "Cannot run job with a nil work function.",
-		},
-
-		// Bad cache function
-		{
-			input:                 input,
-			initialOutput:         []int{},
-			workFunc:              workFunc,
-			cacheFunc:             errorCacheFunc,
-			initialErrorSubstring: "Crazy cache error!",
-		},
-
-		// Bad cache removal function
-		{
-			input: input,
-			options: &JobOptions{
-				OverwriteCache: true,
-				LockKey:        testLockKey,
-				PoolSize:       testPoolSize,
+			job: Job[string, int]{
+				WorkItems: input,
+				WorkFunc:  nil,
 			},
-			initialOutput:       []int{},
-			initialRemaining:    len(input),
-			workFunc:            workFunc,
-			cacheRemovalFunc:    errorRemoveCacheFunc,
-			finalErrorSubstring: "Insane cache removal error!",
+			initialErrorSubstring: "Job cannot have a nil work function.",
+		},
+		{
+			job: Job[string, int]{
+				WorkItems: nil,
+				WorkFunc:  nil,
+			},
+			initialErrorSubstring: "Job cannot have a nil work function.",
+		},
+
+		// Bad Storage Function
+		{
+			job: Job[string, int]{
+				WorkItems:    input,
+				WorkFunc:     workFunc,
+				RetrieveFunc: errorRetrieveFunc,
+				JobOptions: JobOptions{
+					PoolSize: testPoolSize,
+				},
+			},
+			initialErrorSubstring: "Crazy retrieval error!",
+		},
+
+		// Bad Storage Removal Function
+		{
+			job: Job[string, int]{
+				WorkItems:         input,
+				WorkFunc:          workFunc,
+				RemoveStorageFunc: errorRemoveStorageFunc,
+				JobOptions: JobOptions{
+					OverwriteRecords: true,
+					PoolSize:         testPoolSize,
+				},
+			},
+			initialOutput: JobOutput[string, int]{
+				ResultItems:    []int{},
+				RemainingItems: input,
+				RunTime:        int64(0),
+			},
+			finalErrorSubstring: "Insane storage removal error!",
 		},
 	}
 
 	for i, testCase := range testCases {
-		if testCase.options == nil {
-			testCase.options = &JobOptions{
-				LockKey:  testLockKey,
-				PoolSize: testPoolSize,
-			}
-		}
+		testCase.job.WaitForCompletion = false
 
-		testCase.options.WaitForCompletion = false
-
-		output, numRemaining, runTime, err := RunJob(testCase.options, testCase.input, testCase.cacheFunc, testCase.cacheRemovalFunc, testCase.workFunc)
+		output, err := testCase.job.Run()
 		if err != nil {
 			if testCase.initialErrorSubstring != "" {
 				if !strings.Contains(err.Error(), testCase.initialErrorSubstring) {
@@ -517,24 +711,18 @@ func TestRunJobBase(test *testing.T) {
 			continue
 		}
 
-		if numRemaining != testCase.initialRemaining {
-			test.Errorf("Case %d: Unexpected number of initial items remaining. Expected: '%d', actual: '%d'.", i, testCase.initialRemaining, numRemaining)
-			continue
-		}
-
-		if runTime != 0 {
-			test.Errorf("Case %d: Unexpected initial run time. Expected: '0', actual: '%d'.", i, runTime)
-			continue
-		}
+		// Set the done channel to pass the equality check.
+		testCase.initialOutput.Done = output.Done
 
 		if !reflect.DeepEqual(output, testCase.initialOutput) {
-			test.Errorf("Case %d: Unexpected initial results. Expected: '%v', actual: '%v'.", i, testCase.initialOutput, output)
+			test.Errorf("Case %d: Unexpected initial results. Expected: '%s', actual: '%s'.",
+				i, util.MustToJSONIndent(testCase.initialOutput), util.MustToJSONIndent(output))
 			continue
 		}
 
-		testCase.options.WaitForCompletion = true
+		testCase.job.WaitForCompletion = true
 
-		output, numRemaining, runTime, err = RunJob(testCase.options, testCase.input, testCase.cacheFunc, testCase.cacheRemovalFunc, testCase.workFunc)
+		output, err = testCase.job.Run()
 		if err != nil {
 			if testCase.finalErrorSubstring != "" {
 				if !strings.Contains(err.Error(), testCase.finalErrorSubstring) {
@@ -552,60 +740,48 @@ func TestRunJobBase(test *testing.T) {
 			continue
 		}
 
-		if numRemaining != 0 {
-			test.Errorf("Case %d: Unexpected number of final items remaining. Expected: '0', actual: '%d'.", i, numRemaining)
-			continue
-		}
+		// Set the done channel to pass the equality check.
+		testCase.finalOutput.Done = output.Done
 
-		if runTime != testCase.finalRunTime {
-			test.Errorf("Case %d: Unexpected final run time. Expected: '%d', actual: '%d'.", i, testCase.finalRunTime, runTime)
-			continue
-		}
-
-		if !reflect.DeepEqual(testCase.finalOutput, output) {
+		if !reflect.DeepEqual(output, testCase.finalOutput) {
 			test.Errorf("Case %d: Unexpected final results. Expected: '%s', actual: '%s'.",
 				i, util.MustToJSONIndent(testCase.finalOutput), util.MustToJSONIndent(output))
 			continue
 		}
 
-		if testCase.checkEmptyCache && !testCase.resetCache {
-			test.Errorf("Case %d: A test that checks for an empty cache must reset the cache.", i)
-			cache = resetCache()
+		if testCase.checkEmptyStorage && !testCase.resetStorage {
+			test.Errorf("Case %d: A test that checks for an empty storage must reset the storage.", i)
+			storage = resetStorage()
 			continue
 		}
 
-		if testCase.resetCache {
-			if testCase.checkEmptyCache {
-				testCase.options.WaitForCompletion = false
+		if testCase.resetStorage {
+			if testCase.checkEmptyStorage {
+				testCase.job.WaitForCompletion = false
 
-				output, numRemaining, runTime, err = RunJob(testCase.options, testCase.input, testCase.cacheFunc, testCase.cacheRemovalFunc, testCase.workFunc)
+				output, err = testCase.job.Run()
 				if err != nil {
-					test.Errorf("Case %d: Failed to check for an empty cache: '%v'.", i, err)
-					cache = resetCache()
+					test.Errorf("Case %d: Failed to check for an empty storage: '%v'.", i, err)
+					storage = resetStorage()
 					continue
 				}
 
-				if runTime != 0 {
-					test.Errorf("Case %d: Unexpected run time during cache check. Expected: '0', actual: '%d'.", i, runTime)
-					cache = resetCache()
-					continue
+				expected := JobOutput[string, int]{
+					ResultItems:    []int{},
+					RemainingItems: input,
+					RunTime:        int64(0),
+					// Set the done channel to pass the equality check.
+					Done: output.Done,
 				}
 
-				if numRemaining != len(testCase.input) {
-					test.Errorf("Case %d: Unexpected number of items remaining during cache check. Expected: '%d', actual: '%d'.",
-						i, len(testCase.input), numRemaining)
-					cache = resetCache()
-					continue
-				}
-
-				if !reflect.DeepEqual(output, []int{}) {
-					test.Errorf("Case %d: Unexpected output during cache check. Expected: '%v', actual: '%v'.", i, []int{}, output)
-					cache = resetCache()
+				if !reflect.DeepEqual(output, expected) {
+					test.Errorf("Case %d: Unexpected output during storage check. Expected: '%v', actual: '%v'.", i, expected, output)
+					storage = resetStorage()
 					continue
 				}
 			}
 
-			cache = resetCache()
+			storage = resetStorage()
 		}
 	}
 }
@@ -621,7 +797,7 @@ func TestRunJobCancel(test *testing.T) {
 	workWaitGroup := sync.WaitGroup{}
 	workWaitGroup.Add(1)
 
-	workFunc := func(input string) (int, int64, error) {
+	sleepWorkFunc := func(input string) (int, int64, error) {
 		// Signal on the initial piece of work that we can make sure the workers have started up before we cancel.
 		if input == "A" {
 			workWaitGroup.Done()
@@ -635,11 +811,15 @@ func TestRunJobCancel(test *testing.T) {
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 
-	options := &JobOptions{
-		Context:           ctx,
-		WaitForCompletion: true,
-		LockKey:           testLockKey,
-		PoolSize:          testPoolSize,
+	job := &Job[string, int]{
+		WorkItems: input,
+		WorkFunc:  sleepWorkFunc,
+		JobOptions: JobOptions{
+			Context:           ctx,
+			WaitForCompletion: true,
+			PoolSize:          testPoolSize,
+			LockKey:           testLockKey,
+		},
 	}
 
 	// Cancel the context as soon as the initial worker signals it.
@@ -648,25 +828,58 @@ func TestRunJobCancel(test *testing.T) {
 		cancelFunc()
 	}()
 
-	output, numRemaining, runTime, err := RunJob(options, input, nil, nil, workFunc)
+	output, err := job.Run()
 	if err != nil {
 		test.Fatalf("Got an unexpected error: '%v'.", err)
 	}
 
-	if output != nil {
-		test.Fatalf("Got a result when it should have been nil.")
-	}
-
-	if numRemaining != 0 {
-		test.Fatalf("Got jobs remaining when it should be 0.")
-	}
-
-	if runTime != 0 {
-		test.Fatalf("Got run time when it should be 0.")
+	if !reflect.DeepEqual(output, JobOutput[string, int]{}) {
+		test.Fatalf("Unexpected result. Expected: '%s', actual: '%s'.",
+			util.MustToJSONIndent(JobOutput[string, int]{}), util.MustToJSONIndent(output))
 	}
 }
 
-func resetCache() map[string]int {
+func TestRunJobChannel(test *testing.T) {
+	input := []string{
+		"A",
+		"BB",
+		"CCC",
+	}
+
+	job := &Job[string, int]{
+		WorkItems: input,
+		WorkFunc:  workFunc,
+		JobOptions: JobOptions{
+			WaitForCompletion: false,
+			PoolSize:          testPoolSize,
+			LockKey:           testLockKey,
+		},
+	}
+
+	output, err := job.Run()
+	if err != nil {
+		test.Fatalf("Failed to run job: '%v'.", err)
+	}
+
+	// Wait for the worker to signal the job is done.
+	<-output.Done
+
+	expected := JobOutput[string, int]{
+		ResultItems:    []int{1, 2, 3},
+		RemainingItems: []string{},
+		RunTime:        int64(len(input)),
+		Done:           job.Done,
+	}
+
+	// Must check the job object itself for updates.
+	// The output variable is returned before the work is done.
+	if !reflect.DeepEqual(job.JobOutput, expected) {
+		test.Fatalf("Unexpected output. Expected: '%s', actual: '%s'.",
+			util.MustToJSONIndent(expected), util.MustToJSONIndent(job.JobOutput))
+	}
+}
+
+func resetStorage() map[string]int {
 	return map[string]int{
 		"A":  1,
 		"BB": 2,

--- a/internal/jobmanager/jobmanager_test.go
+++ b/internal/jobmanager/jobmanager_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/edulinq/autograder/internal/lockmanager"
 	"github.com/edulinq/autograder/internal/util"
 )
 
@@ -348,7 +347,7 @@ func TestRunJobBase(test *testing.T) {
 		return nil
 	}
 
-	errorRemoveStorageFunc := func(_ []string) error {
+	errorRemoveFunc := func(_ []string) error {
 		return fmt.Errorf("Insane storage removal error!")
 	}
 
@@ -390,13 +389,11 @@ func TestRunJobBase(test *testing.T) {
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: input,
-				RunTime:        int64(0),
 				WorkErrors:     map[int]error{},
 			},
 			finalOutput: &JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
-				RunTime:        int64(len(input)),
 				WorkErrors:     map[int]error{},
 			},
 		},
@@ -408,13 +405,11 @@ func TestRunJobBase(test *testing.T) {
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: nil,
-				RunTime:        int64(0),
 				WorkErrors:     map[int]error{},
 			},
 			finalOutput: &JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: nil,
-				RunTime:        int64(0),
 				WorkErrors:     map[int]error{},
 			},
 		},
@@ -426,13 +421,11 @@ func TestRunJobBase(test *testing.T) {
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: []string{},
-				RunTime:        int64(0),
 				WorkErrors:     map[int]error{},
 			},
 			finalOutput: &JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: []string{},
-				RunTime:        int64(0),
 				WorkErrors:     map[int]error{},
 			},
 		},
@@ -447,13 +440,11 @@ func TestRunJobBase(test *testing.T) {
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{1, 2},
 				RemainingItems: []string{"CCC"},
-				RunTime:        int64(0),
 				WorkErrors:     map[int]error{},
 			},
 			finalOutput: &JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
-				RunTime:        int64(1),
 				WorkErrors:     map[int]error{},
 			},
 		},
@@ -468,35 +459,11 @@ func TestRunJobBase(test *testing.T) {
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: input,
-				RunTime:        int64(0),
 				WorkErrors:     map[int]error{},
 			},
 			finalOutput: &JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
-				RunTime:        int64(len(input)),
-				WorkErrors:     map[int]error{},
-			},
-		},
-		{
-			job: Job[string, int]{
-				WorkItems: input,
-				// Won't be called due to OverwriteRecords.
-				RetrieveFunc: errorRetrieveFunc,
-				JobOptions: &JobOptions{
-					OverwriteRecords: true,
-				},
-			},
-			initialOutput: &JobOutput[string, int]{
-				ResultItems:    []int{},
-				RemainingItems: input,
-				RunTime:        int64(0),
-				WorkErrors:     map[int]error{},
-			},
-			finalOutput: &JobOutput[string, int]{
-				ResultItems:    finalExpected,
-				RemainingItems: []string{},
-				RunTime:        int64(len(input)),
 				WorkErrors:     map[int]error{},
 			},
 		},
@@ -504,20 +471,18 @@ func TestRunJobBase(test *testing.T) {
 		// Passing A Storage Removal Function
 		{
 			job: Job[string, int]{
-				WorkItems:         input,
-				RemoveStorageFunc: removeStorageFunc,
-				JobOptions:        &JobOptions{},
+				WorkItems:  input,
+				RemoveFunc: removeStorageFunc,
+				JobOptions: &JobOptions{},
 			},
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: input,
-				RunTime:        int64(0),
 				WorkErrors:     map[int]error{},
 			},
 			finalOutput: &JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
-				RunTime:        int64(len(input)),
 				WorkErrors:     map[int]error{},
 			},
 		},
@@ -525,19 +490,17 @@ func TestRunJobBase(test *testing.T) {
 			job: Job[string, int]{
 				WorkItems: input,
 				// Won't be called due to OverwriteRecords.
-				RemoveStorageFunc: errorRemoveStorageFunc,
-				JobOptions:        &JobOptions{},
+				RemoveFunc: errorRemoveFunc,
+				JobOptions: &JobOptions{},
 			},
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: input,
-				RunTime:        int64(0),
 				WorkErrors:     map[int]error{},
 			},
 			finalOutput: &JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
-				RunTime:        int64(len(input)),
 				WorkErrors:     map[int]error{},
 			},
 		},
@@ -548,27 +511,25 @@ func TestRunJobBase(test *testing.T) {
 				WorkItems:    input,
 				RetrieveFunc: retrieveFunc,
 				// Storage removal is not called.
-				RemoveStorageFunc: removeStorageFunc,
-				JobOptions:        &JobOptions{},
+				RemoveFunc: removeStorageFunc,
+				JobOptions: &JobOptions{},
 			},
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{1, 2},
 				RemainingItems: []string{"CCC"},
-				RunTime:        int64(0),
 				WorkErrors:     map[int]error{},
 			},
 			finalOutput: &JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
-				RunTime:        int64(1),
 				WorkErrors:     map[int]error{},
 			},
 		},
 		{
 			job: Job[string, int]{
-				WorkItems:         input,
-				RetrieveFunc:      retrieveFunc,
-				RemoveStorageFunc: removeStorageFunc,
+				WorkItems:    input,
+				RetrieveFunc: retrieveFunc,
+				RemoveFunc:   removeStorageFunc,
 				JobOptions: &JobOptions{
 					OverwriteRecords: true,
 				},
@@ -576,13 +537,11 @@ func TestRunJobBase(test *testing.T) {
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: input,
-				RunTime:        int64(0),
 				WorkErrors:     map[int]error{},
 			},
 			finalOutput: &JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
-				RunTime:        int64(len(input)),
 				WorkErrors:     map[int]error{},
 			},
 			expectedStorage: map[string]int{},
@@ -598,13 +557,11 @@ func TestRunJobBase(test *testing.T) {
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: input,
-				RunTime:        int64(0),
 				WorkErrors:     map[int]error{},
 			},
 			finalOutput: &JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
-				RunTime:        int64(len(input)),
 				WorkErrors:     map[int]error{},
 			},
 			expectedStorage: map[string]int{
@@ -624,13 +581,11 @@ func TestRunJobBase(test *testing.T) {
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: input,
-				RunTime:        int64(0),
 				WorkErrors:     map[int]error{},
 			},
 			finalOutput: &JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
-				RunTime:        int64(len(input)),
 				WorkErrors:     map[int]error{},
 			},
 			expectedStorage: map[string]int{
@@ -638,25 +593,22 @@ func TestRunJobBase(test *testing.T) {
 				"BB": 2,
 			},
 		},
-		// Even though both outputs expect 0 run time when processing one item,
-		// the run time is charged in the background.
 		{
 			job: Job[string, int]{
 				WorkItems:    input,
 				StoreFunc:    storageFunc,
 				RetrieveFunc: retrieveFunc,
+				RemoveFunc:   removeStorageFunc,
 				JobOptions:   &JobOptions{},
 			},
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{1, 2},
 				RemainingItems: []string{"CCC"},
-				RunTime:        int64(0),
 				WorkErrors:     map[int]error{},
 			},
 			finalOutput: &JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
-				RunTime:        int64(0),
 				WorkErrors:     map[int]error{},
 			},
 			expectedStorage: map[string]int{
@@ -667,36 +619,10 @@ func TestRunJobBase(test *testing.T) {
 		},
 		{
 			job: Job[string, int]{
-				WorkItems:         input,
-				StoreFunc:         storageFunc,
-				RetrieveFunc:      retrieveFunc,
-				RemoveStorageFunc: removeStorageFunc,
-				JobOptions:        &JobOptions{},
-			},
-			initialOutput: &JobOutput[string, int]{
-				ResultItems:    []int{1, 2},
-				RemainingItems: []string{"CCC"},
-				RunTime:        int64(0),
-				WorkErrors:     map[int]error{},
-			},
-			finalOutput: &JobOutput[string, int]{
-				ResultItems:    finalExpected,
-				RemainingItems: []string{},
-				RunTime:        int64(0),
-				WorkErrors:     map[int]error{},
-			},
-			expectedStorage: map[string]int{
-				"A":   1,
-				"BB":  2,
-				"CCC": 3,
-			},
-		},
-		{
-			job: Job[string, int]{
-				WorkItems:         input,
-				StoreFunc:         storageFunc,
-				RetrieveFunc:      retrieveFunc,
-				RemoveStorageFunc: removeStorageFunc,
+				WorkItems:    input,
+				StoreFunc:    storageFunc,
+				RetrieveFunc: retrieveFunc,
+				RemoveFunc:   removeStorageFunc,
 				JobOptions: &JobOptions{
 					OverwriteRecords: true,
 				},
@@ -704,13 +630,11 @@ func TestRunJobBase(test *testing.T) {
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: input,
-				RunTime:        int64(0),
 				WorkErrors:     map[int]error{},
 			},
 			finalOutput: &JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
-				RunTime:        int64(3),
 				WorkErrors:     map[int]error{},
 			},
 			// Storage happens after record removal.
@@ -722,10 +646,10 @@ func TestRunJobBase(test *testing.T) {
 		},
 		{
 			job: Job[string, int]{
-				WorkItems:         input,
-				StoreFunc:         storageFunc,
-				RetrieveFunc:      retrieveFunc,
-				RemoveStorageFunc: removeStorageFunc,
+				WorkItems:    input,
+				StoreFunc:    storageFunc,
+				RetrieveFunc: retrieveFunc,
+				RemoveFunc:   removeStorageFunc,
 				JobOptions: &JobOptions{
 					OverwriteRecords: true,
 					DryRun:           true,
@@ -734,13 +658,11 @@ func TestRunJobBase(test *testing.T) {
 			initialOutput: &JobOutput[string, int]{
 				ResultItems:    []int{},
 				RemainingItems: input,
-				RunTime:        int64(0),
 				WorkErrors:     map[int]error{},
 			},
 			finalOutput: &JobOutput[string, int]{
 				ResultItems:    finalExpected,
 				RemainingItems: []string{},
-				RunTime:        int64(len(input)),
 				WorkErrors:     map[int]error{},
 			},
 			expectedStorage: map[string]int{
@@ -755,7 +677,6 @@ func TestRunJobBase(test *testing.T) {
 		{
 			job: Job[string, int]{
 				WorkItems:    input,
-				WorkFunc:     workFunc,
 				RetrieveFunc: errorRetrieveFunc,
 				JobOptions:   &JobOptions{},
 			},
@@ -765,8 +686,8 @@ func TestRunJobBase(test *testing.T) {
 		// Bad Storage Removal Function
 		{
 			job: Job[string, int]{
-				WorkItems:         input,
-				RemoveStorageFunc: errorRemoveStorageFunc,
+				WorkItems:  input,
+				RemoveFunc: errorRemoveFunc,
 				JobOptions: &JobOptions{
 					OverwriteRecords: true,
 				},
@@ -781,28 +702,21 @@ func TestRunJobBase(test *testing.T) {
 		testCase.job.LockKey = testLockKey
 
 		testCase.job.WaitForCompletion = false
+		testCase.job.ReturnIncompleteResults = true
 
 		output := testCase.job.Run()
 
-		// Tests may be flaky if the new thread is started and gets the lock to modify output first.
-		// Loses the race to get the lock on output roughly 7/10,000 times.
-		lockmanager.Lock(output.JobID)
-		actual := &JobOutput[string, int]{
-			Error:          output.Error,
-			WorkErrors:     output.WorkErrors,
-			ResultItems:    output.ResultItems,
-			RemainingItems: output.RemainingItems,
-			RunTime:        output.RunTime,
-		}
-		lockmanager.Unlock(output.JobID)
+		// Clear channel and run time for comparison.
+		output.Done = nil
+		output.RunTime = 0
 
-		if actual.Error != nil {
+		if output.Error != nil {
 			if testCase.errorSubstring != "" {
-				if !strings.Contains(actual.Error.Error(), testCase.errorSubstring) {
-					test.Errorf("Case %d: Did not get expected error output on initial run. Expected substring: '%s', actual error: '%v'.", i, testCase.errorSubstring, actual.Error)
+				if !strings.Contains(output.Error.Error(), testCase.errorSubstring) {
+					test.Errorf("Case %d: Did not get expected error output on initial run. Expected substring: '%s', actual error: '%v'.", i, testCase.errorSubstring, output.Error)
 				}
 			} else {
-				test.Errorf("Case %d: Failed to run initial job: '%v'.", i, actual.Error)
+				test.Errorf("Case %d: Failed to run initial job: '%v'.", i, output.Error)
 			}
 
 			storage = resetStorage()
@@ -815,17 +729,14 @@ func TestRunJobBase(test *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(actual, testCase.initialOutput) {
+		if !reflect.DeepEqual(output, testCase.initialOutput) {
 			test.Errorf("Case %d: Unexpected initial results. Expected: '%s', actual: '%s'.",
-				i, util.MustToJSONIndent(testCase.initialOutput.toPrintableJobOutput()), util.MustToJSONIndent(actual.toPrintableJobOutput()))
+				i, util.MustToJSONIndent(testCase.initialOutput.toPrintableJobOutput()), util.MustToJSONIndent(output.toPrintableJobOutput()))
 			storage = resetStorage()
 			continue
 		}
 
 		testCase.job.WaitForCompletion = true
-
-		// Wait for the first run to complete before running again.
-		<-output.Done
 
 		output = testCase.job.Run()
 		if output.Error != nil {
@@ -836,7 +747,6 @@ func TestRunJobBase(test *testing.T) {
 
 		// Set the done channel and job ID to pass the equality check.
 		testCase.finalOutput.Done = output.Done
-		testCase.finalOutput.JobID = output.JobID
 
 		if !reflect.DeepEqual(output, testCase.finalOutput) {
 			test.Errorf("Case %d: Unexpected final results. Expected: '%s', actual: '%s'.",
@@ -859,108 +769,6 @@ func TestRunJobBase(test *testing.T) {
 		}
 
 		storage = resetStorage()
-	}
-}
-
-func TestRunJobReturnCopy(test *testing.T) {
-	input := []string{"A", "BB", "CCC"}
-
-	job := Job[string, int]{
-		WorkItems: input,
-		WorkFunc:  workFunc,
-		PoolSize:  testPoolSize,
-		LockKey:   testLockKey,
-		JobOptions: &JobOptions{
-			ReturnCopy: true,
-		},
-	}
-
-	output := job.Run()
-
-	// Return copy will close the channel before returning.
-	<-output.Done
-
-	if output.Error != nil {
-		test.Fatalf("Failed to run first job: '%v'.", output.Error)
-	}
-
-	expectedOutput := &JobOutput[string, int]{
-		ResultItems:    []int{},
-		RemainingItems: input,
-		RunTime:        int64(0),
-		WorkErrors:     map[int]error{},
-		JobID:          output.JobID,
-		Done:           output.Done,
-	}
-
-	if !reflect.DeepEqual(output, expectedOutput) {
-		test.Fatalf("Unexpected first result. Expected: '%s', actual: '%s'.",
-			util.MustToJSONIndent(expectedOutput.toPrintableJobOutput()), util.MustToJSONIndent(output.toPrintableJobOutput()))
-	}
-
-	storage := map[string]int{
-		"A":  1,
-		"BB": 2,
-	}
-
-	job.RetrieveFunc = func(inputs []string) ([]int, []string, error) {
-		outputs := make([]int, 0, len(storage))
-		remaining := make([]string, 0, len(inputs))
-
-		for _, input := range inputs {
-			output, ok := storage[input]
-			if !ok {
-				remaining = append(remaining, input)
-				continue
-			}
-
-			outputs = append(outputs, output)
-		}
-
-		return outputs, remaining, nil
-	}
-
-	output = job.Run()
-
-	if output.Error != nil {
-		test.Fatalf("Failed to run second job: '%v'.", output.Error)
-	}
-
-	expectedOutput = &JobOutput[string, int]{
-		ResultItems:    []int{1, 2},
-		RemainingItems: []string{"CCC"},
-		RunTime:        int64(0),
-		WorkErrors:     map[int]error{},
-		JobID:          output.JobID,
-		Done:           output.Done,
-	}
-
-	if !reflect.DeepEqual(output, expectedOutput) {
-		test.Fatalf("Unexpected second result. Expected: '%s', actual: '%s'.",
-			util.MustToJSONIndent(expectedOutput.toPrintableJobOutput()), util.MustToJSONIndent(output.toPrintableJobOutput()))
-	}
-
-	// Test overriding ReturnCopy.
-	job.WaitForCompletion = true
-
-	output = job.Run()
-
-	if output.Error != nil {
-		test.Fatalf("Failed to run third job: '%v'.", output.Error)
-	}
-
-	expectedOutput = &JobOutput[string, int]{
-		ResultItems:    []int{1, 2, 3},
-		RemainingItems: []string{},
-		RunTime:        int64(1),
-		WorkErrors:     map[int]error{},
-		JobID:          output.JobID,
-		Done:           output.Done,
-	}
-
-	if !reflect.DeepEqual(output, expectedOutput) {
-		test.Fatalf("Unexpected third result. Expected: '%s', actual: '%s'.",
-			util.MustToJSONIndent(expectedOutput.toPrintableJobOutput()), util.MustToJSONIndent(output.toPrintableJobOutput()))
 	}
 }
 
@@ -1021,10 +829,11 @@ func TestRunJobChannel(test *testing.T) {
 	}
 
 	job := &Job[string, int]{
-		WorkItems: input,
-		WorkFunc:  workFunc,
-		PoolSize:  testPoolSize,
-		LockKey:   testLockKey,
+		WorkItems:               input,
+		WorkFunc:                workFunc,
+		PoolSize:                testPoolSize,
+		LockKey:                 testLockKey,
+		ReturnIncompleteResults: false,
 		JobOptions: &JobOptions{
 			WaitForCompletion: false,
 		},
@@ -1041,10 +850,9 @@ func TestRunJobChannel(test *testing.T) {
 	expected := &JobOutput[string, int]{
 		ResultItems:    []int{1, 2, 3},
 		RemainingItems: []string{},
-		RunTime:        int64(len(input)),
+		RunTime:        output.RunTime,
 		WorkErrors:     map[int]error{},
 		Done:           output.Done,
-		JobID:          output.JobID,
 	}
 
 	if !reflect.DeepEqual(output, expected) {

--- a/internal/jobmanager/jobmanager_test.go
+++ b/internal/jobmanager/jobmanager_test.go
@@ -889,7 +889,7 @@ func TestRunJobCancel(test *testing.T) {
 		Error:          fmt.Errorf("Job was canceled: 'context canceled'."),
 		WorkErrors:     map[string]error{},
 		ResultItems:    map[string]int{},
-		RemainingItems: input,
+		RemainingItems: []string{},
 	}
 
 	output := job.Run()

--- a/internal/jobmanager/main_test.go
+++ b/internal/jobmanager/main_test.go
@@ -1,0 +1,36 @@
+package jobmanager
+
+// Note that this file is largely a copy of db/test.go.
+// The content is repeated to avoid an import cycle.
+
+import (
+	"os"
+	"testing"
+
+	"github.com/edulinq/autograder/internal/config"
+	"github.com/edulinq/autograder/internal/log"
+	"github.com/edulinq/autograder/internal/util"
+)
+
+// Use the common main for all tests in this package.
+func TestMain(suite *testing.M) {
+	// Run inside a func so defers will run before os.Exit().
+	code := func() int {
+		config.MustEnableUnitTestingMode()
+		log.SetLevelFatal()
+
+		defer CleanupTestingMain()
+
+		return suite.Run()
+	}()
+
+	os.Exit(code)
+}
+
+func CleanupTestingMain() {
+	// Remove any temp directories.
+	err := util.RemoveRecordedTempDirs()
+	if err != nil {
+		log.Error("Error when removing temp dirs.", err)
+	}
+}

--- a/internal/model/analysis_test.go
+++ b/internal/model/analysis_test.go
@@ -290,8 +290,8 @@ func TestAssignmentAnalysisOptionsMatchRelpathBase(test *testing.T) {
 }
 
 func TestNewIndividualAnalysisSummaryBase(test *testing.T) {
-	input := []*IndividualAnalysis{
-		&IndividualAnalysis{
+	input := map[string]*IndividualAnalysis{
+		"A": &IndividualAnalysis{
 			Score:               10,
 			LinesOfCode:         10,
 			SubmissionTimeDelta: 0,
@@ -306,7 +306,7 @@ func TestNewIndividualAnalysisSummaryBase(test *testing.T) {
 				},
 			},
 		},
-		&IndividualAnalysis{
+		"B": &IndividualAnalysis{
 			Score:               20,
 			LinesOfCode:         40,
 			SubmissionTimeDelta: 12,
@@ -325,7 +325,7 @@ func TestNewIndividualAnalysisSummaryBase(test *testing.T) {
 				},
 			},
 		},
-		&IndividualAnalysis{
+		"C": &IndividualAnalysis{
 			Score:               30,
 			LinesOfCode:         20,
 			SubmissionTimeDelta: 32,
@@ -340,7 +340,7 @@ func TestNewIndividualAnalysisSummaryBase(test *testing.T) {
 				},
 			},
 		},
-		&IndividualAnalysis{
+		"FAILURE": &IndividualAnalysis{
 			Failure: true,
 		},
 	}
@@ -499,11 +499,11 @@ func TestNewPairwiseAnalysisSummaryBase(test *testing.T) {
 		},
 	}
 
-	input := []*PairwiseAnalysis{
-		NewPairwiseAnalysis(NewPairwiseKey("A", "B"), nil, sims1, nil, nil),
-		NewPairwiseAnalysis(NewPairwiseKey("C", "D"), nil, sims2, nil, nil),
-		NewPairwiseAnalysis(NewPairwiseKey("E", "F"), nil, sims3, nil, nil),
-		&PairwiseAnalysis{
+	input := PairwiseAnalysisMap{
+		NewPairwiseKey("A", "B"): NewPairwiseAnalysis(NewPairwiseKey("A", "B"), nil, sims1, nil, nil),
+		NewPairwiseKey("C", "D"): NewPairwiseAnalysis(NewPairwiseKey("C", "D"), nil, sims2, nil, nil),
+		NewPairwiseKey("E", "F"): NewPairwiseAnalysis(NewPairwiseKey("E", "F"), nil, sims3, nil, nil),
+		NewPairwiseKey("FOO", "BAR"): &PairwiseAnalysis{
 			Failure: true,
 		},
 	}

--- a/internal/util/pool.go
+++ b/internal/util/pool.go
@@ -10,6 +10,7 @@ import (
 // Always call Done() before accessing any results to avoid concurrency issues.
 type PoolResult[OutputType any] struct {
 	// The results of the parallel pool.
+	// TODO: turn into a map
 	Results []OutputType
 
 	// A map of work errors using the item's index for item-level errors.
@@ -19,10 +20,12 @@ type PoolResult[OutputType any] struct {
 	// Use CompletedItems to determine which results were processed.
 	Canceled bool
 
+	// TODO: remove
 	// A list of indices that indicate which results are completed.
 	CompletedItems []bool
 
 	// An internal done function to signal the result can be accessed.
+	// TODO: keep the channel instead
 	doneFunc func()
 }
 
@@ -32,12 +35,14 @@ type resultItem[OutputType any] struct {
 	Error error
 }
 
+// TODO: IsDone? Also,
 func (this PoolResult[OutputType]) Done() {
 	if this.doneFunc != nil {
 		this.doneFunc()
 	}
 }
 
+// TODO: remove
 func (this PoolResult[OutputType]) GetCompletedResults() []OutputType {
 	this.Done()
 
@@ -56,6 +61,7 @@ func (this PoolResult[OutputType]) GetCompletedResults() []OutputType {
 	return completedResults
 }
 
+// TODO: not necessary, siblings inside
 func (this PoolResult[OutputType]) addResultItem(result resultItem[OutputType]) {
 	this.Results[result.Index] = result.Item
 	if result.Error != nil {
@@ -76,6 +82,7 @@ func RunParallelPoolMap[InputType any, OutputType any](poolSize int, workItems [
 		return PoolResult[OutputType]{}, fmt.Errorf("Pool size must be positive, got %d.", poolSize)
 	}
 
+	// TODO: move with sibling struct.
 	type WorkItem struct {
 		Index int
 		Item  InputType
@@ -121,8 +128,10 @@ func RunParallelPoolMap[InputType any, OutputType any](poolSize int, workItems [
 		}()
 
 		for i := 0; i < len(workItems); i++ {
+			// TODO: result collection.
 			select {
 			case <-ctx.Done():
+				// TODO: remove
 				if !completeInProgressWork {
 					return
 				}
@@ -181,6 +190,7 @@ func RunParallelPoolMap[InputType any, OutputType any](poolSize int, workItems [
 	select {
 	case <-ctx.Done():
 		// The context was canceled, return partial results.
+		// TODO: don't return a copy, if they don't want the results, they won't wait on Done().
 		if !completeInProgressWork {
 			// Return a stable copy with the current progress.
 			return PoolResult[OutputType]{

--- a/internal/util/pool.go
+++ b/internal/util/pool.go
@@ -135,6 +135,12 @@ func RunParallelPoolMap[InputType comparable, OutputType any](poolSize int, work
 						return
 					}
 
+					// Pulling work from the queue can be selected over a context cancellation.
+					// Check the context for cancellations before starting new work.
+					if ctx.Err() != nil {
+						return
+					}
+
 					result, err := workFunc(workItem)
 					resultQueue <- ResultItem{workItem, result, err}
 				}

--- a/internal/util/pool.go
+++ b/internal/util/pool.go
@@ -101,7 +101,7 @@ func RunParallelPoolMap[InputType any, OutputType any](poolSize int, workItems [
 	select {
 	case <-ctx.Done():
 		// The context was canceled, return nothing.
-		return nil, nil, nil
+		return results, workErrors, nil
 	case <-exitWaitGroupChan:
 		// Normal Completion
 	}

--- a/internal/util/pool.go
+++ b/internal/util/pool.go
@@ -18,32 +18,28 @@ type PoolResult[InputType comparable, OutputType any] struct {
 	// Signals that the parallel pool was canceled during execution.
 	Canceled bool
 
-	// An internal done channel to signal the result can be accessed.
+	// An internal done channel to signal the results can be accessed.
 	done chan any
 }
 
+// Use this method to block until the results can be accessed.
 func (this PoolResult[InputType, OutputType]) IsDone() {
-	<-this.done
+	if this.done != nil {
+		<-this.done
+	}
 }
 
 // Do a map function (one result for one input) with a parallel pool of workers.
 // Unless there is a critical error (the final return value) or cancellation,
-// every input will either be in Results or WorkErrors.
+// every input will be in PoolResult.Results.
 // A cancellation will stop new work from starting but complete in progress work asynchronously.
-// The partial results from a cancellation are available after IsDone() returns.
+// The partial results from a cancellation are available after PoolResult.IsDone() returns.
 // Consult the returned map of errors using the item to check for item-level errors.
+// Work level errors will not generate a non-nil return error, so both must be checked independently.
 // The underlying collection of input work items must not be modified as this function is running.
 func RunParallelPoolMap[InputType comparable, OutputType any](poolSize int, workItems []InputType, ctx context.Context, workFunc func(InputType) (OutputType, error)) (PoolResult[InputType, OutputType], error) {
-	doneChan := make(chan any)
-
-	output := PoolResult[InputType, OutputType]{
-		Results:    make(map[InputType]OutputType, len(workItems)),
-		WorkErrors: make(map[InputType]error, 0),
-		done:       doneChan,
-	}
-
 	if poolSize <= 0 {
-		return output, fmt.Errorf("Pool size must be positive, got %d.", poolSize)
+		return PoolResult[InputType, OutputType]{}, fmt.Errorf("Pool size must be positive, got %d.", poolSize)
 	}
 
 	type ResultItem struct {
@@ -54,11 +50,23 @@ func RunParallelPoolMap[InputType comparable, OutputType any](poolSize int, work
 
 	resultQueue := make(chan ResultItem, poolSize)
 	workQueue := make(chan InputType, poolSize)
-	doneCollectingChan := make(chan bool, poolSize)
+	doneChan := make(chan any)
+	doneWorkingChan := make(chan any)
+
 	workerExitWaitGroup := sync.WaitGroup{}
+	threadExitWaitGroup := sync.WaitGroup{}
+
+	output := PoolResult[InputType, OutputType]{
+		Results:    make(map[InputType]OutputType, len(workItems)),
+		WorkErrors: make(map[InputType]error, 0),
+		done:       doneChan,
+	}
 
 	// Load work.
+	threadExitWaitGroup.Add(1)
 	go func() {
+		defer threadExitWaitGroup.Done()
+
 		for _, item := range workItems {
 			// Either send a work item, or cancel.
 			select {
@@ -68,37 +76,39 @@ func RunParallelPoolMap[InputType comparable, OutputType any](poolSize int, work
 				// Item was already sent on the chan, do nothing here.
 			}
 		}
+
+		// Signal to the workers that there is no more work.
+		close(workQueue)
 	}()
 
-	workerExitWaitGroupChan := make(chan any)
-
 	// Collect results.
+	threadExitWaitGroup.Add(1)
 	go func() {
 		defer func() {
-			// Got all the results (or canceled), signal completion to all the workers.
-			for i := 0; i < (poolSize); i++ {
-				doneCollectingChan <- true
+			// All workers completed, drain remaining results.
+			// If the context was canceled, the number of results may be less than the number of work items.
+			for {
+				select {
+				case resultItem := <-resultQueue:
+					output.Results[resultItem.Input] = resultItem.Result
+					if resultItem.Error != nil {
+						output.WorkErrors[resultItem.Input] = resultItem.Error
+					}
+				default:
+					return
+				}
 			}
-
-			close(doneChan)
 		}()
+
+		// Close the done channel to signal that the output is accessible.
+		defer close(doneChan)
+
+		defer threadExitWaitGroup.Done()
 
 		for i := 0; i < len(workItems); i++ {
 			select {
-			case <-workerExitWaitGroupChan:
-				// All workers completed, drain remaining results.
-				// If the context was canceled, the number of results may be less than the number of work items.
-				for {
-					select {
-					case resultItem := <-resultQueue:
-						output.Results[resultItem.Input] = resultItem.Result
-						if resultItem.Error != nil {
-							output.WorkErrors[resultItem.Input] = resultItem.Error
-						}
-					default:
-						return
-					}
-				}
+			case <-doneWorkingChan:
+				return
 			case resultItem := <-resultQueue:
 				output.Results[resultItem.Input] = resultItem.Result
 				if resultItem.Error != nil {
@@ -110,17 +120,21 @@ func RunParallelPoolMap[InputType comparable, OutputType any](poolSize int, work
 
 	// Dispatch workers.
 	workerExitWaitGroup.Add(poolSize)
+	threadExitWaitGroup.Add(poolSize)
 	for i := 0; i < poolSize; i++ {
 		go func() {
 			defer workerExitWaitGroup.Done()
+			defer threadExitWaitGroup.Done()
 
 			for {
 				select {
 				case <-ctx.Done():
 					return
-				case <-doneCollectingChan:
-					return
-				case workItem := <-workQueue:
+				case workItem, ok := <-workQueue:
+					if !ok {
+						return
+					}
+
 					result, err := workFunc(workItem)
 					resultQueue <- ResultItem{workItem, result, err}
 				}
@@ -128,11 +142,14 @@ func RunParallelPoolMap[InputType comparable, OutputType any](poolSize int, work
 		}()
 	}
 
-	// Wait on the done chan in the background so we can select between it and the context.
-	// Technically we could wait on the worker wait group, but this will ensure that all results are collected.
+	// Wait on the wait group in the background so we can select between it and the context.
+	// Technically we could wait on the done chan, but this will ensure that all results are collected.
+	threadExitWaitGroup.Add(1)
 	go func() {
+		defer threadExitWaitGroup.Done()
+
 		workerExitWaitGroup.Wait()
-		close(workerExitWaitGroupChan)
+		close(doneWorkingChan)
 	}()
 
 	// Wait for either completion or cancellation.
@@ -145,6 +162,8 @@ func RunParallelPoolMap[InputType comparable, OutputType any](poolSize int, work
 	case <-doneChan:
 		// Normal Completion
 	}
+
+	threadExitWaitGroup.Wait()
 
 	return output, nil
 }

--- a/internal/util/pool.go
+++ b/internal/util/pool.go
@@ -102,7 +102,6 @@ func RunParallelPoolMap[InputType comparable, OutputType any](poolSize int, work
 
 		// Close the done channel to signal that the output is accessible.
 		defer close(doneChan)
-
 		defer threadExitWaitGroup.Done()
 
 		for i := 0; i < len(workItems); i++ {
@@ -149,7 +148,7 @@ func RunParallelPoolMap[InputType comparable, OutputType any](poolSize int, work
 	}
 
 	// Wait on the wait group in the background so we can select between it and the context.
-	// Technically we could wait on the done chan, but this will ensure that all results are collected.
+	// Technically we could wait on the done channel, but this will ensure that all workers have exited.
 	threadExitWaitGroup.Add(1)
 	go func() {
 		defer threadExitWaitGroup.Done()

--- a/internal/util/pool_test.go
+++ b/internal/util/pool_test.go
@@ -29,10 +29,15 @@ func TestRunParallelPoolMapBase(test *testing.T) {
 		"CCC",
 	}
 
-	expected := []int{
-		1,
-		2,
-		3,
+	expected := PoolResult[int]{
+		Results: []int{
+			1,
+			2,
+			3,
+		},
+		WorkErrors:     map[int]error{},
+		Canceled:       false,
+		CompletedItems: []bool{true, true, true},
 	}
 
 	workFunc := func(input string) (int, error) {
@@ -43,7 +48,7 @@ func TestRunParallelPoolMapBase(test *testing.T) {
 		// Count the number of active threads before running.
 		startThreadCount := runtime.NumGoroutine()
 
-		actual, workErrors, err := RunParallelPoolMap(testCase.numThreads, input, context.Background(), workFunc)
+		output, err := RunParallelPoolMap(testCase.numThreads, input, context.Background(), false, workFunc)
 		if err != nil {
 			if !testCase.hasError {
 				test.Errorf("Case %d: Got an unexpected error: '%v'.", i, err)
@@ -57,13 +62,15 @@ func TestRunParallelPoolMapBase(test *testing.T) {
 			continue
 		}
 
-		if len(workErrors) != 0 {
-			test.Errorf("Case %d: Unexpected work errors: '%s'.", i, MustToJSONIndent(workErrors))
-			continue
-		}
+		output.Done()
 
-		if !reflect.DeepEqual(expected, actual) {
-			test.Errorf("Case %d: Result not as expected. Expected: '%s', Actual: '%s'.", i, MustToJSONIndent(expected), MustToJSONIndent(actual))
+		// Clear output done function for comparison check.
+		output.doneFunc = nil
+
+		if !reflect.DeepEqual(expected, output) {
+			test.Errorf("Case %d: Result not as expected. Expected: '%s', actual: '%s'.",
+				i, MustToJSONIndent(expected), MustToJSONIndent(output))
+			continue
 		}
 
 		// Check for the thread count last (this gives the workers a small bit of extra time to exit).
@@ -71,21 +78,23 @@ func TestRunParallelPoolMapBase(test *testing.T) {
 		time.Sleep(25 * time.Millisecond)
 		endThreadCount := runtime.NumGoroutine()
 		if startThreadCount < endThreadCount {
-			test.Errorf("Case %d: Ended with more threads than we started with. Start: %d, End: %d.", i, startThreadCount, endThreadCount)
+			test.Errorf("Case %d: Ended with more threads than we started with. Start: %d, End: %d.",
+				i, startThreadCount, endThreadCount)
 			continue
 		}
 	}
 }
 
-func TestRunParallelPoolMapCancel(test *testing.T) {
+func TestRunParallelPoolMapCancelNoComplete(test *testing.T) {
 	testCases := []struct {
 		numThreads int
 	}{
 		{1},
-		{2},
-		{3},
-		{4},
-		{10},
+		// TEST
+		// {2},
+		// {3},
+		// {4},
+		// {10},
 	}
 
 	input := []string{
@@ -95,6 +104,9 @@ func TestRunParallelPoolMapCancel(test *testing.T) {
 	}
 
 	for i, testCase := range testCases {
+		// Count the number of active threads before running.
+		startThreadCount := runtime.NumGoroutine()
+
 		// Block until the first worker has started.
 		workWaitGroup := sync.WaitGroup{}
 		workWaitGroup.Add(1)
@@ -127,25 +139,152 @@ func TestRunParallelPoolMapCancel(test *testing.T) {
 			cancelFunc()
 		}()
 
-		actual, workErrors, err := RunParallelPoolMap(testCase.numThreads, input, ctx, workFunc)
+		output, err := RunParallelPoolMap(testCase.numThreads, input, ctx, false, workFunc)
 		if err != nil {
 			test.Errorf("Case %d: Got an unexpected error: '%v'.", i, err)
 			continue
 		}
 
-		expected := []int{1}
+		output.Done()
 
-		if !reflect.DeepEqual(actual, expected) {
-			test.Errorf("Case %d: Unexpected result. Expected: '%v', actual: '%v'.",
-				i, MustToJSONIndent(expected), MustToJSONIndent(actual))
+		expected := PoolResult[int]{
+			Results:        []int{1, 0, 0},
+			WorkErrors:     map[int]error{},
+			CompletedItems: []bool{true, false, false},
+			Canceled:       true,
+		}
+
+		// Clear output done function for comparison check.
+		output.doneFunc = nil
+
+		if !reflect.DeepEqual(output, expected) {
+			test.Errorf("Case %d: Unexpected results. Expected: '%v', actual: '%v'.",
+				i, MustToJSONIndent(expected), MustToJSONIndent(output))
 			continue
 		}
 
-		expectedWorkErrors := map[int]error{}
+		// Check for the thread count last (this gives the workers a small bit of extra time to exit).
+		// Note that there may be other tests with stray threads, so we are allowed to have less than when we started.
+		time.Sleep(10 * time.Second)
+		endThreadCount := runtime.NumGoroutine()
+		if startThreadCount < endThreadCount {
+			test.Errorf("Case %d: Ended with more threads than we started with. Start: %d, End: %d.",
+				i, startThreadCount, endThreadCount)
+			continue
+		}
+	}
+}
 
-		if !reflect.DeepEqual(workErrors, expectedWorkErrors) {
-			test.Errorf("Case %d: Unexpected work errors. Expected: '%v', actual: '%v'.",
-				i, MustToJSONIndent(expectedWorkErrors), MustToJSONIndent(workErrors))
+func TestRunParallelPoolMapCancelCompleteInProgress(test *testing.T) {
+	testCases := []struct {
+		numThreads int
+	}{
+		{1},
+		{2},
+		{3},
+		{4},
+		{10},
+	}
+
+	input := []string{
+		"A",
+		"BB",
+		"CCC",
+	}
+
+	for i, testCase := range testCases {
+		// Count the number of active threads before running.
+		startThreadCount := runtime.NumGoroutine()
+
+		// A channel to know which jobs started.
+		startedChan := make(chan string, len(input))
+
+		// Block until the first worker has started.
+		workWaitGroup := sync.WaitGroup{}
+		workWaitGroup.Add(1)
+
+		workFunc := func(input string) (int, error) {
+			startedChan <- input
+
+			// Signal on the first piece of work so that we can make sure the workers have started up before we cancel.
+			if input == "A" {
+				workWaitGroup.Done()
+				time.Sleep(time.Duration(5) * time.Millisecond)
+				return len(input), nil
+			}
+
+			time.Sleep(time.Duration(5) * time.Millisecond)
+
+			return len(input), nil
+		}
+
+		ctx, cancelFunc := context.WithCancel(context.Background())
+
+		// Cancel the context as soon as the first worker signals it.
+		go func() {
+			workWaitGroup.Wait()
+			cancelFunc()
+		}()
+
+		output, err := RunParallelPoolMap(testCase.numThreads, input, ctx, true, workFunc)
+		if err != nil {
+			test.Errorf("Case %d: Got an unexpected error: '%v'.", i, err)
+			continue
+		}
+
+		output.Done()
+
+		close(startedChan)
+
+		actualStarted := map[string]int{}
+		for startedInput := range startedChan {
+			actualStarted[startedInput] = len(startedInput)
+		}
+
+		// Worker threads race to start jobs before the cancellation signal.
+		// Rely on the started channel to know which jobs started before the cancellation signal.
+		// Test that all started work functions finish and their results are collected.
+		variableExpected := make([]int, len(input))
+		variableCompleted := make([]bool, len(input))
+		for input, output := range actualStarted {
+			switch input {
+			case "A":
+				variableExpected[0] = output
+				variableCompleted[0] = true
+			case "BB":
+				variableExpected[1] = output
+				variableCompleted[1] = true
+			case "CCC":
+				variableExpected[2] = output
+				variableCompleted[2] = true
+			default:
+				test.Errorf("Case %d: Unexpected work input: '%s'.", i, input)
+			}
+		}
+
+		expected := PoolResult[int]{
+			Results:        variableExpected,
+			WorkErrors:     map[int]error{},
+			Canceled:       true,
+			CompletedItems: variableCompleted,
+		}
+
+		// Clear output done function for comparison check.
+		output.doneFunc = nil
+
+		if !reflect.DeepEqual(output, expected) {
+			test.Errorf("Case %d: Unexpected results. Expected: '%v', actual: '%v'.",
+				i, MustToJSONIndent(expected), MustToJSONIndent(output))
+			continue
+		}
+
+		// Check for the thread count last (this gives the workers a small bit of extra time to exit).
+		// Note that there may be other tests with stray threads, so we are allowed to have less than when we started.
+		// time.Sleep(25 * time.Millisecond)
+		endThreadCount := runtime.NumGoroutine()
+		if startThreadCount < endThreadCount {
+			test.Errorf("Case %d: Ended with more threads than we started with. Start: %d, End: %d.",
+				i, startThreadCount, endThreadCount)
 			continue
 		}
 	}

--- a/internal/util/pool_test.go
+++ b/internal/util/pool_test.go
@@ -102,13 +102,13 @@ func TestRunParallelPoolMapCancel(test *testing.T) {
 	cancelWaitGroup := sync.WaitGroup{}
 	cancelWaitGroup.Add(1)
 
-	// Input 'A' will complete normally and 'BB' will be completed despite the cancellation signal during execution.
 	// Work will not start on input 'CCC'.
 	workFunc := func(input string) (int, error) {
-		// Signal on the second piece of work so that we can make sure the workers have started up before we cancel.
+		// Signal on the second piece of work so that work on input 'A' will complete normally.
 		if input == "BB" {
 			workWaitGroup.Done()
 			// Wait until the cancellation is triggered.
+			// Work on input 'BB' will complete despite the cancellation signal during execution.
 			cancelWaitGroup.Wait()
 		}
 

--- a/internal/util/pool_test.go
+++ b/internal/util/pool_test.go
@@ -29,15 +29,14 @@ func TestRunParallelPoolMapBase(test *testing.T) {
 		"CCC",
 	}
 
-	expected := PoolResult[int]{
-		Results: []int{
-			1,
-			2,
-			3,
+	expected := PoolResult[string, int]{
+		Results: map[string]int{
+			"A":   1,
+			"BB":  2,
+			"CCC": 3,
 		},
-		WorkErrors:     map[int]error{},
-		Canceled:       false,
-		CompletedItems: []bool{true, true, true},
+		WorkErrors: map[string]error{},
+		Canceled:   false,
 	}
 
 	workFunc := func(input string) (int, error) {
@@ -48,7 +47,7 @@ func TestRunParallelPoolMapBase(test *testing.T) {
 		// Count the number of active threads before running.
 		startThreadCount := runtime.NumGoroutine()
 
-		output, err := RunParallelPoolMap(testCase.numThreads, input, context.Background(), false, workFunc)
+		output, err := RunParallelPoolMap(testCase.numThreads, input, context.Background(), workFunc)
 		if err != nil {
 			if !testCase.hasError {
 				test.Errorf("Case %d: Got an unexpected error: '%v'.", i, err)
@@ -62,10 +61,10 @@ func TestRunParallelPoolMapBase(test *testing.T) {
 			continue
 		}
 
-		output.Done()
+		output.IsDone()
 
-		// Clear output done function for comparison check.
-		output.doneFunc = nil
+		// Clear output done channel for comparison check.
+		output.done = nil
 
 		if !reflect.DeepEqual(expected, output) {
 			test.Errorf("Case %d: Result not as expected. Expected: '%s', actual: '%s'.",
@@ -86,96 +85,6 @@ func TestRunParallelPoolMapBase(test *testing.T) {
 }
 
 func TestRunParallelPoolMapCancel(test *testing.T) {
-	testCases := []struct {
-		numThreads int
-	}{
-		{1},
-		{2},
-		{3},
-		{4},
-		{10},
-	}
-
-	input := []string{
-		"A",
-		"BB",
-		"CCC",
-	}
-
-	for i, testCase := range testCases {
-		// Count the number of active threads before running.
-		startThreadCount := runtime.NumGoroutine()
-
-		// Block until the first worker has started.
-		workWaitGroup := sync.WaitGroup{}
-		workWaitGroup.Add(1)
-
-		workFunc := func(input string) (int, error) {
-			// Allow the first input to return a result to test partial results.
-			if input == "A" {
-				return len(input), nil
-			}
-
-			// Sleep to allow the first result to be captured.
-			time.Sleep(2 * time.Millisecond)
-
-			// Signal on the second piece of work so that we can make sure the workers have started up before we cancel.
-			if input == "BB" {
-				workWaitGroup.Done()
-			}
-
-			// Sleep to allow the the stop signal to go through.
-			// We do not want to capture any more results.
-			time.Sleep(2 * time.Millisecond)
-
-			return len(input), nil
-		}
-
-		ctx, cancelFunc := context.WithCancel(context.Background())
-
-		// Cancel the context as soon as the first worker signals it.
-		go func() {
-			workWaitGroup.Wait()
-			cancelFunc()
-		}()
-
-		output, err := RunParallelPoolMap(testCase.numThreads, input, ctx, false, workFunc)
-		if err != nil {
-			test.Errorf("Case %d: Got an unexpected error: '%v'.", i, err)
-			continue
-		}
-
-		output.Done()
-
-		expected := PoolResult[int]{
-			Results:        []int{1, 0, 0},
-			WorkErrors:     map[int]error{},
-			CompletedItems: []bool{true, false, false},
-			Canceled:       true,
-		}
-
-		// Clear output done function for comparison check.
-		output.doneFunc = nil
-
-		if !reflect.DeepEqual(output, expected) {
-			test.Errorf("Case %d: Unexpected results. Expected: '%v', actual: '%v'.",
-				i, MustToJSONIndent(expected), MustToJSONIndent(output))
-			continue
-		}
-
-		// Check for the thread count last (this gives the workers a small bit of extra time to exit).
-		// Note that there may be other tests with stray threads, so we are allowed to have less than when we started.
-		time.Sleep(1 * time.Second)
-		endThreadCount := runtime.NumGoroutine()
-		if startThreadCount < endThreadCount {
-			test.Errorf("Case %d: Ended with more threads than we started with. Start: %d, End: %d.",
-				i, startThreadCount, endThreadCount)
-			continue
-		}
-	}
-}
-
-func TestRunParallelPoolMapCancelSoft(test *testing.T) {
 	testCases := []struct {
 		numThreads int
 	}{
@@ -226,50 +135,31 @@ func TestRunParallelPoolMapCancelSoft(test *testing.T) {
 			cancelFunc()
 		}()
 
-		output, err := RunParallelPoolMap(testCase.numThreads, input, ctx, true, workFunc)
+		output, err := RunParallelPoolMap(testCase.numThreads, input, ctx, workFunc)
 		if err != nil {
 			test.Errorf("Case %d: Got an unexpected error: '%v'.", i, err)
 			continue
 		}
 
-		output.Done()
+		output.IsDone()
 
 		close(startedChan)
 
-		actualStarted := map[string]int{}
-		for startedInput := range startedChan {
-			actualStarted[startedInput] = len(startedInput)
-		}
-
 		// Workers race to start before the cancellation.
 		// Ensure all started work is completed.
-		variableExpected := make([]int, len(input))
-		variableCompleted := make([]bool, len(input))
-		for input, output := range actualStarted {
-			switch input {
-			case "A":
-				variableExpected[0] = output
-				variableCompleted[0] = true
-			case "BB":
-				variableExpected[1] = output
-				variableCompleted[1] = true
-			case "CCC":
-				variableExpected[2] = output
-				variableCompleted[2] = true
-			default:
-				test.Errorf("Case %d: Unexpected work input: '%s'.", i, input)
-			}
+		expectedResults := map[string]int{}
+		for input := range startedChan {
+			expectedResults[input] = len(input)
 		}
 
-		expected := PoolResult[int]{
-			Results:        variableExpected,
-			WorkErrors:     map[int]error{},
-			Canceled:       true,
-			CompletedItems: variableCompleted,
+		expected := PoolResult[string, int]{
+			Results:    expectedResults,
+			WorkErrors: map[string]error{},
+			Canceled:   true,
 		}
 
-		// Clear output done function for comparison check.
-		output.doneFunc = nil
+		// Clear output done channel for comparison check.
+		output.done = nil
 
 		if !reflect.DeepEqual(output, expected) {
 			test.Errorf("Case %d: Unexpected results. Expected: '%v', actual: '%v'.",
@@ -279,7 +169,6 @@ func TestRunParallelPoolMapCancelSoft(test *testing.T) {
 
 		// Check for the thread count last (this gives the workers a small bit of extra time to exit).
 		// Note that there may be other tests with stray threads, so we are allowed to have less than when we started.
-		// time.Sleep(25 * time.Millisecond)
 		endThreadCount := runtime.NumGoroutine()
 		if startThreadCount < endThreadCount {
 			test.Errorf("Case %d: Ended with more threads than we started with. Start: %d, End: %d.",

--- a/resources/api.json
+++ b/resources/api.json
@@ -136,8 +136,12 @@
             "description": "Get the result of a individual analysis for the specified submissions.",
             "input": [
                 {
-                    "name": "job-options",
-                    "type": "*jobmanager.JobOptions"
+                    "name": "dry-run",
+                    "type": "bool"
+                },
+                {
+                    "name": "overwrite-records",
+                    "type": "bool"
                 },
                 {
                     "name": "submissions",
@@ -150,6 +154,10 @@
                 {
                     "name": "user-pass",
                     "type": "string"
+                },
+                {
+                    "name": "wait-for-completion",
+                    "type": "bool"
                 }
             ],
             "output": [
@@ -175,8 +183,12 @@
             "description": "Get the result of a pairwise analysis for the specified submissions.",
             "input": [
                 {
-                    "name": "job-options",
-                    "type": "*jobmanager.JobOptions"
+                    "name": "dry-run",
+                    "type": "bool"
+                },
+                {
+                    "name": "overwrite-records",
+                    "type": "bool"
                 },
                 {
                     "name": "submissions",
@@ -189,6 +201,10 @@
                 {
                     "name": "user-pass",
                     "type": "string"
+                },
+                {
+                    "name": "wait-for-completion",
+                    "type": "bool"
                 }
             ],
             "output": [
@@ -1358,12 +1374,20 @@
             "category": "struct",
             "fields": [
                 {
-                    "name": "job-options",
-                    "type": "*jobmanager.JobOptions"
+                    "name": "dry-run",
+                    "type": "bool"
+                },
+                {
+                    "name": "overwrite-records",
+                    "type": "bool"
                 },
                 {
                     "name": "submissions",
                     "type": "[]string"
+                },
+                {
+                    "name": "wait-for-completion",
+                    "type": "bool"
                 }
             ]
         },
@@ -1796,11 +1820,7 @@
             "category": "struct",
             "fields": [
                 {
-                    "name": "dry-run",
-                    "type": "bool"
-                },
-                {
-                    "name": "overwrite-cache",
+                    "name": "overwrite-records",
                     "type": "bool"
                 },
                 {

--- a/resources/api.json
+++ b/resources/api.json
@@ -144,6 +144,10 @@
                     "type": "bool"
                 },
                 {
+                    "name": "return-copy",
+                    "type": "bool"
+                },
+                {
                     "name": "submissions",
                     "type": "[]string"
                 },
@@ -188,6 +192,10 @@
                 },
                 {
                     "name": "overwrite-records",
+                    "type": "bool"
+                },
+                {
+                    "name": "return-copy",
                     "type": "bool"
                 },
                 {
@@ -1382,6 +1390,10 @@
                     "type": "bool"
                 },
                 {
+                    "name": "return-copy",
+                    "type": "bool"
+                },
+                {
                     "name": "submissions",
                     "type": "[]string"
                 },
@@ -1826,6 +1838,10 @@
                 },
                 {
                     "name": "overwrite-records",
+                    "type": "bool"
+                },
+                {
+                    "name": "return-copy",
                     "type": "bool"
                 },
                 {

--- a/resources/api.json
+++ b/resources/api.json
@@ -1821,6 +1821,10 @@
             "description": "JobOptions contains user level options for a Job.\nThese options allow for optional context cancellation of the Job.",
             "fields": [
                 {
+                    "name": "dry-run",
+                    "type": "bool"
+                },
+                {
                     "name": "overwrite-records",
                     "type": "bool"
                 },

--- a/resources/api.json
+++ b/resources/api.json
@@ -1818,6 +1818,7 @@
         },
         "jobmanager.JobOptions": {
             "category": "struct",
+            "description": "JobOptions contains user level options for a Job.\nThese options allow for optional context cancellation of the Job.",
             "fields": [
                 {
                     "name": "overwrite-records",

--- a/resources/api.json
+++ b/resources/api.json
@@ -171,7 +171,7 @@
                 },
                 {
                     "name": "results",
-                    "type": "[]*model.IndividualAnalysis"
+                    "type": "map[string]*model.IndividualAnalysis"
                 },
                 {
                     "name": "summary",
@@ -218,7 +218,7 @@
                 },
                 {
                     "name": "results",
-                    "type": "[]*model.PairwiseAnalysis"
+                    "type": "model.PairwiseAnalysisMap"
                 },
                 {
                     "name": "summary",
@@ -2533,6 +2533,9 @@
                     "type": "[][]string"
                 }
             ]
+        },
+        "model.PairwiseAnalysisMap": {
+            "category": "map"
         },
         "model.PairwiseAnalysisSummary": {
             "category": "struct",

--- a/resources/api.json
+++ b/resources/api.json
@@ -136,12 +136,8 @@
             "description": "Get the result of a individual analysis for the specified submissions.",
             "input": [
                 {
-                    "name": "dry-run",
-                    "type": "bool"
-                },
-                {
-                    "name": "overwrite-cache",
-                    "type": "bool"
+                    "name": "job-options",
+                    "type": "*jobmanager.JobOptions"
                 },
                 {
                     "name": "submissions",
@@ -154,10 +150,6 @@
                 {
                     "name": "user-pass",
                     "type": "string"
-                },
-                {
-                    "name": "wait-for-completion",
-                    "type": "bool"
                 }
             ],
             "output": [
@@ -183,12 +175,8 @@
             "description": "Get the result of a pairwise analysis for the specified submissions.",
             "input": [
                 {
-                    "name": "dry-run",
-                    "type": "bool"
-                },
-                {
-                    "name": "overwrite-cache",
-                    "type": "bool"
+                    "name": "job-options",
+                    "type": "*jobmanager.JobOptions"
                 },
                 {
                     "name": "submissions",
@@ -201,10 +189,6 @@
                 {
                     "name": "user-pass",
                     "type": "string"
-                },
-                {
-                    "name": "wait-for-completion",
-                    "type": "bool"
                 }
             ],
             "output": [
@@ -1374,20 +1358,12 @@
             "category": "struct",
             "fields": [
                 {
-                    "name": "dry-run",
-                    "type": "bool"
-                },
-                {
-                    "name": "overwrite-cache",
-                    "type": "bool"
+                    "name": "job-options",
+                    "type": "*jobmanager.JobOptions"
                 },
                 {
                     "name": "submissions",
                     "type": "[]string"
-                },
-                {
-                    "name": "wait-for-completion",
-                    "type": "bool"
                 }
             ]
         },
@@ -1813,6 +1789,23 @@
                 {
                     "name": "to",
                     "type": "[]string"
+                }
+            ]
+        },
+        "jobmanager.JobOptions": {
+            "category": "struct",
+            "fields": [
+                {
+                    "name": "dry-run",
+                    "type": "bool"
+                },
+                {
+                    "name": "overwrite-cache",
+                    "type": "bool"
+                },
+                {
+                    "name": "wait-for-completion",
+                    "type": "bool"
                 }
             ]
         },

--- a/resources/api.json
+++ b/resources/api.json
@@ -144,10 +144,6 @@
                     "type": "bool"
                 },
                 {
-                    "name": "return-copy",
-                    "type": "bool"
-                },
-                {
                     "name": "submissions",
                     "type": "[]string"
                 },
@@ -192,10 +188,6 @@
                 },
                 {
                     "name": "overwrite-records",
-                    "type": "bool"
-                },
-                {
-                    "name": "return-copy",
                     "type": "bool"
                 },
                 {
@@ -1390,10 +1382,6 @@
                     "type": "bool"
                 },
                 {
-                    "name": "return-copy",
-                    "type": "bool"
-                },
-                {
                     "name": "submissions",
                     "type": "[]string"
                 },
@@ -1838,10 +1826,6 @@
                 },
                 {
                     "name": "overwrite-records",
-                    "type": "bool"
-                },
-                {
-                    "name": "return-copy",
                     "type": "bool"
                 },
                 {

--- a/resources/api.json
+++ b/resources/api.json
@@ -1685,6 +1685,14 @@
                 {
                     "name": "fields",
                     "type": "[]core.FieldDescription"
+                },
+                {
+                    "name": "key-type",
+                    "type": "string"
+                },
+                {
+                    "name": "value-type",
+                    "type": "string"
                 }
             ]
         },
@@ -2535,7 +2543,9 @@
             ]
         },
         "model.PairwiseAnalysisMap": {
-            "category": "map"
+            "category": "map",
+            "key-type": "model.PairwiseKey",
+            "value-type": "*model.PairwiseAnalysis"
         },
         "model.PairwiseAnalysisSummary": {
             "category": "struct",


### PR DESCRIPTION
This PR creates a new package, jobmanager. The jobmanager package includes common infrastructure for large jobs that are too big too be run full serial or full parallel.

The jobmanager package provides `RunJob()` that has the utility of parallel pools while abstracting some of the implementation details of synchronization, caching, over-writing caches, and contexts.

`RunJob()` is thoroughly tested and is used by `internal/analysis` for both individual and pairwise. These examples give confidence in the flexibility of the `RunJob()` framework.