### PR TITLE
Added API endpoint for server heartbeat.

### DIFF
--- a/internal/api/metadata/heartbeat.go
+++ b/internal/api/metadata/heartbeat.go
@@ -1,0 +1,27 @@
+package metadata
+
+import (
+	"github.com/edulinq/autograder/internal/api/core"
+	"github.com/edulinq/autograder/internal/util"
+)
+
+type HeartbeatRequest struct {
+	core.APIRequest
+}
+
+type HeartbeatResponse struct {
+	ServerVersion util.Version `json:"server-version"`
+}
+
+func HandleHeartbeat(request *HeartbeatRequest) (*HeartbeatResponse, *core.APIError) {
+	version, err := util.GetFullCachedVersion()
+	if err != nil {
+		return nil, core.NewInternalError("-502", request, "Unable to get API heartbeat.").Err(err)
+	}
+
+	response := HeartbeatResponse{
+		ServerVersion: version,
+	}
+
+	return &response, nil
+}

--- a/internal/api/metadata/heartbeat.go
+++ b/internal/api/metadata/heartbeat.go
@@ -13,10 +13,11 @@ type HeartbeatResponse struct {
 	ServerVersion util.Version `json:"server-version"`
 }
 
+// Get server heartbeat.
 func HandleHeartbeat(request *HeartbeatRequest) (*HeartbeatResponse, *core.APIError) {
 	version, err := util.GetFullCachedVersion()
 	if err != nil {
-		return nil, core.NewInternalError("-502", request, "Unable to get API heartbeat.").Err(err)
+		return nil, core.NewInternalError("-502", request, "Unable to get server version.").Err(err)
 	}
 
 	response := HeartbeatResponse{

--- a/internal/api/metadata/heartbeat_test.go
+++ b/internal/api/metadata/heartbeat_test.go
@@ -18,10 +18,13 @@ func TestHeartbeat(test *testing.T) {
 
 	expected, err := util.GetFullCachedVersion()
 	if err != nil {
-		test.Fatalf("Failed to get expected server version: %v", err)
-		return
+		test.Fatalf("Failed to get expected server version: '%v'.", err)
 	}
+
 	if heartbeatResponse.ServerVersion != expected {
-		test.Fatalf("Server version mismatch. Expected %s, got %s", expected, heartbeatResponse.ServerVersion)
+		test.Fatalf("Server version mismatch. Expected '%s', Actual '%s'.",
+			util.MustToJSONIndent(expected),
+			util.MustToJSONIndent(heartbeatResponse.ServerVersion),
+		)
 	}
 }

--- a/internal/api/metadata/heartbeat_test.go
+++ b/internal/api/metadata/heartbeat_test.go
@@ -1,0 +1,27 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/edulinq/autograder/internal/api/core"
+	"github.com/edulinq/autograder/internal/util"
+)
+
+func TestHeartbeat(test *testing.T) {
+	response := core.SendTestAPIRequest(test, "metadata/heartbeat", nil)
+	if !response.Success {
+		test.Fatalf("Failed to get heartbeat.")
+	}
+
+	var heartbeatResponse HeartbeatResponse
+	util.MustJSONFromString(util.MustToJSON(response.Content), &heartbeatResponse)
+
+	expected, err := util.GetFullCachedVersion()
+	if err != nil {
+		test.Fatalf("Failed to get expected server version: %v", err)
+		return
+	}
+	if heartbeatResponse.ServerVersion != expected {
+		test.Fatalf("Server version mismatch. Expected %s, got %s", expected, heartbeatResponse.ServerVersion)
+	}
+}

--- a/internal/api/metadata/heartbeat_test.go
+++ b/internal/api/metadata/heartbeat_test.go
@@ -22,7 +22,7 @@ func TestHeartbeat(test *testing.T) {
 	}
 
 	if heartbeatResponse.ServerVersion != expected {
-		test.Fatalf("Server version mismatch. Expected '%s', Actual '%s'.",
+		test.Fatalf("Server version mismatch. Expected: '%s', Actual: '%s'.",
 			util.MustToJSONIndent(expected),
 			util.MustToJSONIndent(heartbeatResponse.ServerVersion),
 		)

--- a/internal/api/metadata/routes.go
+++ b/internal/api/metadata/routes.go
@@ -8,6 +8,7 @@ import (
 
 var routes []core.Route = []core.Route{
 	core.MustNewAPIRoute(`metadata/describe`, HandleDescribe),
+	core.MustNewAPIRoute(`metadata/heartbeat`, HandleHeartbeat),
 }
 
 func GetRoutes() *[]core.Route {

--- a/resources/api.json
+++ b/resources/api.json
@@ -1084,6 +1084,16 @@
                 }
             ]
         },
+        "metadata/heartbeat": {
+            "description": "Get server heartbeat.",
+            "input": [],
+            "output": [
+                {
+                    "name": "server-version",
+                    "type": "util.Version"
+                }
+            ]
+        },
         "stats/query": {
             "description": "Query stats for the server.",
             "input": [
@@ -2930,6 +2940,23 @@
         "util.FileSpecType": {
             "category": "alias",
             "alias-type": "string"
+        },
+        "util.Version": {
+            "category": "struct",
+            "fields": [
+                {
+                    "name": "base-version",
+                    "type": "string"
+                },
+                {
+                    "name": "git-hash",
+                    "type": "string"
+                },
+                {
+                    "name": "is-dirty",
+                    "type": "bool"
+                }
+            ]
         }
     }
 }


### PR DESCRIPTION
This PR adds an API endpoint `metadata/heartbeat` that returns the current server version when called in a GET request.