### PR TITLE
Added required fields to API input fields in API descriptions.

### DIFF
--- a/internal/analysis/common.go
+++ b/internal/analysis/common.go
@@ -19,7 +19,7 @@ type AnalysisOptions struct {
 	jobmanager.JobOptions
 
 	// The raw submission specifications to analyze.
-	RawSubmissionSpecs []string `json:"submissions"`
+	RawSubmissionSpecs []string `json:"submissions" required:""`
 
 	// Email of the person making the request for logging/stats purposes.
 	InitiatorEmail string `json:"-"`

--- a/internal/api/core/describe_test.go
+++ b/internal/api/core/describe_test.go
@@ -32,8 +32,8 @@ type simpleJSONStruct struct {
 }
 
 type secureJSONStruct struct {
-	FirstName string `json:"first-name"`
-	LastName  string `json:"last-name"`
+	FirstName string `json:"first-name" required:""`
+	LastName  string `json:"last-name" required:""`
 	Pay       int    `json:"-"`
 }
 
@@ -226,16 +226,28 @@ func TestDescribeTypeBase(test *testing.T) {
 			TypeDescription{
 				Category: StructType,
 				Fields: []FieldDescription{
-					FieldDescription{"email", "string"},
-					FieldDescription{"job-code", "int"},
+					FieldDescription{
+						BaseFieldDescription: BaseFieldDescription{"email", "string"},
+						Required:             false,
+					},
+					FieldDescription{
+						BaseFieldDescription: BaseFieldDescription{"job-code", "int"},
+						Required:             false,
+					},
 				},
 			},
 			map[string]TypeDescription{
 				mustGetTypeID(reflect.TypeOf((*simpleJSONStruct)(nil)).Elem(), nil): TypeDescription{
 					Category: StructType,
 					Fields: []FieldDescription{
-						FieldDescription{"email", "string"},
-						FieldDescription{"job-code", "int"},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"email", "string"},
+							Required:             false,
+						},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"job-code", "int"},
+							Required:             false,
+						},
 					},
 				},
 			},
@@ -247,16 +259,28 @@ func TestDescribeTypeBase(test *testing.T) {
 			TypeDescription{
 				Category: StructType,
 				Fields: []FieldDescription{
-					FieldDescription{"first-name", "string"},
-					FieldDescription{"last-name", "string"},
+					FieldDescription{
+						BaseFieldDescription: BaseFieldDescription{"first-name", "string"},
+						Required:             true,
+					},
+					FieldDescription{
+						BaseFieldDescription: BaseFieldDescription{"last-name", "string"},
+						Required:             true,
+					},
 				},
 			},
 			map[string]TypeDescription{
 				mustGetTypeID(reflect.TypeOf((*secureJSONStruct)(nil)).Elem(), nil): TypeDescription{
 					Category: StructType,
 					Fields: []FieldDescription{
-						FieldDescription{"first-name", "string"},
-						FieldDescription{"last-name", "string"},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"first-name", "string"},
+							Required:             true,
+						},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"last-name", "string"},
+							Required:             true,
+						},
 					},
 				},
 			},
@@ -268,20 +292,44 @@ func TestDescribeTypeBase(test *testing.T) {
 			TypeDescription{
 				Category: StructType,
 				Fields: []FieldDescription{
-					FieldDescription{"email", "string"},
-					FieldDescription{"first-name", "string"},
-					FieldDescription{"job-code", "int"},
-					FieldDescription{"last-name", "string"},
+					FieldDescription{
+						BaseFieldDescription: BaseFieldDescription{"email", "string"},
+						Required:             false,
+					},
+					FieldDescription{
+						BaseFieldDescription: BaseFieldDescription{"first-name", "string"},
+						Required:             true,
+					},
+					FieldDescription{
+						BaseFieldDescription: BaseFieldDescription{"job-code", "int"},
+						Required:             false,
+					},
+					FieldDescription{
+						BaseFieldDescription: BaseFieldDescription{"last-name", "string"},
+						Required:             true,
+					},
 				},
 			},
 			map[string]TypeDescription{
 				mustGetTypeID(reflect.TypeOf((*embeddedJSONStruct)(nil)).Elem(), nil): TypeDescription{
 					Category: StructType,
 					Fields: []FieldDescription{
-						FieldDescription{"email", "string"},
-						FieldDescription{"first-name", "string"},
-						FieldDescription{"job-code", "int"},
-						FieldDescription{"last-name", "string"},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"email", "string"},
+							Required:             false,
+						},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"first-name", "string"},
+							Required:             true,
+						},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"job-code", "int"},
+							Required:             false,
+						},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"last-name", "string"},
+							Required:             true,
+						},
 					},
 				},
 			},
@@ -293,27 +341,57 @@ func TestDescribeTypeBase(test *testing.T) {
 			TypeDescription{
 				Category: StructType,
 				Fields: []FieldDescription{
-					FieldDescription{"coin-value", "core.simpleMapWrapper"},
-					FieldDescription{"good-index", "core.simpleArrayWrapper"},
-					FieldDescription{"personnel", "core.embeddedJSONStruct"},
+					FieldDescription{
+						BaseFieldDescription: BaseFieldDescription{"coin-value", "core.simpleMapWrapper"},
+						Required:             false,
+					},
+					FieldDescription{
+						BaseFieldDescription: BaseFieldDescription{"good-index", "core.simpleArrayWrapper"},
+						Required:             false,
+					},
+					FieldDescription{
+						BaseFieldDescription: BaseFieldDescription{"personnel", "core.embeddedJSONStruct"},
+						Required:             false,
+					},
 				},
 			},
 			map[string]TypeDescription{
 				mustGetTypeID(reflect.TypeOf((*complexJSONStruct)(nil)).Elem(), nil): TypeDescription{
 					Category: StructType,
 					Fields: []FieldDescription{
-						FieldDescription{"coin-value", "core.simpleMapWrapper"},
-						FieldDescription{"good-index", "core.simpleArrayWrapper"},
-						FieldDescription{"personnel", "core.embeddedJSONStruct"},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"coin-value", "core.simpleMapWrapper"},
+							Required:             false,
+						},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"good-index", "core.simpleArrayWrapper"},
+							Required:             false,
+						},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"personnel", "core.embeddedJSONStruct"},
+							Required:             false,
+						},
 					},
 				},
 				mustGetTypeID(reflect.TypeOf((*embeddedJSONStruct)(nil)).Elem(), nil): TypeDescription{
 					Category: StructType,
 					Fields: []FieldDescription{
-						FieldDescription{"email", "string"},
-						FieldDescription{"first-name", "string"},
-						FieldDescription{"job-code", "int"},
-						FieldDescription{"last-name", "string"},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"email", "string"},
+							Required:             false,
+						},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"first-name", "string"},
+							Required:             true,
+						},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"job-code", "int"},
+							Required:             false,
+						},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"last-name", "string"},
+							Required:             true,
+						},
 					},
 				},
 				mustGetTypeID(reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(), nil): TypeDescription{
@@ -361,27 +439,57 @@ func TestDescribeTypeBase(test *testing.T) {
 			TypeDescription{
 				Category: StructType,
 				Fields: []FieldDescription{
-					FieldDescription{"coin-value", "*core.simpleMapWrapper"},
-					FieldDescription{"good-index", "*core.simpleArrayWrapper"},
-					FieldDescription{"personnel", "*core.embeddedJSONStruct"},
+					FieldDescription{
+						BaseFieldDescription: BaseFieldDescription{"coin-value", "*core.simpleMapWrapper"},
+						Required:             false,
+					},
+					FieldDescription{
+						BaseFieldDescription: BaseFieldDescription{"good-index", "*core.simpleArrayWrapper"},
+						Required:             false,
+					},
+					FieldDescription{
+						BaseFieldDescription: BaseFieldDescription{"personnel", "*core.embeddedJSONStruct"},
+						Required:             false,
+					},
 				},
 			},
 			map[string]TypeDescription{
 				mustGetTypeID(reflect.TypeOf((*complexPointerStruct)(nil)).Elem(), nil): TypeDescription{
 					Category: StructType,
 					Fields: []FieldDescription{
-						FieldDescription{"coin-value", "*core.simpleMapWrapper"},
-						FieldDescription{"good-index", "*core.simpleArrayWrapper"},
-						FieldDescription{"personnel", "*core.embeddedJSONStruct"},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"coin-value", "*core.simpleMapWrapper"},
+							Required:             false,
+						},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"good-index", "*core.simpleArrayWrapper"},
+							Required:             false,
+						},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"personnel", "*core.embeddedJSONStruct"},
+							Required:             false,
+						},
 					},
 				},
 				mustGetTypeID(reflect.TypeOf((*embeddedJSONStruct)(nil)).Elem(), nil): TypeDescription{
 					Category: StructType,
 					Fields: []FieldDescription{
-						FieldDescription{"email", "string"},
-						FieldDescription{"first-name", "string"},
-						FieldDescription{"job-code", "int"},
-						FieldDescription{"last-name", "string"},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"email", "string"},
+							Required:             false,
+						},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"first-name", "string"},
+							Required:             true,
+						},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"job-code", "int"},
+							Required:             false,
+						},
+						FieldDescription{
+							BaseFieldDescription: BaseFieldDescription{"last-name", "string"},
+							Required:             true,
+						},
 					},
 				},
 				mustGetTypeID(reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(), nil): TypeDescription{

--- a/internal/api/core/request.go
+++ b/internal/api/core/request.go
@@ -38,8 +38,8 @@ type APIRequest struct {
 type APIRequestUserContext struct {
 	APIRequest
 
-	UserEmail     string `json:"user-email"`
-	UserPass      string `json:"user-pass"`
+	UserEmail     string `json:"user-email" required:""`
+	UserPass      string `json:"user-pass" required:""`
 	RootUserNonce string `json:"root-user-nonce,omitempty"`
 
 	ServerUser *model.ServerUser `json:"-"`
@@ -49,7 +49,7 @@ type APIRequestUserContext struct {
 type APIRequestCourseUserContext struct {
 	APIRequestUserContext
 
-	CourseID string `json:"course-id"`
+	CourseID string `json:"course-id" required:""`
 
 	Course *model.Course     `json:"-"`
 	User   *model.CourseUser `json:"-"`
@@ -59,7 +59,7 @@ type APIRequestCourseUserContext struct {
 type APIRequestAssignmentContext struct {
 	APIRequestCourseUserContext
 
-	AssignmentID string `json:"assignment-id"`
+	AssignmentID string `json:"assignment-id" required:""`
 
 	Assignment *model.Assignment `json:"-"`
 }

--- a/internal/api/courses/assignments/submissions/proxy/resubmit.go
+++ b/internal/api/courses/assignments/submissions/proxy/resubmit.go
@@ -14,7 +14,7 @@ type ResubmitRequest struct {
 
 	TargetSubmission string `json:"target-submission"`
 
-	ProxyUser core.TargetCourseUser `json:"proxy-email"`
+	ProxyUser core.TargetCourseUser `json:"proxy-email" required:""`
 	ProxyTime *timestamp.Timestamp  `json:"proxy-time"`
 }
 

--- a/internal/api/courses/assignments/submissions/proxy/submit.go
+++ b/internal/api/courses/assignments/submissions/proxy/submit.go
@@ -11,7 +11,7 @@ type SubmitRequest struct {
 	core.MinCourseRoleGrader
 	Files core.POSTFiles `json:"-"`
 
-	ProxyUser core.TargetCourseUser `json:"proxy-email"`
+	ProxyUser core.TargetCourseUser `json:"proxy-email" required:""`
 	ProxyTime *timestamp.Timestamp  `json:"proxy-time"`
 
 	Message string `json:"message"`

--- a/internal/api/courses/upsert/filespec.go
+++ b/internal/api/courses/upsert/filespec.go
@@ -11,7 +11,7 @@ type FileSpecRequest struct {
 	core.MinServerRoleCourseCreator
 
 	courses.CourseUpsertOptions
-	FileSpec util.FileSpec `json:"filespec"`
+	FileSpec util.FileSpec `json:"filespec" required:""`
 }
 
 // Upsert a course using a filespec.

--- a/internal/api/courses/users/drop.go
+++ b/internal/api/courses/users/drop.go
@@ -10,7 +10,7 @@ type DropRequest struct {
 	core.APIRequestCourseUserContext
 	core.MinCourseRoleAdmin
 
-	TargetCourseUser core.TargetCourseUser `json:"target-email"`
+	TargetCourseUser core.TargetCourseUser `json:"target-email" required:""`
 }
 
 type DropResponse struct {

--- a/internal/api/courses/users/enroll.go
+++ b/internal/api/courses/users/enroll.go
@@ -12,7 +12,7 @@ type EnrollRequest struct {
 	core.APIRequestCourseUserContext
 	core.MinCourseRoleAdmin
 
-	RawCourseUsers []*model.RawCourseUserData `json:"raw-course-users"`
+	RawCourseUsers []*model.RawCourseUserData `json:"raw-course-users" required:""`
 
 	SkipInserts bool `json:"skip-inserts"`
 	SkipUpdates bool `json:"skip-updates"`

--- a/internal/api/lms/upload/scores.go
+++ b/internal/api/lms/upload/scores.go
@@ -11,8 +11,8 @@ type UploadScoresRequest struct {
 	core.MinCourseRoleGrader
 	Users core.CourseUsers `json:"-"`
 
-	AssignmentLMSID core.NonEmptyString `json:"assignment-lms-id"`
-	Scores          []ScoreEntry        `json:"scores"`
+	AssignmentLMSID core.NonEmptyString `json:"assignment-lms-id" required:""`
+	Scores          []ScoreEntry        `json:"scores" required:""`
 }
 
 type ScoreEntry struct {

--- a/internal/api/lms/user/get.go
+++ b/internal/api/lms/user/get.go
@@ -9,7 +9,7 @@ type UserGetRequest struct {
 	core.APIRequestCourseUserContext
 	core.MinCourseRoleGrader
 
-	TargetUser core.TargetCourseUser `json:"target-email"`
+	TargetUser core.TargetCourseUser `json:"target-email" required:""`
 }
 
 type UserGetResponse struct {

--- a/internal/api/metadata/describe_test.go
+++ b/internal/api/metadata/describe_test.go
@@ -15,16 +15,18 @@ func TestMetadataDescribe(test *testing.T) {
 				Description: "Describe all endpoints on the server.",
 				Input: []core.FieldDescription{
 					core.FieldDescription{
-						Name: "force-compute",
-						Type: "bool",
+						BaseFieldDescription: core.BaseFieldDescription{
+							Name: "force-compute",
+							Type: "bool",
+						},
 					},
 				},
-				Output: []core.FieldDescription{
-					core.FieldDescription{
+				Output: []core.BaseFieldDescription{
+					core.BaseFieldDescription{
 						Name: "endpoints",
 						Type: "map[string]core.EndpointDescription",
 					},
-					core.FieldDescription{
+					core.BaseFieldDescription{
 						Name: "types",
 						Type: "map[string]core.TypeDescription",
 					},
@@ -32,20 +34,43 @@ func TestMetadataDescribe(test *testing.T) {
 			},
 		},
 		Types: map[string]core.TypeDescription{
+			"core.BaseFieldDescription": core.TypeDescription{
+				Category: "struct",
+				Fields: []core.FieldDescription{
+					{
+						BaseFieldDescription: core.BaseFieldDescription{
+							Name: "name",
+							Type: "string",
+						},
+					},
+					{
+						BaseFieldDescription: core.BaseFieldDescription{
+							Name: "type",
+							Type: "string",
+						},
+					},
+				},
+			},
 			"core.EndpointDescription": core.TypeDescription{
 				Category: "struct",
 				Fields: []core.FieldDescription{
 					{
-						Name: "description",
-						Type: "string",
+						BaseFieldDescription: core.BaseFieldDescription{
+							Name: "description",
+							Type: "string",
+						},
 					},
 					{
-						Name: "input",
-						Type: "[]core.FieldDescription",
+						BaseFieldDescription: core.BaseFieldDescription{
+							Name: "input",
+							Type: "[]core.FieldDescription",
+						},
 					},
 					{
-						Name: "output",
-						Type: "[]core.FieldDescription",
+						BaseFieldDescription: core.BaseFieldDescription{
+							Name: "output",
+							Type: "[]core.BaseFieldDescription",
+						},
 					},
 				},
 			},
@@ -53,12 +78,22 @@ func TestMetadataDescribe(test *testing.T) {
 				Category: "struct",
 				Fields: []core.FieldDescription{
 					{
-						Name: "name",
-						Type: "string",
+						BaseFieldDescription: core.BaseFieldDescription{
+							Name: "name",
+							Type: "string",
+						},
 					},
 					{
-						Name: "type",
-						Type: "string",
+						BaseFieldDescription: core.BaseFieldDescription{
+							Name: "required",
+							Type: "bool",
+						},
+					},
+					{
+						BaseFieldDescription: core.BaseFieldDescription{
+							Name: "type",
+							Type: "string",
+						},
 					},
 				},
 			},
@@ -66,24 +101,34 @@ func TestMetadataDescribe(test *testing.T) {
 				Category: "struct",
 				Fields: []core.FieldDescription{
 					{
-						Name: "alias-type",
-						Type: "string",
+						BaseFieldDescription: core.BaseFieldDescription{
+							Name: "alias-type",
+							Type: "string",
+						},
 					},
 					{
-						Name: "category",
-						Type: "string",
+						BaseFieldDescription: core.BaseFieldDescription{
+							Name: "category",
+							Type: "string",
+						},
 					},
 					{
-						Name: "description",
-						Type: "string",
+						BaseFieldDescription: core.BaseFieldDescription{
+							Name: "description",
+							Type: "string",
+						},
 					},
 					{
-						Name: "element-type",
-						Type: "string",
+						BaseFieldDescription: core.BaseFieldDescription{
+							Name: "element-type",
+							Type: "string",
+						},
 					},
 					{
-						Name: "fields",
-						Type: "[]core.FieldDescription",
+						BaseFieldDescription: core.BaseFieldDescription{
+							Name: "fields",
+							Type: "[]core.FieldDescription",
+						},
 					},
 				},
 			},

--- a/internal/api/users/password/change.go
+++ b/internal/api/users/password/change.go
@@ -8,7 +8,7 @@ import (
 type PasswordChangeRequest struct {
 	core.APIRequestUserContext
 
-	NewPass string `json:"new-pass"`
+	NewPass string `json:"new-pass" required:""`
 }
 
 type PasswordChangeResponse struct {

--- a/internal/api/users/password/reset.go
+++ b/internal/api/users/password/reset.go
@@ -10,7 +10,7 @@ import (
 type PasswordResetRequest struct {
 	core.APIRequest
 
-	UserEmail core.NonEmptyString `json:"user-email"`
+	UserEmail core.NonEmptyString `json:"user-email" required:""`
 }
 
 type PasswordResetResponse struct{}

--- a/internal/api/users/remove.go
+++ b/internal/api/users/remove.go
@@ -9,7 +9,7 @@ type RemoveRequest struct {
 	core.APIRequestUserContext
 	core.MinServerRoleAdmin
 
-	TargetUser core.TargetServerUser `json:"target-email"`
+	TargetUser core.TargetServerUser `json:"target-email" required:""`
 }
 
 type RemoveResponse struct {

--- a/internal/api/users/tokens/delete.go
+++ b/internal/api/users/tokens/delete.go
@@ -8,7 +8,7 @@ import (
 type TokensDeleteRequest struct {
 	core.APIRequestUserContext
 
-	TokenID core.NonEmptyString `json:"token-id"`
+	TokenID core.NonEmptyString `json:"token-id" required:""`
 }
 
 type TokensDeleteResponse struct {

--- a/internal/email/message.go
+++ b/internal/email/message.go
@@ -10,11 +10,11 @@ import (
 )
 
 type Message struct {
-	To      []string `json:"to"`
+	To      []string `json:"to" required:""`
 	CC      []string `json:"cc"`
 	BCC     []string `json:"bcc"`
-	Subject string   `json:"subject"`
-	Body    string   `json:"body"`
+	Subject string   `json:"subject" required:""`
+	Body    string   `json:"body" required:""`
 	HTML    bool     `json:"html"`
 }
 

--- a/internal/procedures/users/upsert.go
+++ b/internal/procedures/users/upsert.go
@@ -13,7 +13,7 @@ import (
 // Upserting should only be done by server or course admins,
 // it should not be used for self creation.
 type UpsertUsersOptions struct {
-	RawUsers []*model.RawServerUserData `json:"raw-users"`
+	RawUsers []*model.RawServerUserData `json:"raw-users" required:""`
 
 	SkipInserts bool `json:"skip-inserts"`
 	SkipUpdates bool `json:"skip-updates"`

--- a/internal/stats/query.go
+++ b/internal/stats/query.go
@@ -35,7 +35,7 @@ type Query struct {
 
 	// Only return data of this type.
 	// This field is required in the query to specify which kind of metric to return.
-	Type MetricType `json:"type"`
+	Type MetricType `json:"type" required:""`
 }
 
 func (this *Query) Validate() error {

--- a/resources/api.json
+++ b/resources/api.json
@@ -11,7 +11,7 @@
                 {
                     "name": "body",
                     "type": "string",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "cc",
@@ -36,12 +36,12 @@
                 {
                     "name": "subject",
                     "type": "string",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "to",
                     "type": "[]string",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "user-email",
@@ -168,7 +168,7 @@
                 {
                     "name": "submissions",
                     "type": "[]string",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "user-email",
@@ -225,7 +225,7 @@
                 {
                     "name": "submissions",
                     "type": "[]string",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "user-email",
@@ -532,7 +532,7 @@
                 {
                     "name": "proxy-email",
                     "type": "core.TargetCourseUser",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "proxy-time",
@@ -603,7 +603,7 @@
                 {
                     "name": "proxy-email",
                     "type": "core.TargetCourseUser",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "proxy-time",
@@ -808,7 +808,7 @@
                 {
                     "name": "type",
                     "type": "string",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "user-email",
@@ -844,7 +844,7 @@
                 {
                     "name": "filespec",
                     "type": "util.FileSpec",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "skip-build-images",
@@ -951,7 +951,7 @@
                 {
                     "name": "target-email",
                     "type": "core.TargetCourseUser",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "user-email",
@@ -987,7 +987,7 @@
                 {
                     "name": "raw-course-users",
                     "type": "[]*model.RawCourseUserData",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "send-emails",
@@ -1089,7 +1089,7 @@
                 {
                     "name": "assignment-lms-id",
                     "type": "string",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "course-id",
@@ -1099,7 +1099,7 @@
                 {
                     "name": "scores",
                     "type": "[]upload.ScoreEntry",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "user-email",
@@ -1142,7 +1142,7 @@
                 {
                     "name": "target-email",
                     "type": "core.TargetCourseUser",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "user-email",
@@ -1285,7 +1285,7 @@
                 {
                     "name": "type",
                     "type": "string",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "user-email",
@@ -1417,7 +1417,7 @@
                 {
                     "name": "new-pass",
                     "type": "string",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "user-email",
@@ -1447,7 +1447,7 @@
                 {
                     "name": "user-email",
                     "type": "string",
-                    "required": false
+                    "required": true
                 }
             ],
             "output": []
@@ -1458,7 +1458,7 @@
                 {
                     "name": "target-email",
                     "type": "core.TargetServerUser",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "user-email",
@@ -1514,7 +1514,7 @@
                 {
                     "name": "token-id",
                     "type": "string",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "user-email",
@@ -1545,7 +1545,7 @@
                 {
                     "name": "raw-users",
                     "type": "[]*model.RawServerUserData",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "send-emails",
@@ -1598,7 +1598,7 @@
                 {
                     "name": "submissions",
                     "type": "[]string",
-                    "required": false
+                    "required": true
                 },
                 {
                     "name": "wait-for-completion",

--- a/resources/api.json
+++ b/resources/api.json
@@ -5,43 +5,53 @@
             "input": [
                 {
                     "name": "bcc",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "required": false
                 },
                 {
                     "name": "body",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "cc",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "required": false
                 },
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "dry-run",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "html",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "subject",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "to",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -64,15 +74,18 @@
             "input": [
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -87,19 +100,23 @@
             "input": [
                 {
                     "name": "assignment-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -114,15 +131,18 @@
             "input": [
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -137,27 +157,33 @@
             "input": [
                 {
                     "name": "dry-run",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "overwrite-records",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "submissions",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "wait-for-completion",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 }
             ],
             "output": [
@@ -188,27 +214,33 @@
             "input": [
                 {
                     "name": "dry-run",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "overwrite-records",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "submissions",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "wait-for-completion",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 }
             ],
             "output": [
@@ -239,23 +271,28 @@
             "input": [
                 {
                     "name": "assignment-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "filter-role",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -270,23 +307,28 @@
             "input": [
                 {
                     "name": "assignment-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "filter-role",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -301,27 +343,33 @@
             "input": [
                 {
                     "name": "assignment-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUserSelfOrGrader"
+                    "type": "core.TargetCourseUserSelfOrGrader",
+                    "required": false
                 },
                 {
                     "name": "target-submission",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -344,23 +392,28 @@
             "input": [
                 {
                     "name": "assignment-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUserSelfOrGrader"
+                    "type": "core.TargetCourseUserSelfOrGrader",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -379,23 +432,28 @@
             "input": [
                 {
                     "name": "assignment-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUserSelfOrGrader"
+                    "type": "core.TargetCourseUserSelfOrGrader",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -414,27 +472,33 @@
             "input": [
                 {
                     "name": "assignment-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUserSelfOrGrader"
+                    "type": "core.TargetCourseUserSelfOrGrader",
+                    "required": false
                 },
                 {
                     "name": "target-submission",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -457,31 +521,38 @@
             "input": [
                 {
                     "name": "assignment-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "proxy-email",
-                    "type": "core.TargetCourseUser"
+                    "type": "core.TargetCourseUser",
+                    "required": false
                 },
                 {
                     "name": "proxy-time",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "target-submission",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -516,31 +587,38 @@
             "input": [
                 {
                     "name": "assignment-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "message",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "proxy-email",
-                    "type": "core.TargetCourseUser"
+                    "type": "core.TargetCourseUser",
+                    "required": false
                 },
                 {
                     "name": "proxy-time",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -571,27 +649,33 @@
             "input": [
                 {
                     "name": "assignment-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUserSelfOrGrader"
+                    "type": "core.TargetCourseUserSelfOrGrader",
+                    "required": false
                 },
                 {
                     "name": "target-submission",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -610,27 +694,33 @@
             "input": [
                 {
                     "name": "allow-late",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "assignment-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "message",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -657,19 +747,23 @@
             "input": [
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "dry-run",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -688,39 +782,48 @@
             "input": [
                 {
                     "name": "after",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "before",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "limit",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "sort",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "type",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "where",
-                    "type": "map[stats.MetricAttribute]interface {}"
+                    "type": "map[stats.MetricAttribute]interface {}",
+                    "required": false
                 }
             ],
             "output": [
@@ -735,39 +838,48 @@
             "input": [
                 {
                     "name": "dry-run",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "filespec",
-                    "type": "util.FileSpec"
+                    "type": "util.FileSpec",
+                    "required": false
                 },
                 {
                     "name": "skip-build-images",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "skip-emails",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "skip-lms-sync",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "skip-source-sync",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "skip-template-files",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -782,35 +894,43 @@
             "input": [
                 {
                     "name": "dry-run",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "skip-build-images",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "skip-emails",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "skip-lms-sync",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "skip-source-sync",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "skip-template-files",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -825,19 +945,23 @@
             "input": [
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUser"
+                    "type": "core.TargetCourseUser",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -852,35 +976,43 @@
             "input": [
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "dry-run",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "raw-course-users",
-                    "type": "[]*model.RawCourseUserData"
+                    "type": "[]*model.RawCourseUserData",
+                    "required": false
                 },
                 {
                     "name": "send-emails",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "skip-inserts",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "skip-updates",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -895,19 +1027,23 @@
             "input": [
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUserSelfOrGrader"
+                    "type": "core.TargetCourseUserSelfOrGrader",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -926,15 +1062,18 @@
             "input": [
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -949,23 +1088,28 @@
             "input": [
                 {
                     "name": "assignment-lms-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "scores",
-                    "type": "[]upload.ScoreEntry"
+                    "type": "[]upload.ScoreEntry",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -992,19 +1136,23 @@
             "input": [
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUser"
+                    "type": "core.TargetCourseUser",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -1027,35 +1175,43 @@
             "input": [
                 {
                     "name": "after",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "level",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "past",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "target-assignment",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "target-course",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "target-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -1078,7 +1234,8 @@
             "input": [
                 {
                     "name": "force-compute",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 }
             ],
             "output": [
@@ -1107,35 +1264,43 @@
             "input": [
                 {
                     "name": "after",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "before",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "limit",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "sort",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "type",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "where",
-                    "type": "map[stats.MetricAttribute]interface {}"
+                    "type": "map[stats.MetricAttribute]interface {}",
+                    "required": false
                 }
             ],
             "output": [
@@ -1150,11 +1315,13 @@
             "input": [
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -1173,11 +1340,13 @@
             "input": [
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -1192,15 +1361,18 @@
             "input": [
                 {
                     "name": "target-email",
-                    "type": "core.TargetServerUserSelfOrAdmin"
+                    "type": "core.TargetServerUserSelfOrAdmin",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -1223,11 +1395,13 @@
             "input": [
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -1242,15 +1416,18 @@
             "input": [
                 {
                     "name": "new-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -1269,7 +1446,8 @@
             "input": [
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ],
             "output": []
@@ -1279,15 +1457,18 @@
             "input": [
                 {
                     "name": "target-email",
-                    "type": "core.TargetServerUser"
+                    "type": "core.TargetServerUser",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -1302,15 +1483,18 @@
             "input": [
                 {
                     "name": "name",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -1329,15 +1513,18 @@
             "input": [
                 {
                     "name": "token-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -1352,31 +1539,38 @@
             "input": [
                 {
                     "name": "dry-run",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "raw-users",
-                    "type": "[]*model.RawServerUserData"
+                    "type": "[]*model.RawServerUserData",
+                    "required": false
                 },
                 {
                     "name": "send-emails",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "skip-inserts",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "skip-updates",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "user-pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 }
             ],
             "output": [
@@ -1393,19 +1587,23 @@
             "fields": [
                 {
                     "name": "dry-run",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "overwrite-records",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "submissions",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "required": false
                 },
                 {
                     "name": "wait-for-completion",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 }
             ]
         },
@@ -1414,19 +1612,38 @@
             "fields": [
                 {
                     "name": "due-date",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "max-points",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 },
                 {
                     "name": "name",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
+                }
+            ]
+        },
+        "core.BaseFieldDescription": {
+            "category": "struct",
+            "fields": [
+                {
+                    "name": "name",
+                    "type": "string",
+                    "required": false
+                },
+                {
+                    "name": "type",
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -1435,15 +1652,18 @@
             "fields": [
                 {
                     "name": "assignments",
-                    "type": "map[string]*core.AssignmentInfo"
+                    "type": "map[string]*core.AssignmentInfo",
+                    "required": false
                 },
                 {
                     "name": "id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "name",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -1453,23 +1673,28 @@
             "fields": [
                 {
                     "name": "email",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "lms-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "name",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "role",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "type",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -1478,15 +1703,18 @@
             "fields": [
                 {
                     "name": "description",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "input",
-                    "type": "[]core.FieldDescription"
+                    "type": "[]core.FieldDescription",
+                    "required": false
                 },
                 {
                     "name": "output",
-                    "type": "[]core.FieldDescription"
+                    "type": "[]core.BaseFieldDescription",
+                    "required": false
                 }
             ]
         },
@@ -1496,11 +1724,13 @@
             "fields": [
                 {
                     "name": "id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "role",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 }
             ]
         },
@@ -1509,11 +1739,18 @@
             "fields": [
                 {
                     "name": "name",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
+                },
+                {
+                    "name": "required",
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "type",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -1527,23 +1764,28 @@
             "fields": [
                 {
                     "name": "courses",
-                    "type": "map[string]core.EnrollmentInfo"
+                    "type": "map[string]core.EnrollmentInfo",
+                    "required": false
                 },
                 {
                     "name": "email",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "name",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "role",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "type",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -1557,7 +1799,8 @@
             "fields": [
                 {
                     "name": "TargetCourseUser",
-                    "type": "core.TargetCourseUser"
+                    "type": "core.TargetCourseUser",
+                    "required": false
                 }
             ]
         },
@@ -1571,7 +1814,8 @@
             "fields": [
                 {
                     "name": "TargetServerUser",
-                    "type": "core.TargetServerUser"
+                    "type": "core.TargetServerUser",
+                    "required": false
                 }
             ]
         },
@@ -1580,23 +1824,28 @@
             "fields": [
                 {
                     "name": "alias-type",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "category",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "description",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "element-type",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "fields",
-                    "type": "[]core.FieldDescription"
+                    "type": "[]core.FieldDescription",
+                    "required": false
                 }
             ]
         },
@@ -1609,35 +1858,43 @@
             "fields": [
                 {
                     "name": "assignment-template-files",
-                    "type": "map[string][]string"
+                    "type": "map[string][]string",
+                    "required": false
                 },
                 {
                     "name": "built-assignment-images",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "required": false
                 },
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "created",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "lms-sync-result",
-                    "type": "*model.LMSSyncResult"
+                    "type": "*model.LMSSyncResult",
+                    "required": false
                 },
                 {
                     "name": "message",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "success",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "updated",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 }
             ]
         },
@@ -1650,35 +1907,43 @@
             "fields": [
                 {
                     "name": "assignment",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "attributes",
-                    "type": "map[string]interface {}"
+                    "type": "map[string]interface {}",
+                    "required": false
                 },
                 {
                     "name": "course",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "error",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "level",
-                    "type": "int32"
+                    "type": "int32",
+                    "required": false
                 },
                 {
                     "name": "message",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "timestamp",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "user",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -1687,15 +1952,18 @@
             "fields": [
                 {
                     "name": "filename",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "lines-of-code",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "original-filename",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -1704,19 +1972,23 @@
             "fields": [
                 {
                     "name": "exclude-patterns",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "required": false
                 },
                 {
                     "name": "include-patterns",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "required": false
                 },
                 {
                     "name": "template-file-ops",
-                    "type": "[]*util.FileOperation"
+                    "type": "[]*util.FileOperation",
+                    "required": false
                 },
                 {
                     "name": "template-files",
-                    "type": "[]*util.FileSpec"
+                    "type": "[]*util.FileSpec",
+                    "required": false
                 }
             ]
         },
@@ -1725,19 +1997,23 @@
             "fields": [
                 {
                     "name": "id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "late-days-lms-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "late-days-lms-name",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "name",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -1746,19 +2022,23 @@
             "fields": [
                 {
                     "name": "ambiguous-matches",
-                    "type": "[]model.AssignmentInfo"
+                    "type": "[]model.AssignmentInfo",
+                    "required": false
                 },
                 {
                     "name": "non-matched-assignments",
-                    "type": "[]model.AssignmentInfo"
+                    "type": "[]model.AssignmentInfo",
+                    "required": false
                 },
                 {
                     "name": "synced-assignments",
-                    "type": "[]model.AssignmentInfo"
+                    "type": "[]model.AssignmentInfo",
+                    "required": false
                 },
                 {
                     "name": "unchanged-assignments",
-                    "type": "[]model.AssignmentInfo"
+                    "type": "[]model.AssignmentInfo",
+                    "required": false
                 }
             ]
         },
@@ -1772,11 +2052,13 @@
             "fields": [
                 {
                     "name": "locator",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "message",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -1786,31 +2068,38 @@
             "fields": [
                 {
                     "name": "assignment",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "raw-score",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 },
                 {
                     "name": "score",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 },
                 {
                     "name": "submission-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "submission-time",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "upload-time",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "user",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -1820,51 +2109,63 @@
             "fields": [
                 {
                     "name": "added",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "communication-error",
-                    "type": "*model.ExternalLocatableError"
+                    "type": "*model.ExternalLocatableError",
+                    "required": false
                 },
                 {
                     "name": "dropped",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "required": false
                 },
                 {
                     "name": "email",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "emailed",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "enrolled",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "required": false
                 },
                 {
                     "name": "modified",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "not-exists",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "removed",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "skipped",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "system-error",
-                    "type": "*model.ExternalLocatableError"
+                    "type": "*model.ExternalLocatableError",
+                    "required": false
                 },
                 {
                     "name": "validation-error",
-                    "type": "*model.ExternalLocatableError"
+                    "type": "*model.ExternalLocatableError",
+                    "required": false
                 }
             ]
         },
@@ -1873,27 +2174,33 @@
             "fields": [
                 {
                     "name": "filename",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "options",
-                    "type": "map[string]interface {}"
+                    "type": "map[string]interface {}",
+                    "required": false
                 },
                 {
                     "name": "original-filename",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "score",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 },
                 {
                     "name": "tool",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "version",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -1902,35 +2209,43 @@
             "fields": [
                 {
                     "name": "grading_end_time",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "grading_start_time",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "hard_fail",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "max_points",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 },
                 {
                     "name": "message",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "name",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "score",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 },
                 {
                     "name": "skipped",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 }
             ]
         },
@@ -1939,75 +2254,93 @@
             "fields": [
                 {
                     "name": "additional-info",
-                    "type": "map[string]interface {}"
+                    "type": "map[string]interface {}",
+                    "required": false
                 },
                 {
                     "name": "assignment-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "epilogue",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "grading_end_time",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "grading_start_time",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "max_points",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 },
                 {
                     "name": "message",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "name",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "prologue",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "proxy-user",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "proxy_end_time",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "proxy_start_time",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "questions",
-                    "type": "[]*model.GradedQuestion"
+                    "type": "[]*model.GradedQuestion",
+                    "required": false
                 },
                 {
                     "name": "score",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 },
                 {
                     "name": "short-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "user",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -2016,23 +2349,28 @@
             "fields": [
                 {
                     "name": "info",
-                    "type": "*model.GradingInfo"
+                    "type": "*model.GradingInfo",
+                    "required": false
                 },
                 {
                     "name": "input-files-gzip",
-                    "type": "map[string][]uint8"
+                    "type": "map[string][]uint8",
+                    "required": false
                 },
                 {
                     "name": "output-files-gzip",
-                    "type": "map[string][]uint8"
+                    "type": "map[string][]uint8",
+                    "required": false
                 },
                 {
                     "name": "stderr",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "stdout",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -2041,79 +2379,98 @@
             "fields": [
                 {
                     "name": "analysis-timestamp",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "assignment-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "failure",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "failure-message",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "files",
-                    "type": "[]model.AnalysisFileInfo"
+                    "type": "[]model.AnalysisFileInfo",
+                    "required": false
                 },
                 {
                     "name": "lines-of-code",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "lines-of-code-delta",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "lines-of-code-per-hour",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 },
                 {
                     "name": "options",
-                    "type": "*model.AssignmentAnalysisOptions"
+                    "type": "*model.AssignmentAnalysisOptions",
+                    "required": false
                 },
                 {
                     "name": "score",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 },
                 {
                     "name": "score-delta",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 },
                 {
                     "name": "score-per-hour",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 },
                 {
                     "name": "short-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "skipped-files",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "required": false
                 },
                 {
                     "name": "submission-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "submission-start-time",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "submission-time-delta",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "user-email",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -2122,63 +2479,78 @@
             "fields": [
                 {
                     "name": "aggregate-lines-of-code",
-                    "type": "util.AggregateValues"
+                    "type": "util.AggregateValues",
+                    "required": false
                 },
                 {
                     "name": "aggregate-lines-of-code-delta",
-                    "type": "util.AggregateValues"
+                    "type": "util.AggregateValues",
+                    "required": false
                 },
                 {
                     "name": "aggregate-lines-of-code-per-file",
-                    "type": "map[string]util.AggregateValues"
+                    "type": "map[string]util.AggregateValues",
+                    "required": false
                 },
                 {
                     "name": "aggregate-lines-of-code-per-hour",
-                    "type": "util.AggregateValues"
+                    "type": "util.AggregateValues",
+                    "required": false
                 },
                 {
                     "name": "aggregate-score",
-                    "type": "util.AggregateValues"
+                    "type": "util.AggregateValues",
+                    "required": false
                 },
                 {
                     "name": "aggregate-score-delta",
-                    "type": "util.AggregateValues"
+                    "type": "util.AggregateValues",
+                    "required": false
                 },
                 {
                     "name": "aggregate-score-per-hour",
-                    "type": "util.AggregateValues"
+                    "type": "util.AggregateValues",
+                    "required": false
                 },
                 {
                     "name": "aggregate-submission-time-delta",
-                    "type": "util.AggregateValues"
+                    "type": "util.AggregateValues",
+                    "required": false
                 },
                 {
                     "name": "complete",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "complete-count",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "error-count",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "failure-count",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "first-timestamp",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "last-timestamp",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "pending-count",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 }
             ]
         },
@@ -2187,11 +2559,13 @@
             "fields": [
                 {
                     "name": "assignment-sync",
-                    "type": "*model.AssignmentSyncResult"
+                    "type": "*model.AssignmentSyncResult",
+                    "required": false
                 },
                 {
                     "name": "user-sync",
-                    "type": "[]*model.UserOpResult"
+                    "type": "[]*model.UserOpResult",
+                    "required": false
                 }
             ]
         },
@@ -2204,43 +2578,53 @@
             "fields": [
                 {
                     "name": "analysis-timestamp",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "failure",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "failure-message",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "mean-similarities",
-                    "type": "map[string]float64"
+                    "type": "map[string]float64",
+                    "required": false
                 },
                 {
                     "name": "options",
-                    "type": "*model.AssignmentAnalysisOptions"
+                    "type": "*model.AssignmentAnalysisOptions",
+                    "required": false
                 },
                 {
                     "name": "similarities",
-                    "type": "map[string][]*model.FileSimilarity"
+                    "type": "map[string][]*model.FileSimilarity",
+                    "required": false
                 },
                 {
                     "name": "skipped-files",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "required": false
                 },
                 {
                     "name": "submission-ids",
-                    "type": "model.PairwiseKey"
+                    "type": "model.PairwiseKey",
+                    "required": false
                 },
                 {
                     "name": "total-mean-similarity",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 },
                 {
                     "name": "unmatched-files",
-                    "type": "[][]string"
+                    "type": "[][]string",
+                    "required": false
                 }
             ]
         },
@@ -2249,39 +2633,48 @@
             "fields": [
                 {
                     "name": "aggregate-mean-similarities",
-                    "type": "map[string]util.AggregateValues"
+                    "type": "map[string]util.AggregateValues",
+                    "required": false
                 },
                 {
                     "name": "aggregate-total-mean-similarity",
-                    "type": "util.AggregateValues"
+                    "type": "util.AggregateValues",
+                    "required": false
                 },
                 {
                     "name": "complete",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "complete-count",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "error-count",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "failure-count",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "first-timestamp",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "last-timestamp",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "pending-count",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 }
             ]
         },
@@ -2295,19 +2688,23 @@
             "fields": [
                 {
                     "name": "course-lms-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "course-role",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "email",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "name",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -2317,31 +2714,38 @@
             "fields": [
                 {
                     "name": "course",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "course-lms-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "course-role",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "email",
-                    "type": "string"
+                    "type": "string",
+                    "required": true
                 },
                 {
                     "name": "name",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "pass",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "role",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -2354,39 +2758,48 @@
             "fields": [
                 {
                     "name": "assignment-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "course-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "grading_start_time",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "max_points",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 },
                 {
                     "name": "message",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "score",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 },
                 {
                     "name": "short-id",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "user",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -2396,55 +2809,68 @@
             "fields": [
                 {
                     "name": "added",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "cleartext-password",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "communication-error",
-                    "type": "*model.LocatableError"
+                    "type": "*model.LocatableError",
+                    "required": false
                 },
                 {
                     "name": "dropped",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "required": false
                 },
                 {
                     "name": "email",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "emailed",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "enrolled",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "required": false
                 },
                 {
                     "name": "modified",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "not-exists",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "removed",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "skipped",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 },
                 {
                     "name": "system-error",
-                    "type": "*model.LocatableError"
+                    "type": "*model.LocatableError",
+                    "required": false
                 },
                 {
                     "name": "validation-error",
-                    "type": "*model.LocatableError"
+                    "type": "*model.LocatableError",
+                    "required": false
                 }
             ]
         },
@@ -2453,19 +2879,23 @@
             "fields": [
                 {
                     "name": "attributes",
-                    "type": "map[stats.MetricAttribute]interface {}"
+                    "type": "map[stats.MetricAttribute]interface {}",
+                    "required": false
                 },
                 {
                     "name": "timestamp",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": false
                 },
                 {
                     "name": "type",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "value",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 }
             ]
         },
@@ -2486,11 +2916,13 @@
             "fields": [
                 {
                     "name": "entry",
-                    "type": "interface {}"
+                    "type": "interface {}",
+                    "required": false
                 },
                 {
                     "name": "row",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 }
             ]
         },
@@ -2499,11 +2931,13 @@
             "fields": [
                 {
                     "name": "email",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "score",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 }
             ]
         },
@@ -2512,23 +2946,28 @@
             "fields": [
                 {
                     "name": "count",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "max",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 },
                 {
                     "name": "mean",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 },
                 {
                     "name": "median",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 },
                 {
                     "name": "min",
-                    "type": "float64"
+                    "type": "float64",
+                    "required": false
                 }
             ]
         },
@@ -2537,15 +2976,18 @@
             "fields": [
                 {
                     "name": "name",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "records",
-                    "type": "[]util.CallStackRecord"
+                    "type": "[]util.CallStackRecord",
+                    "required": false
                 },
                 {
                     "name": "status",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -2554,19 +2996,23 @@
             "fields": [
                 {
                     "name": "call",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "file",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "line",
-                    "type": "int"
+                    "type": "int",
+                    "required": false
                 },
                 {
                     "name": "pointer",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -2579,27 +3025,33 @@
             "fields": [
                 {
                     "name": "dest",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "path",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "reference",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "token",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "type",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "username",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 }
             ]
         },
@@ -2612,15 +3064,18 @@
             "fields": [
                 {
                     "name": "base-version",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "git-hash",
-                    "type": "string"
+                    "type": "string",
+                    "required": false
                 },
                 {
                     "name": "is-dirty",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": false
                 }
             ]
         }


### PR DESCRIPTION
This PR adds required fields to API input fields in the automatically generated API description.

By adding the field `required` to the appropriate input fields, interfaces that call the `autograder-server` can pre-validate API requests.

This information is parsed from the source code by looking for a `required` field tag. The value of the tag is ignored, so it should be left empty. The pre-validation of API endpoints will be strengthened by the addition of the default value field, which will come in a future PR.