### PR TITLE
Added the jobmanager package to help structure running large jobs.

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -14,7 +14,7 @@ All these packages (except cmd) live in `internal`.
  3. util
  4. config
  5. lockmanager
- 6. common, systemserver, stats
+ 6. common, systemserver, stats, jobmanager
  7. email
  8. docker
  9. model

--- a/internal/jobmanager/jobmanager.go
+++ b/internal/jobmanager/jobmanager.go
@@ -285,7 +285,7 @@ func (this *Job[InputType, OutputType]) run(output *JobOutput[InputType, OutputT
 // Perform optional work on the final output.
 func (this *Job[InputType, OutputType]) completeRun(output *JobOutput[InputType, OutputType]) {
 	if this.OnComplete != nil {
-		defer this.OnComplete(output)
+		this.OnComplete(output)
 	}
 }
 

--- a/internal/jobmanager/jobmanager.go
+++ b/internal/jobmanager/jobmanager.go
@@ -1,0 +1,407 @@
+package jobmanager
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/edulinq/autograder/internal/lockmanager"
+	"github.com/edulinq/autograder/internal/log"
+	"github.com/edulinq/autograder/internal/timestamp"
+	"github.com/edulinq/autograder/internal/util"
+)
+
+// JobOptions contains user level options for a Job.
+// These options allow for optional context cancellation of the Job.
+type JobOptions struct {
+	// Don't save anything.
+	DryRun bool `json:"dry-run"`
+
+	// Remove any existing records before running the job.
+	OverwriteRecords bool `json:"overwrite-records"`
+
+	// Wait for the entire job to complete and return all results.
+	WaitForCompletion bool `json:"wait-for-completion"`
+
+	// A context that can be used to cancel the job.
+	Context context.Context `json:"-"`
+}
+
+// Job provides system level customization of the job's execution.
+// It supports the following optional functionality:
+//   - synchronization
+//   - context cancellation
+//   - record retrieval
+//   - record storage
+//   - record removal from storage
+//   - asynchronous output processing
+//
+// Given job options, input items, and a work function,
+// Job will invoke the work func on each input item in a parallel pool to produce a JobOutput.
+// If a lock key is provided, Job will block on that key before running.
+// The locking behavior prevents overuse of resources and conflicts between the same Job.
+// Provide an input key generation function to synchronize at the input item level in addition to the job level.
+type Job[InputType comparable, OutputType any] struct {
+	// The user level options for a Job.
+	*JobOptions
+
+	// Instead of adding to the results as they are processed,
+	// return a copy of the potentially incomplete results fetched before the job starts.
+	// If WaitForCompletion is true, this option is ignored.
+	ReturnIncompleteResults bool
+
+	// The number of workers in the parallel pool.
+	PoolSize int
+
+	// An optional key to lock the job on.
+	// The job will block until it acquires the lock.
+	// Provide a WorkItemKeyFunc to synchronize individual work items.
+	LockKey string
+
+	// A list of items that need work.
+	WorkItems []InputType
+
+	// An optional function to retrieve existing records that should not be processed.
+	// Returns a list of processed records, remaining items, and an error.
+	// E.g. This function could be used to retrieve completed items from a cache.
+	RetrieveFunc func([]InputType) (map[InputType]OutputType, error)
+
+	// An optional function to store the result.
+	// Use this function to cache the result of the work function to reduce future computation.
+	StoreFunc func([]OutputType) error
+
+	// An optional function to remove existing records from storage.
+	RemoveFunc func([]InputType) error
+
+	// A function to transform work items into results.
+	// Returns a result and an error.
+	WorkFunc func(InputType) (OutputType, error)
+
+	// An optional function to get the locking key for an individual work item.
+	WorkItemKeyFunc func(InputType) string
+
+	// An optional function to process the final JobOutput upon successful completion.
+	OnSuccess func(JobOutput[InputType, OutputType])
+}
+
+// JobOutput is the result of a call to Job.Run().
+// It contains a system error, a map of work errors, the result items,
+// the remaining items, the total run time, and a channel that signals execution is complete.
+// System errors are held in Error, whereas errors during work are included in WorkErrors.
+// If there are work errors there will always be a system error, but the converse is not always true.
+// Always wait for the Done channel to be closed before handling JobOutput.
+type JobOutput[InputType comparable, OutputType any] struct {
+	// Signals the job was canceled during execution.
+	Canceled bool
+
+	// An error for Job.Run().
+	Error error
+
+	// A map of errors encountered while running the job.
+	// The key of the error will be the index of the item
+	// that failed in RemainingItems.
+	WorkErrors map[InputType]error
+
+	// The map of results.
+	ResultItems map[InputType]OutputType
+
+	// The list of items that still need work.
+	RemainingItems []InputType
+
+	// The total computation time spent in WorkFunc().
+	// This time does not include time spent waiting for locks or retrieving stored items.
+	RunTime int64
+
+	// Signals the job is complete.
+	Done <-chan any
+}
+
+func (this *Job[InputType, OutputType]) Validate() error {
+	if this == nil {
+		return fmt.Errorf("Job is nil.")
+	}
+
+	if this.WorkFunc == nil {
+		return fmt.Errorf("Job cannot have a nil work function.")
+	}
+
+	if this.PoolSize <= 0 {
+		return fmt.Errorf("Pool size must be positive, got %d.", this.PoolSize)
+	}
+
+	return this.JobOptions.Validate()
+}
+
+func (this *JobOptions) Validate() error {
+	if this == nil {
+		return fmt.Errorf("Job options are nil.")
+	}
+
+	if this.Context == nil {
+		this.Context = context.Background()
+	}
+
+	return nil
+}
+
+// Given a customized Job, Job.Run() processes input items in a parallel pool of workers.
+// Returns the collected results in a JobOutput.
+// When not waiting for completion, the JobOutput may still be modified until the Done channel is closed.
+// Returning a copy of results gives immediate access to stable results but the final results will not be accessible later.
+// Returns nil if the context is canceled during execution.
+func (this *Job[InputType, OutputType]) Run() *JobOutput[InputType, OutputType] {
+	// Run closes the channel to signal the returned JobOutput is safe to handle.
+	// The channel is closed by this thread except when !WaitForCompletion and !ReturnIncompleteResults.
+	done := make(chan any)
+
+	output := JobOutput[InputType, OutputType]{
+		Done:           done,
+		ResultItems:    make(map[InputType]OutputType, len(this.WorkItems)),
+		RemainingItems: this.WorkItems,
+		RunTime:        0,
+		WorkErrors:     make(map[InputType]error, 0),
+	}
+
+	err := this.Validate()
+	if err != nil {
+		output.Error = fmt.Errorf("Failed to validate job: '%w'.", err)
+
+		close(done)
+		return &output
+	}
+
+	// If we are overwriting records, remove all the old records.
+	if this.OverwriteRecords && !this.DryRun && this.RemoveFunc != nil {
+		err = this.RemoveFunc(this.WorkItems)
+		if err != nil {
+			output.Error = fmt.Errorf("Failed to remove items: '%w'.", err)
+
+			close(done)
+			return &output
+		}
+	}
+
+	// Query for stored records.
+	if !this.OverwriteRecords && this.RetrieveFunc != nil {
+		output.ResultItems, err = this.RetrieveFunc(this.WorkItems)
+		if err != nil {
+			output.Error = fmt.Errorf("Failed to retrieve items: '%w'.", err)
+
+			close(done)
+			return &output
+		}
+
+		output.RemainingItems = getRemainingItems(this.WorkItems, output.ResultItems)
+	}
+
+	if this.WaitForCompletion {
+		this.run(&output, true)
+
+		close(done)
+	} else if this.ReturnIncompleteResults {
+		backgroundDone := make(chan any)
+
+		backgroundOutput := &JobOutput[InputType, OutputType]{
+			Done:           backgroundDone,
+			ResultItems:    make(map[InputType]OutputType, len(output.RemainingItems)),
+			RemainingItems: output.RemainingItems,
+			RunTime:        0,
+			WorkErrors:     make(map[InputType]error, 0),
+		}
+
+		go func() {
+			defer close(backgroundDone)
+
+			this.run(backgroundOutput, false)
+			if backgroundOutput.Error != nil {
+				log.Error("Failure while running asynchronous job.", backgroundOutput.Error)
+			}
+		}()
+
+		close(done)
+	} else {
+		go func() {
+			this.run(&output, true)
+			if output.Error != nil {
+				log.Error("Failure while running asynchronous job.", output.Error)
+			}
+
+			close(done)
+		}()
+	}
+
+	// If the context was canceled during execution, return immediately.
+	if this.Context.Err() != nil {
+		return &output
+	}
+
+	return &output
+}
+
+// Job.run() processes the remaining items and updates the partial job output.
+// If Job.Run() returned incomplete results, the JobOutput will not be accessible.
+// In this case, Job.run() will not not update the results to reduce memory usage.
+// However, the run time and error will be updated for stats and logging purposes.
+// The parameter updateOutput signals whether Job.run() will add results to JobOutput.
+func (this *Job[InputType, OutputType]) run(output *JobOutput[InputType, OutputType], updateOutput bool) {
+	if len(output.RemainingItems) == 0 {
+		return
+	}
+
+	noLockWait := true
+	if this.LockKey != "" {
+		noLockWait = lockmanager.Lock(this.LockKey)
+		defer lockmanager.Unlock(this.LockKey)
+	}
+
+	// The context has been canceled while waiting for a lock, abandon this job.
+	if this.Context.Err() != nil {
+		output.Error = fmt.Errorf("Job was canceled: '%v'.", this.Context.Err())
+		output.Canceled = true
+		return
+	}
+
+	// If we had to wait for the lock, then check again for stored records.
+	if !noLockWait && this.RetrieveFunc != nil {
+		partialResults, err := this.RetrieveFunc(output.RemainingItems)
+		if err != nil {
+			output.Error = fmt.Errorf("Failed to re-check record storage before run: '%w'.", err)
+			return
+		}
+
+		output.RemainingItems = getRemainingItems(output.RemainingItems, partialResults)
+
+		if updateOutput {
+			// Collect the partial records from storage.
+			for input, result := range partialResults {
+				output.ResultItems[input] = result
+			}
+		}
+	}
+
+	if len(output.RemainingItems) == 0 {
+		return
+	}
+
+	err := this.runParallelPoolMap(output, updateOutput)
+	if err != nil {
+		output.Error = fmt.Errorf("Failed to run job in a parallel pool: '%w'.", err)
+		return
+	}
+
+	if this.Context.Err() != nil {
+		output.Error = fmt.Errorf("Job was canceled: '%v'.", this.Context.Err())
+		output.Canceled = true
+		return
+	}
+
+	if len(output.WorkErrors) > 0 {
+		output.Error = fmt.Errorf("Failed to complete work for '%d' items.", len(output.WorkErrors))
+		return
+	}
+
+	if this.OnSuccess != nil {
+		this.OnSuccess(*output)
+	}
+}
+
+func (this *Job[InputType, OutputType]) runParallelPoolMap(output *JobOutput[InputType, OutputType], updateOutput bool) error {
+	type resultItem struct {
+		Output  OutputType
+		RunTime int64
+	}
+
+	results, err := util.RunParallelPoolMap(this.PoolSize, output.RemainingItems, this.Context, func(workItem InputType) (resultItem, error) {
+		workItemKey := ""
+		if this.WorkItemKeyFunc != nil {
+			workItemKey = this.WorkItemKeyFunc(workItem)
+		}
+
+		// Optionally lock this id so we don't work on an item multiple times.
+		if workItemKey != "" {
+			lockmanager.Lock(workItemKey)
+			defer lockmanager.Unlock(workItemKey)
+		}
+
+		if this.Context.Err() != nil {
+			return resultItem{}, nil
+		}
+
+		// Check storage for a record.
+		if this.RetrieveFunc != nil {
+			results, err := this.RetrieveFunc([]InputType{workItem})
+			if err != nil {
+				return resultItem{}, fmt.Errorf("Failed to retrieve item '%v': '%w'.", workItem, err)
+			}
+
+			result, ok := results[workItem]
+			if ok {
+				return resultItem{result, 0}, nil
+			}
+		}
+
+		// Nothing cached, compute the job.
+		startTime := timestamp.Now()
+
+		result, err := this.WorkFunc(workItem)
+		if err != nil {
+			return resultItem{}, fmt.Errorf("Failed to perform individual work on item '%v': '%w'.", workItem, err)
+		}
+
+		if this.Context.Err() != nil {
+			return resultItem{}, nil
+		}
+
+		runTime := (timestamp.Now() - startTime).ToMSecs()
+
+		// Store the result.
+		if !this.DryRun && this.StoreFunc != nil {
+			err = this.StoreFunc([]OutputType{result})
+			if err != nil {
+				return resultItem{}, fmt.Errorf("Failed to store result for item '%v': '%w'.", workItem, err)
+			}
+		}
+
+		return resultItem{result, runTime}, nil
+	})
+
+	output.RemainingItems = []InputType{}
+
+	// The job was canceled so return without collecting results.
+	if results.Canceled {
+		output.Canceled = true
+		return nil
+	}
+
+	results.IsDone()
+
+	output.WorkErrors = results.WorkErrors
+
+	for input, result := range results.Results {
+		_, ok := results.WorkErrors[input]
+		if ok {
+			continue
+		}
+
+		// Always update the run time for stats purposes.
+		output.RunTime += result.RunTime
+
+		if updateOutput {
+			output.ResultItems[input] = result.Output
+		}
+	}
+
+	return err
+}
+
+func getRemainingItems[InputType comparable, OutputType any](workItems []InputType, results map[InputType]OutputType) []InputType {
+	remainingItems := []InputType{}
+
+	for _, workItem := range workItems {
+		_, ok := results[workItem]
+		if !ok {
+			remainingItems = append(remainingItems, workItem)
+		}
+	}
+
+	return remainingItems
+}

--- a/internal/jobmanager/jobmanager_test.go
+++ b/internal/jobmanager/jobmanager_test.go
@@ -1,0 +1,1031 @@
+package jobmanager
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/edulinq/autograder/internal/util"
+)
+
+var testLockKey string = "test_key"
+var testPoolSize int = 1
+
+var input []string = []string{
+	"A",
+	"BB",
+	"CCC",
+}
+
+var workFunc = func(input string) (int, error) {
+	return len(input), nil
+}
+
+type printableJob[InputType any, OutputType any] struct {
+	*JobOptions
+
+	// Overwrite the JSON tag to display the context.
+	Context context.Context `json:"context"`
+
+	ReturnIncompleteResults bool `json:"return-incomplete-results"`
+
+	PoolSize int `json:"pool-size"`
+
+	LockKey string `json:"lock-key"`
+
+	WorkItems []InputType `json:"work-items"`
+}
+
+func (this *Job[InputType, OutputType]) toPrintableJob() *printableJob[InputType, OutputType] {
+	if this == nil {
+		return nil
+	}
+
+	return &printableJob[InputType, OutputType]{
+		JobOptions:              this.JobOptions,
+		Context:                 this.Context,
+		ReturnIncompleteResults: this.ReturnIncompleteResults,
+		PoolSize:                this.PoolSize,
+		LockKey:                 this.LockKey,
+		WorkItems:               this.WorkItems,
+	}
+}
+
+type printableJobOutput[InputType comparable, OutputType any] struct {
+	Canceled bool `json:"canceled"`
+
+	Error error `json:"error"`
+
+	WorkErrors map[InputType]error `json:"work-errors"`
+
+	ResultItems map[InputType]OutputType `json:"result-items"`
+
+	RemainingItems []InputType `json:"remaining-items"`
+
+	RunTime int64 `json:"run-time"`
+}
+
+func (this *JobOutput[InputType, OutputType]) toPrintableJobOutput() *printableJobOutput[InputType, OutputType] {
+	if this == nil {
+		return nil
+	}
+
+	return &printableJobOutput[InputType, OutputType]{
+		Canceled:       this.Canceled,
+		Error:          this.Error,
+		WorkErrors:     this.WorkErrors,
+		ResultItems:    this.ResultItems,
+		RemainingItems: this.RemainingItems,
+		RunTime:        this.RunTime,
+	}
+}
+
+func TestJobValidateBase(test *testing.T) {
+	testCases := []struct {
+		input       *Job[string, int]
+		expected    *Job[string, int]
+		errorString string
+	}{
+		// Success
+
+		// No Context Provided
+		{
+			&Job[string, int]{
+				WorkFunc:   workFunc,
+				PoolSize:   testPoolSize,
+				LockKey:    testLockKey,
+				JobOptions: &JobOptions{},
+			},
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
+				JobOptions: &JobOptions{
+					Context: context.Background(),
+				},
+			},
+			"",
+		},
+		{
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
+				JobOptions: &JobOptions{
+					WaitForCompletion: true,
+				},
+			},
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
+				JobOptions: &JobOptions{
+					Context:           context.Background(),
+					WaitForCompletion: true,
+				},
+			},
+			"",
+		},
+
+		// Nil Context Provided
+		{
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
+				JobOptions: &JobOptions{
+					Context: nil,
+				},
+			},
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
+				JobOptions: &JobOptions{
+					Context: context.Background(),
+				},
+			},
+			"",
+		},
+		{
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
+				JobOptions: &JobOptions{
+					Context:           nil,
+					WaitForCompletion: true,
+				},
+			},
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
+				JobOptions: &JobOptions{
+					Context:           context.Background(),
+					WaitForCompletion: true,
+				},
+			},
+			"",
+		},
+
+		// Context provided
+		{
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
+				JobOptions: &JobOptions{
+					Context: context.TODO(),
+				},
+			},
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
+				JobOptions: &JobOptions{
+					Context: context.TODO(),
+				},
+			},
+			"",
+		},
+		{
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
+				JobOptions: &JobOptions{
+					Context:           context.TODO(),
+					WaitForCompletion: true,
+				},
+			},
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+				LockKey:  testLockKey,
+				JobOptions: &JobOptions{
+					Context:           context.TODO(),
+					WaitForCompletion: true,
+				},
+			},
+			"",
+		},
+
+		// Errors
+
+		// Nil
+		{
+			nil,
+			nil,
+			"Job is nil.",
+		},
+		// Bad Work Function
+		{
+			&Job[string, int]{},
+			nil,
+			"Job cannot have a nil work function.",
+		},
+		{
+			&Job[string, int]{
+				WorkFunc: nil,
+			},
+			nil,
+			"Job cannot have a nil work function.",
+		},
+		// Bad Pool Size
+		{
+			&Job[string, int]{
+				WorkFunc: workFunc,
+			},
+			nil,
+			"Pool size must be positive, got 0.",
+		},
+		{
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				PoolSize: 0,
+			},
+			nil,
+			"Pool size must be positive, got 0.",
+		},
+		{
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				PoolSize: -1,
+			},
+			nil,
+			"Pool size must be positive, got -1.",
+		},
+		// Nil Job Options
+		{
+			&Job[string, int]{
+				WorkFunc: workFunc,
+				PoolSize: testPoolSize,
+			},
+			nil,
+			"Job options are nil.",
+		},
+		{
+			&Job[string, int]{
+				WorkFunc:   workFunc,
+				PoolSize:   testPoolSize,
+				JobOptions: nil,
+			},
+			nil,
+			"Job options are nil.",
+		},
+	}
+
+	for i, testCase := range testCases {
+		err := testCase.input.Validate()
+		if err != nil {
+			if testCase.errorString != "" {
+				if err.Error() != testCase.errorString {
+					test.Errorf("Case %d: Did not get expected error output. Expected substring: '%s', actual error: '%s'.", i, testCase.errorString, err.Error())
+				}
+			} else {
+				test.Errorf("Case %d: Failed to validate '%+v': '%v'.", i, testCase.input, err)
+			}
+
+			continue
+		}
+
+		if testCase.errorString != "" {
+			test.Errorf("Case %d: Did not get expected error: '%s'.", i, testCase.errorString)
+			continue
+		}
+
+		if testCase.input.WorkFunc == nil {
+			test.Errorf("Case %d: Found a nil work func after validation.", i)
+			continue
+		}
+
+		// Clear work functions for comparison.
+		testCase.input.WorkFunc = nil
+		testCase.expected.WorkFunc = nil
+
+		if !reflect.DeepEqual(testCase.expected, testCase.input) {
+			test.Errorf("Case %d: Unexpected result. Expected: '%s', actual: '%s'.",
+				i, util.MustToJSONIndent(testCase.expected.toPrintableJob()), util.MustToJSONIndent(testCase.input.toPrintableJob()))
+			continue
+		}
+	}
+}
+
+func TestRunJobBase(test *testing.T) {
+	finalExpected := map[string]int{
+		"A":   1,
+		"BB":  2,
+		"CCC": 3,
+	}
+
+	// A basic cache to test caching functionality.
+	storage := map[string]int{}
+
+	retrieveFunc := func(_ []string) (map[string]int, error) {
+		results := make(map[string]int, len(storage))
+
+		for input, output := range storage {
+			results[input] = output
+		}
+
+		return results, nil
+	}
+
+	removeStorageFunc := func(inputs []string) error {
+		for _, input := range inputs {
+			delete(storage, input)
+		}
+
+		return nil
+	}
+
+	errorRemoveFunc := func(_ []string) error {
+		return fmt.Errorf("Insane storage removal error!")
+	}
+
+	storageFunc := func(results []int) error {
+		for _, result := range results {
+			switch result {
+			case 1:
+				storage["A"] = 1
+			case 2:
+				storage["BB"] = 2
+			case 3:
+				storage["CCC"] = 3
+			default:
+				storage["unknown"] = result
+			}
+		}
+
+		return nil
+	}
+
+	testCases := []struct {
+		job Job[string, int]
+
+		initialOutput *JobOutput[string, int]
+		finalOutput   *JobOutput[string, int]
+
+		errorSubstring string
+
+		expectedStorage map[string]int
+	}{
+		// Success
+
+		// Base Options
+		{
+			job: Job[string, int]{
+				WorkItems:  nil,
+				JobOptions: &JobOptions{},
+			},
+			initialOutput: &JobOutput[string, int]{
+				ResultItems:    map[string]int{},
+				RemainingItems: nil,
+			},
+			finalOutput: &JobOutput[string, int]{
+				ResultItems:    map[string]int{},
+				RemainingItems: nil,
+			},
+		},
+		{
+			job: Job[string, int]{
+				WorkItems:  []string{},
+				JobOptions: &JobOptions{},
+			},
+			initialOutput: &JobOutput[string, int]{
+				ResultItems:    map[string]int{},
+				RemainingItems: []string{},
+			},
+			finalOutput: &JobOutput[string, int]{
+				ResultItems:    map[string]int{},
+				RemainingItems: []string{},
+			},
+		},
+		{
+			job: Job[string, int]{
+				WorkItems:  input,
+				JobOptions: &JobOptions{},
+			},
+			initialOutput: &JobOutput[string, int]{
+				ResultItems:    map[string]int{},
+				RemainingItems: input,
+			},
+			finalOutput: &JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+			},
+		},
+
+		// Passing A Retrieval Function
+		{
+			job: Job[string, int]{
+				WorkItems:    input,
+				RetrieveFunc: retrieveFunc,
+				JobOptions:   &JobOptions{},
+			},
+			initialOutput: &JobOutput[string, int]{
+				ResultItems: map[string]int{
+					"A":  1,
+					"BB": 2,
+				},
+				RemainingItems: []string{"CCC"},
+			},
+			finalOutput: &JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+			},
+		},
+		{
+			job: Job[string, int]{
+				WorkItems:    input,
+				RetrieveFunc: retrieveFunc,
+				JobOptions: &JobOptions{
+					OverwriteRecords: true,
+				},
+			},
+			initialOutput: &JobOutput[string, int]{
+				ResultItems:    map[string]int{},
+				RemainingItems: input,
+			},
+			finalOutput: &JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+			},
+		},
+
+		// Passing A Storage Removal Function
+		{
+			job: Job[string, int]{
+				WorkItems: input,
+				// Storage removal is not called when not overwriting records.
+				RemoveFunc: removeStorageFunc,
+				JobOptions: &JobOptions{
+					OverwriteRecords: false,
+				},
+			},
+			initialOutput: &JobOutput[string, int]{
+				ResultItems:    map[string]int{},
+				RemainingItems: input,
+			},
+			finalOutput: &JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+			},
+		},
+		{
+			job: Job[string, int]{
+				WorkItems:  input,
+				RemoveFunc: removeStorageFunc,
+				JobOptions: &JobOptions{
+					OverwriteRecords: true,
+				},
+			},
+			initialOutput: &JobOutput[string, int]{
+				ResultItems:    map[string]int{},
+				RemainingItems: input,
+			},
+			finalOutput: &JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+			},
+			expectedStorage: map[string]int{},
+		},
+		{
+			job: Job[string, int]{
+				WorkItems: input,
+				// Storage removal is not called when not overwriting records.
+				RemoveFunc: errorRemoveFunc,
+				JobOptions: &JobOptions{
+					OverwriteRecords: false,
+				},
+			},
+			initialOutput: &JobOutput[string, int]{
+				ResultItems:    map[string]int{},
+				RemainingItems: input,
+			},
+			finalOutput: &JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+			},
+		},
+
+		// Passing Retrieval And Storage Removal Functions
+		{
+			job: Job[string, int]{
+				WorkItems:    input,
+				RetrieveFunc: retrieveFunc,
+				// Storage removal is not called when not overwriting records.
+				RemoveFunc: removeStorageFunc,
+				JobOptions: &JobOptions{
+					OverwriteRecords: false,
+				},
+			},
+			initialOutput: &JobOutput[string, int]{
+				ResultItems: map[string]int{
+					"A":  1,
+					"BB": 2,
+				},
+				RemainingItems: []string{"CCC"},
+			},
+			finalOutput: &JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+			},
+		},
+		{
+			job: Job[string, int]{
+				WorkItems:    input,
+				RetrieveFunc: retrieveFunc,
+				RemoveFunc:   removeStorageFunc,
+				JobOptions: &JobOptions{
+					OverwriteRecords: true,
+				},
+			},
+			initialOutput: &JobOutput[string, int]{
+				ResultItems:    map[string]int{},
+				RemainingItems: input,
+			},
+			finalOutput: &JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+			},
+			expectedStorage: map[string]int{},
+		},
+
+		// Storage Functions
+		{
+			job: Job[string, int]{
+				WorkItems:  input,
+				StoreFunc:  storageFunc,
+				JobOptions: &JobOptions{},
+			},
+			initialOutput: &JobOutput[string, int]{
+				ResultItems:    map[string]int{},
+				RemainingItems: input,
+			},
+			finalOutput: &JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+			},
+			expectedStorage: map[string]int{
+				"A":   1,
+				"BB":  2,
+				"CCC": 3,
+			},
+		},
+		{
+			job: Job[string, int]{
+				WorkItems: input,
+				StoreFunc: storageFunc,
+				JobOptions: &JobOptions{
+					DryRun: true,
+				},
+			},
+			initialOutput: &JobOutput[string, int]{
+				ResultItems:    map[string]int{},
+				RemainingItems: input,
+			},
+			finalOutput: &JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+			},
+			expectedStorage: map[string]int{
+				"A":  1,
+				"BB": 2,
+			},
+		},
+
+		// Retrieval, Removal, And Storage Functions
+		{
+			job: Job[string, int]{
+				WorkItems:    input,
+				StoreFunc:    storageFunc,
+				RetrieveFunc: retrieveFunc,
+				JobOptions:   &JobOptions{},
+			},
+			initialOutput: &JobOutput[string, int]{
+				ResultItems: map[string]int{
+					"A":  1,
+					"BB": 2,
+				},
+				RemainingItems: []string{"CCC"},
+			},
+			finalOutput: &JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+			},
+			expectedStorage: map[string]int{
+				"A":   1,
+				"BB":  2,
+				"CCC": 3,
+			},
+		},
+		{
+			job: Job[string, int]{
+				WorkItems:    input,
+				StoreFunc:    storageFunc,
+				RetrieveFunc: retrieveFunc,
+				RemoveFunc:   removeStorageFunc,
+				JobOptions: &JobOptions{
+					OverwriteRecords: true,
+				},
+			},
+			initialOutput: &JobOutput[string, int]{
+				ResultItems:    map[string]int{},
+				RemainingItems: input,
+			},
+			finalOutput: &JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+			},
+			// Storage happens after record removal.
+			expectedStorage: map[string]int{
+				"A":   1,
+				"BB":  2,
+				"CCC": 3,
+			},
+		},
+		{
+			job: Job[string, int]{
+				WorkItems:    input,
+				StoreFunc:    storageFunc,
+				RetrieveFunc: retrieveFunc,
+				RemoveFunc:   removeStorageFunc,
+				JobOptions: &JobOptions{
+					OverwriteRecords: true,
+					DryRun:           true,
+				},
+			},
+			initialOutput: &JobOutput[string, int]{
+				ResultItems:    map[string]int{},
+				RemainingItems: input,
+			},
+			finalOutput: &JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+			},
+			expectedStorage: map[string]int{
+				"A":  1,
+				"BB": 2,
+			},
+		},
+
+		// Work Item Key Function
+		{
+			job: Job[string, int]{
+				WorkItems: input,
+				WorkItemKeyFunc: func(input string) string {
+					return input
+				},
+				JobOptions: &JobOptions{},
+			},
+			initialOutput: &JobOutput[string, int]{
+				ResultItems:    map[string]int{},
+				RemainingItems: input,
+			},
+			finalOutput: &JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+			},
+		},
+		{
+			job: Job[string, int]{
+				WorkItems: input,
+				WorkItemKeyFunc: func(_ string) string {
+					return "serial_test_key"
+				},
+				JobOptions: &JobOptions{},
+			},
+			initialOutput: &JobOutput[string, int]{
+				ResultItems:    map[string]int{},
+				RemainingItems: input,
+			},
+			finalOutput: &JobOutput[string, int]{
+				ResultItems:    finalExpected,
+				RemainingItems: []string{},
+			},
+		},
+
+		// On Success Function
+		{
+			job: Job[string, int]{
+				WorkItems: input,
+				OnSuccess: func(output JobOutput[string, int]) {
+					for i, result := range output.ResultItems {
+						output.ResultItems[i] = result * 2
+					}
+				},
+				JobOptions: &JobOptions{},
+			},
+			initialOutput: &JobOutput[string, int]{
+				ResultItems:    map[string]int{},
+				RemainingItems: input,
+			},
+			finalOutput: &JobOutput[string, int]{
+				ResultItems: map[string]int{
+					"A":   2,
+					"BB":  4,
+					"CCC": 6,
+				},
+				RemainingItems: []string{},
+			},
+		},
+
+		// Errors
+
+		// Bad Storage Function
+		{
+			job: Job[string, int]{
+				WorkItems: input,
+				RetrieveFunc: func(_ []string) (map[string]int, error) {
+					return nil, fmt.Errorf("Crazy retrieval error!")
+				},
+				JobOptions: &JobOptions{},
+			},
+			errorSubstring: "Crazy retrieval error!",
+		},
+
+		// Bad Storage Removal Function
+		{
+			job: Job[string, int]{
+				WorkItems:  input,
+				RemoveFunc: errorRemoveFunc,
+				JobOptions: &JobOptions{
+					OverwriteRecords: true,
+				},
+			},
+			errorSubstring: "Insane storage removal error!",
+		},
+	}
+
+	for i, testCase := range testCases {
+		// Set defualt job config.
+		testCase.job.WorkFunc = workFunc
+		testCase.job.PoolSize = testPoolSize
+		testCase.job.LockKey = testLockKey
+
+		testCase.job.WaitForCompletion = false
+		testCase.job.ReturnIncompleteResults = true
+
+		storage = resetStorage()
+
+		output := testCase.job.Run()
+		if output.Error != nil {
+			if testCase.errorSubstring != "" {
+				if !strings.Contains(output.Error.Error(), testCase.errorSubstring) {
+					test.Errorf("Case %d: Did not get expected error output on initial run. Expected substring: '%s', actual error: '%v'.", i, testCase.errorSubstring, output.Error)
+				}
+			} else {
+				test.Errorf("Case %d: Failed to run initial job: '%s'.", i, output.Error.Error())
+			}
+
+			continue
+		}
+
+		if testCase.errorSubstring != "" {
+			test.Errorf("Case %d: Did not get expected initial error: '%s'.", i, testCase.errorSubstring)
+			continue
+		}
+
+		// Clear channel and run time for comparison.
+		output.Done = nil
+		output.RunTime = 0
+
+		// Set default error output for successful test cases.
+		testCase.initialOutput.WorkErrors = map[string]error{}
+
+		if !reflect.DeepEqual(output, testCase.initialOutput) {
+			test.Errorf("Case %d: Unexpected initial results. Expected: '%s', actual: '%s'.",
+				i, util.MustToJSONIndent(testCase.initialOutput.toPrintableJobOutput()), util.MustToJSONIndent(output.toPrintableJobOutput()))
+			continue
+		}
+
+		testCase.job.WaitForCompletion = true
+
+		output = testCase.job.Run()
+		if output.Error != nil {
+			test.Errorf("Case %d: Failed to run final job: '%s'.", i, output.Error.Error())
+			continue
+		}
+
+		// Clear channel and run time for comparison.
+		output.Done = nil
+		output.RunTime = 0
+
+		// Set default error output for successful test cases.
+		testCase.finalOutput.WorkErrors = map[string]error{}
+
+		if !reflect.DeepEqual(output, testCase.finalOutput) {
+			test.Errorf("Case %d: Unexpected final results. Expected: '%s', actual: '%s'.",
+				i, util.MustToJSONIndent(testCase.finalOutput.toPrintableJobOutput()), util.MustToJSONIndent(output.toPrintableJobOutput()))
+			continue
+		}
+
+		if testCase.expectedStorage == nil {
+			testCase.expectedStorage = map[string]int{
+				"A":  1,
+				"BB": 2,
+			}
+		}
+
+		// Sleep to let the writes to the storage complete.
+		time.Sleep(time.Duration(2) * time.Millisecond)
+
+		if !reflect.DeepEqual(storage, testCase.expectedStorage) {
+			test.Errorf("Case %d: Unexpected storage results. Expected: '%v', actual: '%v'.", i, testCase.expectedStorage, storage)
+			continue
+		}
+	}
+}
+
+func TestRunJobCancel(test *testing.T) {
+	// Block until the initial worker has started.
+	workWaitGroup := sync.WaitGroup{}
+	workWaitGroup.Add(1)
+
+	sleepWorkFunc := func(input string) (int, error) {
+		// Allow the first input to return a result to test cleanup.
+		if input == "A" {
+			return len(input), nil
+		}
+
+		// Signal on the second piece of work so that we can make sure the workers have started up before we cancel.
+		if input == "BB" {
+			workWaitGroup.Done()
+		}
+
+		// Sleep for a really long time (for a test).
+		time.Sleep(1 * time.Hour)
+
+		return len(input), nil
+	}
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+
+	job := &Job[string, int]{
+		WorkItems: input,
+		WorkFunc:  sleepWorkFunc,
+		PoolSize:  testPoolSize,
+		LockKey:   testLockKey,
+		JobOptions: &JobOptions{
+			Context:           ctx,
+			WaitForCompletion: true,
+		},
+	}
+
+	// Cancel the context as soon as the worker signals it.
+	go func() {
+		workWaitGroup.Wait()
+		cancelFunc()
+	}()
+
+	expectedOutput := &JobOutput[string, int]{
+		Canceled:       true,
+		Error:          fmt.Errorf("Job was canceled: 'context canceled'."),
+		WorkErrors:     map[string]error{},
+		ResultItems:    map[string]int{},
+		RemainingItems: []string{},
+	}
+
+	output := job.Run()
+	if output.Error.Error() != expectedOutput.Error.Error() {
+		test.Fatalf("Unexpected error. Expected: '%s', actual: '%s'.",
+			expectedOutput.Error.Error(), output.Error.Error())
+	}
+
+	// Clear done channel and errors for comparison check.
+	output.Done = nil
+	output.Error = nil
+	expectedOutput.Error = nil
+
+	if !reflect.DeepEqual(output, expectedOutput) {
+		test.Fatalf("Unexpected result. Expected: '%s', actual: '%s'.",
+			util.MustToJSONIndent(expectedOutput.toPrintableJobOutput()), util.MustToJSONIndent(output.toPrintableJobOutput()))
+	}
+}
+
+func TestRunJobChannel(test *testing.T) {
+	job := &Job[string, int]{
+		WorkItems:               input,
+		WorkFunc:                workFunc,
+		PoolSize:                testPoolSize,
+		LockKey:                 testLockKey,
+		ReturnIncompleteResults: false,
+		JobOptions: &JobOptions{
+			WaitForCompletion: false,
+		},
+	}
+
+	output := job.Run()
+	if output.Error != nil {
+		test.Fatalf("Failed to run job: '%v'.", output.Error)
+	}
+
+	// Wait for the worker to signal the job is done.
+	<-output.Done
+
+	expected := &JobOutput[string, int]{
+		ResultItems: map[string]int{
+			"A":   1,
+			"BB":  2,
+			"CCC": 3,
+		},
+		RemainingItems: []string{},
+		RunTime:        output.RunTime,
+		WorkErrors:     map[string]error{},
+		Done:           output.Done,
+	}
+
+	if !reflect.DeepEqual(output, expected) {
+		test.Fatalf("Unexpected output. Expected: '%s', actual: '%s'.",
+			util.MustToJSONIndent(expected.toPrintableJobOutput()), util.MustToJSONIndent(output.toPrintableJobOutput()))
+	}
+}
+
+func TestBadWorkFunc(test *testing.T) {
+	job := &Job[string, int]{
+		WorkItems: input,
+		WorkFunc: func(input string) (int, error) {
+			return 0, fmt.Errorf("Sneaky work error.")
+		},
+		PoolSize:                testPoolSize,
+		LockKey:                 testLockKey,
+		ReturnIncompleteResults: true,
+		JobOptions: &JobOptions{
+			WaitForCompletion: false,
+		},
+	}
+
+	// The incomplete results should not have any errors.
+	output := job.Run()
+	if output.Error != nil {
+		test.Fatalf("Failed to run job: '%s'.", output.Error.Error())
+	}
+
+	job.WaitForCompletion = true
+
+	expectedOutput := &JobOutput[string, int]{
+		Error:          fmt.Errorf("Failed to complete work for '%d' items.", len(input)),
+		RemainingItems: []string{},
+		ResultItems:    map[string]int{},
+		WorkErrors: map[string]error{
+			"A":   fmt.Errorf("Failed to perform individual work on item 'A': 'Sneaky work error.'."),
+			"BB":  fmt.Errorf("Failed to perform individual work on item 'BB': 'Sneaky work error.'."),
+			"CCC": fmt.Errorf("Failed to perform individual work on item 'CCC': 'Sneaky work error.'."),
+		},
+	}
+
+	output = job.Run()
+	if output.Error == nil {
+		test.Fatalf("Did not get expected error. Expected: '%s'.", expectedOutput.Error.Error())
+	}
+
+	if output.Error.Error() != expectedOutput.Error.Error() {
+		test.Fatalf("Unexpected error. Expected: '%s', actual: '%s'.",
+			expectedOutput.Error.Error(), output.Error.Error())
+	}
+
+	if len(output.WorkErrors) != len(expectedOutput.WorkErrors) {
+		test.Fatalf("Unexpected number of work errors. Expected: '%v', actual: '%v'.",
+			expectedOutput.WorkErrors, output.WorkErrors)
+	}
+
+	for item, expectedError := range expectedOutput.WorkErrors {
+		actualError, ok := output.WorkErrors[item]
+		if !ok {
+			test.Fatalf("Unable to find expected error for item '%v': '%s'.", item, expectedError.Error())
+		}
+
+		if expectedError.Error() != actualError.Error() {
+			test.Fatalf("Unexpected work error for item '%v'. Expected: '%s', actual: '%s'.",
+				item, expectedError.Error(), actualError.Error())
+		}
+	}
+
+	// Clear done channel and errors for comparison check.
+	output.Done = nil
+	expectedOutput.Done = nil
+
+	output.Error = nil
+	expectedOutput.Error = nil
+
+	output.WorkErrors = nil
+	expectedOutput.WorkErrors = nil
+
+	if !reflect.DeepEqual(output, expectedOutput) {
+		test.Fatalf("Unexpected result. Expected: '%s', actual: '%s'.",
+			util.MustToJSONIndent(expectedOutput.toPrintableJobOutput()), util.MustToJSONIndent(output.toPrintableJobOutput()))
+	}
+}
+
+func resetStorage() map[string]int {
+	return map[string]int{
+		"A":  1,
+		"BB": 2,
+	}
+}

--- a/internal/jobmanager/jobmanager_test.go
+++ b/internal/jobmanager/jobmanager_test.go
@@ -652,11 +652,11 @@ func TestRunJobBase(test *testing.T) {
 			},
 		},
 
-		// On Success Function
+		// On Complete Function
 		{
 			job: Job[string, int]{
 				WorkItems: input,
-				OnSuccess: func(output JobOutput[string, int]) {
+				OnComplete: func(output *JobOutput[string, int]) {
 					for i, result := range output.ResultItems {
 						output.ResultItems[i] = result * 2
 					}
@@ -911,7 +911,7 @@ func TestBadWorkFunc(test *testing.T) {
 	job.WaitForCompletion = true
 
 	expectedOutput := &JobOutput[string, int]{
-		Error:          fmt.Errorf("Failed to complete work for '%d' items.", len(input)),
+		Error:          nil,
 		RemainingItems: []string{},
 		ResultItems:    map[string]int{},
 		WorkErrors: map[string]error{
@@ -922,13 +922,8 @@ func TestBadWorkFunc(test *testing.T) {
 	}
 
 	output = job.Run()
-	if output.Error == nil {
-		test.Fatalf("Did not get expected error. Expected: '%s'.", expectedOutput.Error.Error())
-	}
-
-	if output.Error.Error() != expectedOutput.Error.Error() {
-		test.Fatalf("Unexpected error. Expected: '%s', actual: '%s'.",
-			expectedOutput.Error.Error(), output.Error.Error())
+	if output.Error != nil {
+		test.Fatalf("Failed to run job: '%s'.", output.Error.Error())
 	}
 
 	if len(output.WorkErrors) != len(expectedOutput.WorkErrors) {
@@ -951,9 +946,6 @@ func TestBadWorkFunc(test *testing.T) {
 	// Clear done channel and errors for comparison check.
 	output.Done = nil
 	expectedOutput.Done = nil
-
-	output.Error = nil
-	expectedOutput.Error = nil
 
 	output.WorkErrors = nil
 	expectedOutput.WorkErrors = nil

--- a/internal/jobmanager/jobmanager_test.go
+++ b/internal/jobmanager/jobmanager_test.go
@@ -25,65 +25,6 @@ var workFunc = func(input string) (int, error) {
 	return len(input), nil
 }
 
-type printableJob[InputType any, OutputType any] struct {
-	*JobOptions
-
-	// Overwrite the JSON tag to display the context.
-	Context context.Context `json:"context"`
-
-	ReturnIncompleteResults bool `json:"return-incomplete-results"`
-
-	PoolSize int `json:"pool-size"`
-
-	LockKey string `json:"lock-key"`
-
-	WorkItems []InputType `json:"work-items"`
-}
-
-func (this *Job[InputType, OutputType]) toPrintableJob() *printableJob[InputType, OutputType] {
-	if this == nil {
-		return nil
-	}
-
-	return &printableJob[InputType, OutputType]{
-		JobOptions:              this.JobOptions,
-		Context:                 this.Context,
-		ReturnIncompleteResults: this.ReturnIncompleteResults,
-		PoolSize:                this.PoolSize,
-		LockKey:                 this.LockKey,
-		WorkItems:               this.WorkItems,
-	}
-}
-
-type printableJobOutput[InputType comparable, OutputType any] struct {
-	Canceled bool `json:"canceled"`
-
-	Error error `json:"error"`
-
-	WorkErrors map[InputType]error `json:"work-errors"`
-
-	ResultItems map[InputType]OutputType `json:"result-items"`
-
-	RemainingItems []InputType `json:"remaining-items"`
-
-	RunTime int64 `json:"run-time"`
-}
-
-func (this *JobOutput[InputType, OutputType]) toPrintableJobOutput() *printableJobOutput[InputType, OutputType] {
-	if this == nil {
-		return nil
-	}
-
-	return &printableJobOutput[InputType, OutputType]{
-		Canceled:       this.Canceled,
-		Error:          this.Error,
-		WorkErrors:     this.WorkErrors,
-		ResultItems:    this.ResultItems,
-		RemainingItems: this.RemainingItems,
-		RunTime:        this.RunTime,
-	}
-}
-
 func TestJobValidateBase(test *testing.T) {
 	testCases := []struct {
 		input       *Job[string, int]
@@ -310,7 +251,7 @@ func TestJobValidateBase(test *testing.T) {
 
 		if !reflect.DeepEqual(testCase.expected, testCase.input) {
 			test.Errorf("Case %d: Unexpected result. Expected: '%s', actual: '%s'.",
-				i, util.MustToJSONIndent(testCase.expected.toPrintableJob()), util.MustToJSONIndent(testCase.input.toPrintableJob()))
+				i, util.MustToJSONIndent(testCase.expected), util.MustToJSONIndent(testCase.input))
 			continue
 		}
 	}
@@ -801,7 +742,7 @@ func TestRunJobBase(test *testing.T) {
 
 		if !reflect.DeepEqual(output, testCase.initialOutput) {
 			test.Errorf("Case %d: Unexpected initial results. Expected: '%s', actual: '%s'.",
-				i, util.MustToJSONIndent(testCase.initialOutput.toPrintableJobOutput()), util.MustToJSONIndent(output.toPrintableJobOutput()))
+				i, util.MustToJSONIndent(testCase.initialOutput), util.MustToJSONIndent(output))
 			continue
 		}
 
@@ -822,7 +763,7 @@ func TestRunJobBase(test *testing.T) {
 
 		if !reflect.DeepEqual(output, testCase.finalOutput) {
 			test.Errorf("Case %d: Unexpected final results. Expected: '%s', actual: '%s'.",
-				i, util.MustToJSONIndent(testCase.finalOutput.toPrintableJobOutput()), util.MustToJSONIndent(output.toPrintableJobOutput()))
+				i, util.MustToJSONIndent(testCase.finalOutput), util.MustToJSONIndent(output))
 			continue
 		}
 
@@ -889,7 +830,7 @@ func TestRunJobCancel(test *testing.T) {
 		Error:          fmt.Errorf("Job was canceled: 'context canceled'."),
 		WorkErrors:     map[string]error{},
 		ResultItems:    map[string]int{},
-		RemainingItems: []string{},
+		RemainingItems: input,
 	}
 
 	output := job.Run()
@@ -905,7 +846,7 @@ func TestRunJobCancel(test *testing.T) {
 
 	if !reflect.DeepEqual(output, expectedOutput) {
 		test.Fatalf("Unexpected result. Expected: '%s', actual: '%s'.",
-			util.MustToJSONIndent(expectedOutput.toPrintableJobOutput()), util.MustToJSONIndent(output.toPrintableJobOutput()))
+			util.MustToJSONIndent(expectedOutput), util.MustToJSONIndent(output))
 	}
 }
 
@@ -943,7 +884,7 @@ func TestRunJobChannel(test *testing.T) {
 
 	if !reflect.DeepEqual(output, expected) {
 		test.Fatalf("Unexpected output. Expected: '%s', actual: '%s'.",
-			util.MustToJSONIndent(expected.toPrintableJobOutput()), util.MustToJSONIndent(output.toPrintableJobOutput()))
+			util.MustToJSONIndent(expected), util.MustToJSONIndent(output))
 	}
 }
 
@@ -1019,7 +960,7 @@ func TestBadWorkFunc(test *testing.T) {
 
 	if !reflect.DeepEqual(output, expectedOutput) {
 		test.Fatalf("Unexpected result. Expected: '%s', actual: '%s'.",
-			util.MustToJSONIndent(expectedOutput.toPrintableJobOutput()), util.MustToJSONIndent(output.toPrintableJobOutput()))
+			util.MustToJSONIndent(expectedOutput), util.MustToJSONIndent(output))
 	}
 }
 

--- a/internal/jobmanager/main_test.go
+++ b/internal/jobmanager/main_test.go
@@ -1,0 +1,36 @@
+package jobmanager
+
+// Note that this file is largely a copy of db/test.go.
+// The content is repeated to avoid an import cycle.
+
+import (
+	"os"
+	"testing"
+
+	"github.com/edulinq/autograder/internal/config"
+	"github.com/edulinq/autograder/internal/log"
+	"github.com/edulinq/autograder/internal/util"
+)
+
+// Use the common main for all tests in this package.
+func TestMain(suite *testing.M) {
+	// Run inside a func so defers will run before os.Exit().
+	code := func() int {
+		config.MustEnableUnitTestingMode()
+		log.SetLevelFatal()
+
+		defer CleanupTestingMain()
+
+		return suite.Run()
+	}()
+
+	os.Exit(code)
+}
+
+func CleanupTestingMain() {
+	// Remove any temp directories.
+	err := util.RemoveRecordedTempDirs()
+	if err != nil {
+		log.Error("Error when removing temp dirs.", err)
+	}
+}

--- a/internal/util/pool.go
+++ b/internal/util/pool.go
@@ -18,13 +18,13 @@ type PoolResult[InputType comparable, OutputType any] struct {
 	// Signals that the parallel pool was canceled during execution.
 	Canceled bool
 
-	// An internal done channel to signal the results can be accessed.
-	done chan any
+	// Signals the results can be accessed.
+	Done <-chan any
 }
 
 // Use this method to block until the results can be accessed.
 func (this PoolResult[InputType, OutputType]) IsDone() {
-	<-this.done
+	<-this.Done
 }
 
 // Do a map function (one result for one input) with a parallel pool of workers.
@@ -70,7 +70,7 @@ func RunParallelPoolMap[InputType comparable, OutputType any](poolSize int, work
 	output := PoolResult[InputType, OutputType]{
 		Results:    make(map[InputType]OutputType, len(workItems)),
 		WorkErrors: make(map[InputType]error, 0),
-		done:       doneChan,
+		Done:       doneChan,
 	}
 
 	// Load work.

--- a/internal/util/pool_test.go
+++ b/internal/util/pool_test.go
@@ -65,7 +65,7 @@ func TestRunParallelPoolMapBase(test *testing.T) {
 		output.IsDone()
 
 		// Clear output done channel for comparison check.
-		output.done = nil
+		output.Done = nil
 
 		if !reflect.DeepEqual(expected, output) {
 			test.Errorf("Case %d: Result not as expected. Expected: '%s', actual: '%s'.",
@@ -136,7 +136,7 @@ func TestRunParallelPoolMapCancel(test *testing.T) {
 	}
 
 	// Clear output done channel for comparison check.
-	output.done = nil
+	output.Done = nil
 
 	if !reflect.DeepEqual(output, expected) {
 		test.Fatalf("Unexpected results. Expected: '%v', actual: '%v'.",


### PR DESCRIPTION
This PR adds the `jobmanager` package which provides common infrastructure for running large jobs.

The `jobmanager` allows for flexible configuration through the `Job` struct. It allows for synchronization (at the job and work item level), context cancellation, record retrieval, record storage, record removal, and asynchronous output processing. By adding a layer of abstraction, large operations that require some or all of these features can be more easily defined and run.

This PR builds off of the recent [changes to the parallel pool](https://github.com/edulinq/autograder-server/commit/84ef1c55e7a13dd23b37cd7e71d2b02ff40c531b). This PR is the next step in completing the job manager PR that grew too large, which can be found [here](https://github.com/edulinq/autograder-server/pull/174).

Next, individual and pairwise analysis will be routed through the job manager to streamline the analysis code.