### PR TITLE
Refactored the parallel pool utility to better handle context cancell…

### DIFF
--- a/internal/analysis/individual_test.go
+++ b/internal/analysis/individual_test.go
@@ -24,8 +24,8 @@ func TestIndividualAnalysisBase(test *testing.T) {
 		"course101::hw0::course-student@test.edulinq.org::1697406265",
 	}
 
-	expected := []*model.IndividualAnalysis{
-		&model.IndividualAnalysis{
+	expected := map[string]*model.IndividualAnalysis{
+		ids[0]: &model.IndividualAnalysis{
 			AnalysisTimestamp: timestamp.Zero(),
 			Options:           assignment.AssignmentAnalysisOptions,
 
@@ -104,7 +104,7 @@ func TestIndividualAnalysisBase(test *testing.T) {
 	}
 }
 
-func testIndividual(test *testing.T, ids []string, expected []*model.IndividualAnalysis, expectedInitialCacheCount int) {
+func testIndividual(test *testing.T, ids []string, expected map[string]*model.IndividualAnalysis, expectedInitialCacheCount int) {
 	queryResult, err := db.GetIndividualAnalysis(ids)
 	if err != nil {
 		test.Fatalf("Failed to do initial query for cached anslysis: '%v'.", err)
@@ -236,22 +236,22 @@ func TestIndividualAnalysisIncludeExclude(test *testing.T) {
 			continue
 		}
 
-		if testCase.expectedCount != len(results[0].Files) {
+		if testCase.expectedCount != len(results[submissionIDs[0]].Files) {
 			test.Errorf("Case %d: Unexpected number of result files. Expected: %d, Actual: %d.",
-				i, testCase.expectedCount, len(results[0].Files))
+				i, testCase.expectedCount, len(results[submissionIDs[0]].Files))
 			continue
 		}
 
-		if (baseCount - testCase.expectedCount) != len(results[0].SkippedFiles) {
+		if (baseCount - testCase.expectedCount) != len(results[submissionIDs[0]].SkippedFiles) {
 			test.Errorf("Case %d: Unexpected number of skipped files. Expected: %d, Actual: %d.",
-				i, (baseCount - testCase.expectedCount), len(results[0].SkippedFiles))
+				i, (baseCount - testCase.expectedCount), len(results[submissionIDs[0]].SkippedFiles))
 			continue
 		}
 
 		if testCase.expectedCount == 0 {
-			if relpath != results[0].SkippedFiles[0] {
+			if relpath != results[submissionIDs[0]].SkippedFiles[0] {
 				test.Errorf("Case %d: Unexpected skipped file. Expected: '%s', Actual: '%s'.",
-					i, relpath, results[0].SkippedFiles[0])
+					i, relpath, results[submissionIDs[0]].SkippedFiles[0])
 				continue
 			}
 		}
@@ -487,7 +487,7 @@ func TestIndividualAnalysisCountBase(test *testing.T) {
 
 		// Check if the result was from the cache using the start time.
 		if len(results) > 0 {
-			resultTime := results[0].AnalysisTimestamp
+			resultTime := results[testCase.options.ResolvedSubmissionIDs[0]].AnalysisTimestamp
 			resultIsFromCache := (resultTime <= startTime)
 
 			if testCase.expectedResultIsFromCache != resultIsFromCache {
@@ -559,11 +559,12 @@ func TestIndividualAnalysisFailureBase(test *testing.T) {
 		test.Fatalf("Found %d results, when 1 was expected.", len(results))
 	}
 
-	if !results[0].Failure {
+	if !results[options.ResolvedSubmissionIDs[0]].Failure {
 		test.Fatalf("Result is not a failure, when it should be.")
 	}
 
-	if !strings.Contains(results[0].FailureMessage, expectedMessageSubstring) {
-		test.Fatalf("Failure message does not contain expected substring. Expected Substring: '%s', Actual: '%s'.", expectedMessageSubstring, results[0].FailureMessage)
+	if !strings.Contains(results[options.ResolvedSubmissionIDs[0]].FailureMessage, expectedMessageSubstring) {
+		test.Fatalf("Failure message does not contain expected substring. Expected Substring: '%s', Actual: '%s'.",
+			expectedMessageSubstring, results[options.ResolvedSubmissionIDs[0]].FailureMessage)
 	}
 }

--- a/internal/analysis/pairwise.go
+++ b/internal/analysis/pairwise.go
@@ -45,7 +45,7 @@ var forceDefaultEnginesForTesting bool = false
 // Otherwise, this function will return any cached results from the database
 // and the remaining analysis will be done asynchronously.
 // Returns: (complete results, number of pending analysis runs, error)
-func PairwiseAnalysis(options AnalysisOptions) ([]*model.PairwiseAnalysis, int, error) {
+func PairwiseAnalysis(options AnalysisOptions) (model.PairwiseAnalysisMap, int, error) {
 	if options.Context == nil {
 		options.Context = context.Background()
 	}
@@ -66,7 +66,10 @@ func PairwiseAnalysis(options AnalysisOptions) ([]*model.PairwiseAnalysis, int, 
 			return nil, 0, err
 		}
 
-		completeAnalysis = append(completeAnalysis, results...)
+		for key, result := range results {
+			completeAnalysis[key] = result
+		}
+
 		remainingKeys = nil
 	} else {
 		if !options.RetainOriginalContext {
@@ -103,42 +106,38 @@ func createPairwiseKeys(fullSubmissionIDs []string) []model.PairwiseKey {
 	return allKeys
 }
 
-func getCachedPairwiseResults(options AnalysisOptions) ([]*model.PairwiseAnalysis, []model.PairwiseKey, error) {
+func getCachedPairwiseResults(options AnalysisOptions) (model.PairwiseAnalysisMap, []model.PairwiseKey, error) {
 	allKeys := createPairwiseKeys(options.ResolvedSubmissionIDs)
 
 	// If we are overwriting the cache, don't query the DB for any of the cached results.
 	if options.OverwriteCache {
-		return make([]*model.PairwiseAnalysis, 0), allKeys, nil
+		return make(model.PairwiseAnalysisMap, 0), allKeys, nil
 	}
 
 	return getCachedPairwiseResultsInternal(allKeys)
 }
 
-func getCachedPairwiseResultsInternal(allKeys []model.PairwiseKey) ([]*model.PairwiseAnalysis, []model.PairwiseKey, error) {
+func getCachedPairwiseResultsInternal(allKeys []model.PairwiseKey) (model.PairwiseAnalysisMap, []model.PairwiseKey, error) {
 	// Get any already done analysis results from the DB.
 	dbResults, err := db.GetPairwiseAnalysis(allKeys)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to get cached pairwise analysis from DB: '%w'.", err)
 	}
 
-	// Split up the keys into complete and remaining.
-	completeAnalysis := make([]*model.PairwiseAnalysis, 0, len(dbResults))
 	remainingKeys := make([]model.PairwiseKey, 0, len(allKeys)-len(dbResults))
 
 	for _, key := range allKeys {
-		result, ok := dbResults[key]
-		if ok {
-			completeAnalysis = append(completeAnalysis, result)
-		} else {
+		_, ok := dbResults[key]
+		if !ok {
 			remainingKeys = append(remainingKeys, key)
 		}
 	}
 
-	return completeAnalysis, remainingKeys, nil
+	return dbResults, remainingKeys, nil
 }
 
 // Lock based on course and then run the analysis in a parallel pool.
-func runPairwiseAnalysis(options AnalysisOptions, keys []model.PairwiseKey) ([]*model.PairwiseAnalysis, error) {
+func runPairwiseAnalysis(options AnalysisOptions, keys []model.PairwiseKey) (model.PairwiseAnalysisMap, error) {
 	if len(keys) == 0 {
 		return nil, nil
 	}
@@ -159,20 +158,22 @@ func runPairwiseAnalysis(options AnalysisOptions, keys []model.PairwiseKey) ([]*
 		return nil, nil
 	}
 
-	results := make([]*model.PairwiseAnalysis, 0, len(keys))
+	results := make(model.PairwiseAnalysisMap, len(keys))
 
 	// If we had to wait for the lock, then check again for cached results.
 	// If there are multiple requests queued up,
 	// it will be faster to do a bulk check for cached results instead of checking each one individually.
 	if !noLockWait {
-		var partialResults []*model.PairwiseAnalysis = nil
+		var partialResults model.PairwiseAnalysisMap = nil
 		partialResults, keys, err = getCachedPairwiseResultsInternal(keys)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to re-check result cache before run: '%w'.", err)
 		}
 
 		// Collect the partial results from the cache.
-		results = append(results, partialResults...)
+		for id, result := range partialResults {
+			results[id] = result
+		}
 	}
 
 	// All results were fetched from the cache.
@@ -184,7 +185,7 @@ func runPairwiseAnalysis(options AnalysisOptions, keys []model.PairwiseKey) ([]*
 	if options.OverwriteCache && !options.DryRun {
 		err := db.RemovePairwiseAnalysis(keys)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to remove old individual analysis cache entries: '%w'.", err)
+			return nil, fmt.Errorf("Failed to remove old pairwise analysis cache entries: '%w'.", err)
 		}
 	}
 
@@ -192,19 +193,18 @@ func runPairwiseAnalysis(options AnalysisOptions, keys []model.PairwiseKey) ([]*
 	defer templateFileStore.Close()
 
 	poolSize := config.ANALYSIS_PAIRWISE_COURSE_POOL_SIZE.Get()
-	type PoolResult struct {
+	type AnalysisPoolResult struct {
 		Result  *model.PairwiseAnalysis
 		RunTime int64
-		Error   error
 	}
 
-	poolResults, _, err := util.RunParallelPoolMap(poolSize, keys, options.Context, func(key model.PairwiseKey) (PoolResult, error) {
+	poolResults, err := util.RunParallelPoolMap(poolSize, keys, options.Context, func(key model.PairwiseKey) (AnalysisPoolResult, error) {
 		result, runTime, err := runSinglePairwiseAnalysis(options, key, templateFileStore)
 		if err != nil {
 			err = fmt.Errorf("Failed to perform pairwise analysis on submissions %s: '%w'.", key.String(), err)
 		}
 
-		return PoolResult{result, runTime, err}, nil
+		return AnalysisPoolResult{result, runTime}, err
 	})
 
 	if err != nil {
@@ -212,20 +212,30 @@ func runPairwiseAnalysis(options AnalysisOptions, keys []model.PairwiseKey) ([]*
 	}
 
 	// If the analysis was canceled, exit right away.
-	if options.Context.Err() != nil {
+	if poolResults.Canceled {
 		return nil, nil
 	}
+
+	poolResults.IsDone()
 
 	var errs error = nil
 	totalRunTime := int64(0)
 
-	for _, poolResult := range poolResults {
-		if poolResult.Error != nil {
-			errs = errors.Join(errs, poolResult.Error)
-		} else {
-			results = append(results, poolResult.Result)
-			totalRunTime += poolResult.RunTime
+	for _, key := range keys {
+		err, ok := poolResults.WorkErrors[key]
+		if ok {
+			errs = errors.Join(errs, err)
+			continue
 		}
+
+		analysisPoolResult, ok := poolResults.Results[key]
+		if !ok {
+			errs = errors.Join(errs, fmt.Errorf("Unable to find result for submissions: '%s'.", key.String()))
+			continue
+		}
+
+		results[key] = analysisPoolResult.Result
+		totalRunTime += analysisPoolResult.RunTime
 	}
 
 	collectPairwiseStats(keys, totalRunTime, options.InitiatorEmail)

--- a/internal/analysis/pairwise_test.go
+++ b/internal/analysis/pairwise_test.go
@@ -29,13 +29,13 @@ func TestPairwiseAnalysisFake(test *testing.T) {
 		"course101::hw0::course-student@test.edulinq.org::1697406272",
 	}
 
-	expected := []*model.PairwiseAnalysis{
-		&model.PairwiseAnalysis{
+	expected := model.PairwiseAnalysisMap{
+		model.NewPairwiseKey(ids[0], ids[1]): &model.PairwiseAnalysis{
 			Options:           assignment.AssignmentAnalysisOptions,
 			AnalysisTimestamp: timestamp.Zero(),
 			SubmissionIDs: model.NewPairwiseKey(
-				"course101::hw0::course-student@test.edulinq.org::1697406256",
-				"course101::hw0::course-student@test.edulinq.org::1697406265",
+				ids[0],
+				ids[1],
 			),
 			Similarities: map[string][]*model.FileSimilarity{
 				"submission.py": []*model.FileSimilarity{
@@ -52,12 +52,12 @@ func TestPairwiseAnalysisFake(test *testing.T) {
 			},
 			TotalMeanSimilarity: 0.13,
 		},
-		&model.PairwiseAnalysis{
+		model.NewPairwiseKey(ids[0], ids[2]): &model.PairwiseAnalysis{
 			Options:           assignment.AssignmentAnalysisOptions,
 			AnalysisTimestamp: timestamp.Zero(),
 			SubmissionIDs: model.NewPairwiseKey(
-				"course101::hw0::course-student@test.edulinq.org::1697406256",
-				"course101::hw0::course-student@test.edulinq.org::1697406272",
+				ids[0],
+				ids[2],
 			),
 			Similarities: map[string][]*model.FileSimilarity{
 				"submission.py": []*model.FileSimilarity{
@@ -74,12 +74,12 @@ func TestPairwiseAnalysisFake(test *testing.T) {
 			},
 			TotalMeanSimilarity: 0.13,
 		},
-		&model.PairwiseAnalysis{
+		model.NewPairwiseKey(ids[1], ids[2]): &model.PairwiseAnalysis{
 			Options:           assignment.AssignmentAnalysisOptions,
 			AnalysisTimestamp: timestamp.Zero(),
 			SubmissionIDs: model.NewPairwiseKey(
-				"course101::hw0::course-student@test.edulinq.org::1697406265",
-				"course101::hw0::course-student@test.edulinq.org::1697406272",
+				ids[1],
+				ids[2],
 			),
 			Similarities: map[string][]*model.FileSimilarity{
 				"submission.py": []*model.FileSimilarity{
@@ -141,7 +141,7 @@ func TestPairwiseAnalysisFake(test *testing.T) {
 	}
 }
 
-func testPairwise(test *testing.T, ids []string, expected []*model.PairwiseAnalysis, expectedInitialCacheCount int) {
+func testPairwise(test *testing.T, ids []string, expected model.PairwiseAnalysisMap, expectedInitialCacheCount int) {
 	// Check for records in the DB.
 	queryKeys := make([]model.PairwiseKey, 0, len(expected))
 	for _, analysis := range expected {
@@ -412,22 +412,24 @@ func TestPairwiseAnalysisIncludeExclude(test *testing.T) {
 			continue
 		}
 
-		if testCase.expectedCount != len(results[0].Similarities) {
+		key := model.NewPairwiseKey(options.ResolvedSubmissionIDs[0], options.ResolvedSubmissionIDs[1])
+
+		if testCase.expectedCount != len(results[key].Similarities) {
 			test.Errorf("Case %d: Unexpected number of result similarities. Expected: %d, Actual: %d.",
-				i, testCase.expectedCount, len(results[0].Similarities))
+				i, testCase.expectedCount, len(results[key].Similarities))
 			continue
 		}
 
-		if (baseCount - testCase.expectedCount) != len(results[0].SkippedFiles) {
+		if (baseCount - testCase.expectedCount) != len(results[key].SkippedFiles) {
 			test.Errorf("Case %d: Unexpected number of skipped files. Expected: %d, Actual: %d.",
-				i, (baseCount - testCase.expectedCount), len(results[0].SkippedFiles))
+				i, (baseCount - testCase.expectedCount), len(results[key].SkippedFiles))
 			continue
 		}
 
 		if testCase.expectedCount == 0 {
-			if relpath != results[0].SkippedFiles[0] {
+			if relpath != results[key].SkippedFiles[0] {
 				test.Errorf("Case %d: Unexpected skipped file. Expected: '%s', Actual: '%s'.",
-					i, relpath, results[0].SkippedFiles[0])
+					i, relpath, results[key].SkippedFiles[0])
 			}
 		}
 	}
@@ -649,7 +651,9 @@ func TestPairwiseAnalysisCountBase(test *testing.T) {
 
 		// Check if the result was from the cache using the start time.
 		if len(results) > 0 {
-			resultTime := results[0].AnalysisTimestamp
+			key := model.NewPairwiseKey(testCase.options.ResolvedSubmissionIDs[0], testCase.options.ResolvedSubmissionIDs[1])
+
+			resultTime := results[key].AnalysisTimestamp
 			resultIsFromCache := (resultTime <= startTime)
 
 			if testCase.expectedResultIsFromCache != resultIsFromCache {
@@ -727,11 +731,14 @@ func TestPairwiseAnalysisFailureBase(test *testing.T) {
 		test.Fatalf("Number of results not as expected. Expected: %d, Actual: %d.", 1, len(results))
 	}
 
-	if !results[0].Failure {
+	key := model.NewPairwiseKey(options.ResolvedSubmissionIDs[0], options.ResolvedSubmissionIDs[1])
+
+	if !results[key].Failure {
 		test.Fatalf("Result is not a failure, when it should be.")
 	}
 
-	if !strings.Contains(results[0].FailureMessage, expectedMessageSubstring) {
-		test.Fatalf("Failure message does not contain expected substring. Expected Substring: '%s', Actual: '%s'.", expectedMessageSubstring, results[0].FailureMessage)
+	if !strings.Contains(results[key].FailureMessage, expectedMessageSubstring) {
+		test.Fatalf("Failure message does not contain expected substring. Expected Substring: '%s', Actual: '%s'.",
+			expectedMessageSubstring, results[key].FailureMessage)
 	}
 }

--- a/internal/analysis/pairwise_test.go
+++ b/internal/analysis/pairwise_test.go
@@ -29,7 +29,7 @@ func TestPairwiseAnalysisFake(test *testing.T) {
 		"course101::hw0::course-student@test.edulinq.org::1697406272",
 	}
 
-	expected := model.PairwiseAnalysisMap{
+	expected := map[model.PairwiseKey]*model.PairwiseAnalysis{
 		model.NewPairwiseKey(ids[0], ids[1]): &model.PairwiseAnalysis{
 			Options:           assignment.AssignmentAnalysisOptions,
 			AnalysisTimestamp: timestamp.Zero(),
@@ -141,7 +141,7 @@ func TestPairwiseAnalysisFake(test *testing.T) {
 	}
 }
 
-func testPairwise(test *testing.T, ids []string, expected model.PairwiseAnalysisMap, expectedInitialCacheCount int) {
+func testPairwise(test *testing.T, ids []string, expected map[model.PairwiseKey]*model.PairwiseAnalysis, expectedInitialCacheCount int) {
 	// Check for records in the DB.
 	queryKeys := make([]model.PairwiseKey, 0, len(expected))
 	for _, analysis := range expected {

--- a/internal/api/courses/assignments/submissions/analysis/individual.go
+++ b/internal/api/courses/assignments/submissions/analysis/individual.go
@@ -16,10 +16,10 @@ type IndividualRequest struct {
 }
 
 type IndividualResponse struct {
-	Complete bool                             `json:"complete"`
-	Options  analysis.AnalysisOptions         `json:"options"`
-	Summary  *model.IndividualAnalysisSummary `json:"summary"`
-	Results  []*model.IndividualAnalysis      `json:"results"`
+	Complete bool                                 `json:"complete"`
+	Options  analysis.AnalysisOptions             `json:"options"`
+	Summary  *model.IndividualAnalysisSummary     `json:"summary"`
+	Results  map[string]*model.IndividualAnalysis `json:"results"`
 }
 
 // Get the result of a individual analysis for the specified submissions.
@@ -44,7 +44,7 @@ func HandleIndividual(request *IndividualRequest) (*IndividualResponse, *core.AP
 
 	request.ResolvedSubmissionIDs = fullSubmissionIDs
 	request.InitiatorEmail = request.ServerUser.Email
-	request.AnalysisOptions.Context = request.Context
+	request.AnalysisOptions.Context = request.APIRequestUserContext.Context
 
 	results, pendingCount, err := analysis.IndividualAnalysis(request.AnalysisOptions)
 	if err != nil {

--- a/internal/api/courses/assignments/submissions/analysis/individual_test.go
+++ b/internal/api/courses/assignments/submissions/analysis/individual_test.go
@@ -53,7 +53,7 @@ func TestIndividualBase(test *testing.T) {
 				PendingCount:  2,
 			},
 		},
-		Results: []*model.IndividualAnalysis{},
+		Results: map[string]*model.IndividualAnalysis{},
 	}
 
 	if !reflect.DeepEqual(expected, responseContent) {
@@ -146,8 +146,8 @@ func TestIndividualBase(test *testing.T) {
 				},
 			},
 		},
-		Results: []*model.IndividualAnalysis{
-			&model.IndividualAnalysis{
+		Results: map[string]*model.IndividualAnalysis{
+			"course101::hw0::course-student@test.edulinq.org::1697406256": &model.IndividualAnalysis{
 				Options:             assignment.AssignmentAnalysisOptions,
 				AnalysisTimestamp:   timestamp.Zero(),
 				FullID:              "course101::hw0::course-student@test.edulinq.org::1697406256",
@@ -170,7 +170,7 @@ func TestIndividualBase(test *testing.T) {
 					},
 				},
 			},
-			&model.IndividualAnalysis{
+			"course101::hw0::course-student@test.edulinq.org::1697406265": &model.IndividualAnalysis{
 				Options:             assignment.AssignmentAnalysisOptions,
 				AnalysisTimestamp:   timestamp.Zero(),
 				FullID:              "course101::hw0::course-student@test.edulinq.org::1697406265",

--- a/internal/api/courses/assignments/submissions/analysis/pairwise.go
+++ b/internal/api/courses/assignments/submissions/analysis/pairwise.go
@@ -19,7 +19,7 @@ type PairwiseResponse struct {
 	Complete bool                           `json:"complete"`
 	Options  analysis.AnalysisOptions       `json:"options"`
 	Summary  *model.PairwiseAnalysisSummary `json:"summary"`
-	Results  []*model.PairwiseAnalysis      `json:"results"`
+	Results  model.PairwiseAnalysisMap      `json:"results"`
 }
 
 // Get the result of a pairwise analysis for the specified submissions.
@@ -44,7 +44,7 @@ func HandlePairwise(request *PairwiseRequest) (*PairwiseResponse, *core.APIError
 
 	request.ResolvedSubmissionIDs = fullSubmissionIDs
 	request.InitiatorEmail = request.ServerUser.Email
-	request.AnalysisOptions.Context = request.Context
+	request.AnalysisOptions.Context = request.APIRequestUserContext.Context
 
 	results, pendingCount, err := analysis.PairwiseAnalysis(request.AnalysisOptions)
 	if err != nil {

--- a/internal/api/courses/assignments/submissions/analysis/pairwise.go
+++ b/internal/api/courses/assignments/submissions/analysis/pairwise.go
@@ -16,10 +16,10 @@ type PairwiseRequest struct {
 }
 
 type PairwiseResponse struct {
-	Complete bool                           `json:"complete"`
-	Options  analysis.AnalysisOptions       `json:"options"`
-	Summary  *model.PairwiseAnalysisSummary `json:"summary"`
-	Results  model.PairwiseAnalysisMap      `json:"results"`
+	Complete bool                                          `json:"complete"`
+	Options  analysis.AnalysisOptions                      `json:"options"`
+	Summary  *model.PairwiseAnalysisSummary                `json:"summary"`
+	Results  map[model.PairwiseKey]*model.PairwiseAnalysis `json:"results"`
 }
 
 // Get the result of a pairwise analysis for the specified submissions.

--- a/internal/api/courses/assignments/submissions/analysis/pairwise_test.go
+++ b/internal/api/courses/assignments/submissions/analysis/pairwise_test.go
@@ -53,7 +53,7 @@ func TestPairwiseBase(test *testing.T) {
 				PendingCount:  1,
 			},
 		},
-		Results: model.PairwiseAnalysisMap{},
+		Results: map[model.PairwiseKey]*model.PairwiseAnalysis{},
 	}
 
 	if !reflect.DeepEqual(expected, responseContent) {
@@ -107,7 +107,7 @@ func TestPairwiseBase(test *testing.T) {
 				Max:    0.13,
 			},
 		},
-		Results: model.PairwiseAnalysisMap{
+		Results: map[model.PairwiseKey]*model.PairwiseAnalysis{
 			model.NewPairwiseKey(submissionID1, submissionID2): &model.PairwiseAnalysis{
 				Options:           assignment.AssignmentAnalysisOptions,
 				AnalysisTimestamp: timestamp.Zero(),

--- a/internal/api/courses/assignments/submissions/analysis/pairwise_test.go
+++ b/internal/api/courses/assignments/submissions/analysis/pairwise_test.go
@@ -53,7 +53,7 @@ func TestPairwiseBase(test *testing.T) {
 				PendingCount:  1,
 			},
 		},
-		Results: []*model.PairwiseAnalysis{},
+		Results: model.PairwiseAnalysisMap{},
 	}
 
 	if !reflect.DeepEqual(expected, responseContent) {
@@ -71,6 +71,9 @@ func TestPairwiseBase(test *testing.T) {
 	}
 
 	util.MustJSONFromString(util.MustToJSON(response.Content), &responseContent)
+
+	submissionID1 := "course101::hw0::course-student@test.edulinq.org::1697406256"
+	submissionID2 := "course101::hw0::course-student@test.edulinq.org::1697406265"
 
 	// Second round should be complete.
 	expected = PairwiseResponse{
@@ -104,13 +107,13 @@ func TestPairwiseBase(test *testing.T) {
 				Max:    0.13,
 			},
 		},
-		Results: []*model.PairwiseAnalysis{
-			&model.PairwiseAnalysis{
+		Results: model.PairwiseAnalysisMap{
+			model.NewPairwiseKey(submissionID1, submissionID2): &model.PairwiseAnalysis{
 				Options:           assignment.AssignmentAnalysisOptions,
 				AnalysisTimestamp: timestamp.Zero(),
 				SubmissionIDs: model.NewPairwiseKey(
-					"course101::hw0::course-student@test.edulinq.org::1697406256",
-					"course101::hw0::course-student@test.edulinq.org::1697406265",
+					submissionID1,
+					submissionID2,
 				),
 				Similarities: map[string][]*model.FileSimilarity{
 					"submission.py": []*model.FileSimilarity{

--- a/internal/model/analysis_test.go
+++ b/internal/model/analysis_test.go
@@ -290,8 +290,8 @@ func TestAssignmentAnalysisOptionsMatchRelpathBase(test *testing.T) {
 }
 
 func TestNewIndividualAnalysisSummaryBase(test *testing.T) {
-	input := []*IndividualAnalysis{
-		&IndividualAnalysis{
+	input := map[string]*IndividualAnalysis{
+		"A": &IndividualAnalysis{
 			Score:               10,
 			LinesOfCode:         10,
 			SubmissionTimeDelta: 0,
@@ -306,7 +306,7 @@ func TestNewIndividualAnalysisSummaryBase(test *testing.T) {
 				},
 			},
 		},
-		&IndividualAnalysis{
+		"B": &IndividualAnalysis{
 			Score:               20,
 			LinesOfCode:         40,
 			SubmissionTimeDelta: 12,
@@ -325,7 +325,7 @@ func TestNewIndividualAnalysisSummaryBase(test *testing.T) {
 				},
 			},
 		},
-		&IndividualAnalysis{
+		"C": &IndividualAnalysis{
 			Score:               30,
 			LinesOfCode:         20,
 			SubmissionTimeDelta: 32,
@@ -340,7 +340,7 @@ func TestNewIndividualAnalysisSummaryBase(test *testing.T) {
 				},
 			},
 		},
-		&IndividualAnalysis{
+		"FAILURE": &IndividualAnalysis{
 			Failure: true,
 		},
 	}
@@ -499,11 +499,11 @@ func TestNewPairwiseAnalysisSummaryBase(test *testing.T) {
 		},
 	}
 
-	input := []*PairwiseAnalysis{
-		NewPairwiseAnalysis(NewPairwiseKey("A", "B"), nil, sims1, nil, nil),
-		NewPairwiseAnalysis(NewPairwiseKey("C", "D"), nil, sims2, nil, nil),
-		NewPairwiseAnalysis(NewPairwiseKey("E", "F"), nil, sims3, nil, nil),
-		&PairwiseAnalysis{
+	input := PairwiseAnalysisMap{
+		NewPairwiseKey("A", "B"): NewPairwiseAnalysis(NewPairwiseKey("A", "B"), nil, sims1, nil, nil),
+		NewPairwiseKey("C", "D"): NewPairwiseAnalysis(NewPairwiseKey("C", "D"), nil, sims2, nil, nil),
+		NewPairwiseKey("E", "F"): NewPairwiseAnalysis(NewPairwiseKey("E", "F"), nil, sims3, nil, nil),
+		NewPairwiseKey("FOO", "BAR"): &PairwiseAnalysis{
 			Failure: true,
 		},
 	}

--- a/internal/model/analysis_test.go
+++ b/internal/model/analysis_test.go
@@ -21,18 +21,89 @@ func TestPairwiseAnalysisMarshal(test *testing.T) {
 			NewPairwiseKey("bar", "baz"): &PairwiseAnalysis{},
 		},
 		map[PairwiseKey]*PairwiseAnalysis{
-			NewPairwiseKey("baz", "foo"): NewPairwiseAnalysis(NewPairwiseKey("baz", "foo"), nil, nil, nil, nil),
+			NewPairwiseKey("baz", "qux"): NewPairwiseAnalysis(
+				NewPairwiseKey("baz", "foo"),
+				nil,
+				nil,
+				nil,
+				nil,
+			),
+		},
+		map[PairwiseKey]*PairwiseAnalysis{
+			NewPairwiseKey("qux", "foo"): NewPairwiseAnalysis(
+				NewPairwiseKey("baz", "foo"),
+				&Assignment{},
+				map[string][]*FileSimilarity{},
+				[][2]string{},
+				[]string{},
+			),
 		},
 		map[PairwiseKey]*PairwiseAnalysis{
 			NewPairwiseKey("failed", "analysis"): NewFailedPairwiseAnalysis(NewPairwiseKey("failed", "analysis"), nil, ""),
 		},
 	}
 
-	for _, testCase := range testCases {
+	for i, testCase := range testCases {
 		pairwiseAnalysisJSON := util.MustToJSON(testCase)
 
 		var pairwiseAnalysisResult map[PairwiseKey]*PairwiseAnalysis
 		util.MustJSONFromString(pairwiseAnalysisJSON, &pairwiseAnalysisResult)
+
+		// Normalize the expected results.
+		for _, result := range testCase {
+			if result == nil {
+				continue
+			}
+
+			// Nil empty similarities.
+			if len(result.Similarities) == 0 {
+				result.Similarities = nil
+			}
+
+			if len(result.MeanSimilarities) == 0 {
+				result.MeanSimilarities = nil
+			}
+
+			// Nil empty skipped and unmatched files.
+			if len(result.SkippedFiles) == 0 {
+				result.SkippedFiles = nil
+			}
+
+			if len(result.UnmatchedFiles) == 0 {
+				result.UnmatchedFiles = nil
+			}
+		}
+
+		// Normalize the actual results.
+		for _, result := range pairwiseAnalysisResult {
+			if result == nil {
+				continue
+			}
+
+			// Nil empty similarities.
+			if len(result.Similarities) == 0 {
+				result.Similarities = nil
+			}
+
+			if len(result.MeanSimilarities) == 0 {
+				result.MeanSimilarities = nil
+			}
+
+			// Nil empty skipped and unmatched files.
+			if len(result.SkippedFiles) == 0 {
+				result.SkippedFiles = nil
+			}
+
+			if len(result.UnmatchedFiles) == 0 {
+				result.UnmatchedFiles = nil
+			}
+		}
+
+		if !reflect.DeepEqual(testCase, pairwiseAnalysisResult) {
+			test.Errorf("Case %d: Unexpected result. Expected: '%s', Actual: '%s'.",
+				i, util.MustToJSONIndent(testCase), util.MustToJSONIndent(pairwiseAnalysisResult))
+			continue
+		}
 	}
 }
 

--- a/internal/model/analysis_test.go
+++ b/internal/model/analysis_test.go
@@ -10,6 +10,32 @@ import (
 	"github.com/edulinq/autograder/internal/util"
 )
 
+func TestPairwiseAnalysisMarshal(test *testing.T) {
+	testCases := []map[PairwiseKey]*PairwiseAnalysis{
+		nil,
+		map[PairwiseKey]*PairwiseAnalysis{},
+		map[PairwiseKey]*PairwiseAnalysis{
+			NewPairwiseKey("foo", "bar"): nil,
+		},
+		map[PairwiseKey]*PairwiseAnalysis{
+			NewPairwiseKey("bar", "baz"): &PairwiseAnalysis{},
+		},
+		map[PairwiseKey]*PairwiseAnalysis{
+			NewPairwiseKey("baz", "foo"): NewPairwiseAnalysis(NewPairwiseKey("baz", "foo"), nil, nil, nil, nil),
+		},
+		map[PairwiseKey]*PairwiseAnalysis{
+			NewPairwiseKey("failed", "analysis"): NewFailedPairwiseAnalysis(NewPairwiseKey("failed", "analysis"), nil, ""),
+		},
+	}
+
+	for _, testCase := range testCases {
+		pairwiseAnalysisJSON := util.MustToJSON(testCase)
+
+		var pairwiseAnalysisResult map[PairwiseKey]*PairwiseAnalysis
+		util.MustJSONFromString(pairwiseAnalysisJSON, &pairwiseAnalysisResult)
+	}
+}
+
 func TestAssignmentAnalysisOptionsValidateBase(test *testing.T) {
 	testCases := []struct {
 		input          *AssignmentAnalysisOptions
@@ -499,7 +525,7 @@ func TestNewPairwiseAnalysisSummaryBase(test *testing.T) {
 		},
 	}
 
-	input := PairwiseAnalysisMap{
+	input := map[PairwiseKey]*PairwiseAnalysis{
 		NewPairwiseKey("A", "B"): NewPairwiseAnalysis(NewPairwiseKey("A", "B"), nil, sims1, nil, nil),
 		NewPairwiseKey("C", "D"): NewPairwiseAnalysis(NewPairwiseKey("C", "D"), nil, sims2, nil, nil),
 		NewPairwiseKey("E", "F"): NewPairwiseAnalysis(NewPairwiseKey("E", "F"), nil, sims3, nil, nil),

--- a/internal/util/pool.go
+++ b/internal/util/pool.go
@@ -6,44 +6,84 @@ import (
 	"sync"
 )
 
+// The result of running a map function in parallel pool.
+// Always call IsDone() before accessing any results to avoid concurrency issues.
+type PoolResult[InputType comparable, OutputType any] struct {
+	// The results of the parallel pool.
+	Results map[InputType]OutputType
+
+	// A map of work errors using the item for item-level errors.
+	WorkErrors map[InputType]error
+
+	// Signals that the parallel pool was canceled during execution.
+	Canceled bool
+
+	// An internal done channel to signal the results can be accessed.
+	done chan any
+}
+
+// Use this method to block until the results can be accessed.
+func (this PoolResult[InputType, OutputType]) IsDone() {
+	<-this.done
+}
+
 // Do a map function (one result for one input) with a parallel pool of workers.
 // Unless there is a critical error (the final return value) or cancellation,
-// the output will have the same length as and index-match the input, but will have an empty value if there is an error.
-// A cancellation will return (nil, nil, nil).
-// Consult the returned map of errors using the item's index to check for item-level errors.
+// every input will either be in PoolResult.Results or PoolResult.WorkErrors.
+// A cancellation will stop new work from starting but complete in progress work asynchronously.
+// The partial results from a cancellation are available after PoolResult.IsDone() returns.
+// Consult the returned map of errors using the item to check for item-level errors.
+// Work level errors will not generate a critical error, so both must be checked independently.
 // The underlying collection of input work items must not be modified as this function is running.
-func RunParallelPoolMap[InputType any, OutputType any](poolSize int, workItems []InputType, ctx context.Context, workFunc func(InputType) (OutputType, error)) ([]OutputType, map[int]error, error) {
+func RunParallelPoolMap[InputType comparable, OutputType any](poolSize int, workItems []InputType, ctx context.Context, workFunc func(InputType) (OutputType, error)) (*PoolResult[InputType, OutputType], error) {
 	if poolSize <= 0 {
-		return nil, nil, fmt.Errorf("Pool size must be positive, got %d.", poolSize)
-	}
-
-	type WorkItem struct {
-		Index int
-		Item  InputType
+		return nil, fmt.Errorf("Pool size must be positive, got %d.", poolSize)
 	}
 
 	type ResultItem struct {
-		Index int
-		Item  OutputType
-		Error error
+		Input  InputType
+		Result OutputType
+		Error  error
 	}
 
-	results := make([]OutputType, len(workItems))
-	workErrors := make(map[int]error)
-
 	resultQueue := make(chan ResultItem, poolSize)
-	workQueue := make(chan WorkItem, poolSize)
-	doneChan := make(chan bool, poolSize)
-	exitWaitGroup := sync.WaitGroup{}
+	workQueue := make(chan InputType, poolSize)
+
+	// The done working channel is used by the pool workers to signal work is complete to the result collectors.
+	doneWorkingChan := make(chan any)
+	// The done channel is used to signal that the all results are collected and accessible.
+	// It also waits to signal until all worker threads join the main thread.
+	doneChan := make(chan any)
+
+	// A wait group used to determine when the workers have completed there work.
+	// Note that completion can be natural or due to a cancellation.
+	workerExitWaitGroup := sync.WaitGroup{}
+	workerExitWaitGroup.Add(poolSize)
+
+	// There will always be poolSize + 2 threads started.
+	// A thread will be started for the work loader, the result collector, and each worker in the pool.
+	// Every one of these work threads must call threadExitWaitGroup.Done() to avoid a deadlock.
+	threadExitWaitGroup := sync.WaitGroup{}
+	threadExitWaitGroup.Add(poolSize + 2)
+
+	output := PoolResult[InputType, OutputType]{
+		Results:    make(map[InputType]OutputType, len(workItems)),
+		WorkErrors: make(map[InputType]error, 0),
+		done:       doneChan,
+	}
 
 	// Load work.
 	go func() {
-		for i, item := range workItems {
+		defer threadExitWaitGroup.Done()
+		// Signal to the workers that there is no more work.
+		defer close(workQueue)
+
+		for _, item := range workItems {
 			// Either send a work item, or cancel.
 			select {
 			case <-ctx.Done():
 				return
-			case workQueue <- WorkItem{i, item}:
+			case workQueue <- item:
 				// Item was already sent on the chan, do nothing here.
 			}
 		}
@@ -51,39 +91,61 @@ func RunParallelPoolMap[InputType any, OutputType any](poolSize int, workItems [
 
 	// Collect results.
 	go func() {
-		for i := 0; i < len(workItems); i++ {
-			select {
-			case <-ctx.Done():
-				return
-			case resultItem := <-resultQueue:
-				results[resultItem.Index] = resultItem.Item
-				if resultItem.Error != nil {
-					workErrors[resultItem.Index] = resultItem.Error
+		defer func() {
+			defer threadExitWaitGroup.Done()
+
+			// All workers completed, drain remaining results.
+			// If the context was canceled, the number of results may be less than the number of work items.
+			for {
+				select {
+				case resultItem := <-resultQueue:
+					output.Results[resultItem.Input] = resultItem.Result
+					if resultItem.Error != nil {
+						output.WorkErrors[resultItem.Input] = resultItem.Error
+					}
+				default:
+					return
 				}
 			}
-		}
+		}()
 
-		// Got all the results (or canceled), signal completion to all the workers.
-		for i := 0; i < (poolSize); i++ {
-			doneChan <- true
+		for i := 0; i < len(workItems); i++ {
+			select {
+			case <-doneWorkingChan:
+				return
+			case resultItem := <-resultQueue:
+				output.Results[resultItem.Input] = resultItem.Result
+				if resultItem.Error != nil {
+					output.WorkErrors[resultItem.Input] = resultItem.Error
+				}
+			}
 		}
 	}()
 
 	// Dispatch workers.
-	exitWaitGroup.Add(poolSize)
 	for i := 0; i < poolSize; i++ {
 		go func() {
-			defer exitWaitGroup.Done()
+			defer threadExitWaitGroup.Done()
+			defer workerExitWaitGroup.Done()
 
 			for {
 				select {
 				case <-ctx.Done():
 					return
-				case workItem := <-workQueue:
-					result, err := workFunc(workItem.Item)
-					resultQueue <- ResultItem{workItem.Index, result, err}
-				case <-doneChan:
-					return
+				case workItem, ok := <-workQueue:
+					// The work queue was closed which signals there is no more work.
+					if !ok {
+						return
+					}
+
+					// Pulling work from the queue can be selected over a context cancellation.
+					// Check the context for cancellations before starting new work.
+					if ctx.Err() != nil {
+						return
+					}
+
+					result, err := workFunc(workItem)
+					resultQueue <- ResultItem{workItem, result, err}
 				}
 			}
 		}()
@@ -91,20 +153,28 @@ func RunParallelPoolMap[InputType any, OutputType any](poolSize int, workItems [
 
 	// Wait on the wait group in the background so we can select between it and the context.
 	// Technically we could wait on the done channel, but this will ensure that all workers have exited.
-	exitWaitGroupChan := make(chan bool, 1)
 	go func() {
-		exitWaitGroup.Wait()
-		exitWaitGroupChan <- true
+		// Once all pool workers have completed there work, signal to collect the remaining results.
+		workerExitWaitGroup.Wait()
+		close(doneWorkingChan)
+
+		// Wait for all worker threads to signal they have exited.
+		threadExitWaitGroup.Wait()
+
+		// Close the done channel to signal that the output is accessible and worker threads are joined.
+		close(doneChan)
 	}()
 
 	// Wait for either completion or cancellation.
 	select {
 	case <-ctx.Done():
-		// The context was canceled, return nothing.
-		return nil, nil, nil
-	case <-exitWaitGroupChan:
+		// The context was canceled, return partial results.
+		output.Canceled = true
+
+		return &output, nil
+	case <-doneChan:
 		// Normal Completion
 	}
 
-	return results, workErrors, nil
+	return &output, nil
 }

--- a/resources/api.json
+++ b/resources/api.json
@@ -218,7 +218,7 @@
                 },
                 {
                     "name": "results",
-                    "type": "model.PairwiseAnalysisMap"
+                    "type": "map[model.PairwiseKey]*model.PairwiseAnalysis"
                 },
                 {
                     "name": "summary",
@@ -2515,9 +2515,6 @@
                     "type": "[][]string"
                 }
             ]
-        },
-        "model.PairwiseAnalysisMap": {
-            "category": "map"
         },
         "model.PairwiseAnalysisSummary": {
             "category": "struct",

--- a/resources/api.json
+++ b/resources/api.json
@@ -171,7 +171,7 @@
                 },
                 {
                     "name": "results",
-                    "type": "[]*model.IndividualAnalysis"
+                    "type": "map[string]*model.IndividualAnalysis"
                 },
                 {
                     "name": "summary",
@@ -218,7 +218,7 @@
                 },
                 {
                     "name": "results",
-                    "type": "[]*model.PairwiseAnalysis"
+                    "type": "model.PairwiseAnalysisMap"
                 },
                 {
                     "name": "summary",
@@ -2515,6 +2515,9 @@
                     "type": "[][]string"
                 }
             ]
+        },
+        "model.PairwiseAnalysisMap": {
+            "category": "map"
         },
         "model.PairwiseAnalysisSummary": {
             "category": "struct",


### PR DESCRIPTION
…ations.

This PR improves the parallel pool utility function to better handle context cancellations. The new implementation still returns partial results quickly upon cancellation. But, the new implementation provides the method `IsDone()` which lets the calling function optionally wait to collect all of the partial results before the cancellation. So, calling functions can wait and clean up and potential artifacts from a partial job, if desired.

The analysis functions are updated to fit into the new parallel pool model, which affects analysis from the model layer to the api layer.

These changes are a stepping stone for the larger [job manager PR](https://github.com/edulinq/autograder-server/pull/174), which has grown too large.