### PR TITLE
Properly captured the type description of non-stuct types in the API description.

### DIFF
--- a/internal/api/core/describe.go
+++ b/internal/api/core/describe.go
@@ -360,7 +360,7 @@ func DescribeType(customType reflect.Type, addType bool, info TypeInfoCache) (Fu
 		typeDescription.ValueType = elemTypeID
 	case reflect.Struct:
 		typeDescription.Category = StructType
-		typeDescription.Fields, err = getFieldDescriptions(customType, info)
+		typeDescription.Fields, err = describeStructFields(customType, info)
 		if err != nil {
 			return FullTypeDescription{}, "", TypeInfoCache{}, err
 		}
@@ -382,7 +382,7 @@ func DescribeType(customType reflect.Type, addType bool, info TypeInfoCache) (Fu
 	return typeDescription, originalTypeID, info, nil
 }
 
-func getFieldDescriptions(customType reflect.Type, info TypeInfoCache) ([]FieldDescription, error) {
+func describeStructFields(customType reflect.Type, info TypeInfoCache) ([]FieldDescription, error) {
 	fieldDescriptions := make([]FieldDescription, 0)
 
 	fieldNameDescriptions, err := util.GetFieldDescriptionsFromType(customType)

--- a/internal/api/core/describe_test.go
+++ b/internal/api/core/describe_test.go
@@ -9,8 +9,13 @@ import (
 	"github.com/edulinq/autograder/internal/util"
 )
 
+// This is a simple alias for the string type.
 type stringWrapper string
+
+// A named map type.
 type simpleMapWrapper map[string]int
+
+// Wrapping a list in a named type!
 type simpleArrayWrapper []bool
 
 type simplePointerWrapper *string
@@ -147,15 +152,17 @@ func TestDescribeTypeBase(test *testing.T) {
 			reflect.TypeOf((*stringWrapper)(nil)).Elem(),
 			FullTypeDescription{
 				BaseTypeDescription: BaseTypeDescription{
-					Category:  AliasType,
-					AliasType: "string",
+					Description: "This is a simple alias for the string type.",
+					Category:    AliasType,
+					AliasType:   "string",
 				},
 			},
 			map[string]FullTypeDescription{
 				mustGetTypeID(reflect.TypeOf((*stringWrapper)(nil)).Elem(), nil): FullTypeDescription{
 					BaseTypeDescription: BaseTypeDescription{
-						Category:  AliasType,
-						AliasType: "string",
+						Description: "This is a simple alias for the string type.",
+						Category:    AliasType,
+						AliasType:   "string",
 					},
 				},
 			},
@@ -210,17 +217,19 @@ func TestDescribeTypeBase(test *testing.T) {
 			reflect.TypeOf((*simpleMapWrapper)(nil)).Elem(),
 			FullTypeDescription{
 				BaseTypeDescription: BaseTypeDescription{
-					Category:  MapType,
-					KeyType:   "string",
-					ValueType: "int",
+					Description: "A named map type.",
+					Category:    MapType,
+					KeyType:     "string",
+					ValueType:   "int",
 				},
 			},
 			map[string]FullTypeDescription{
 				mustGetTypeID(reflect.TypeOf((*simpleMapWrapper)(nil)).Elem(), nil): FullTypeDescription{
 					BaseTypeDescription: BaseTypeDescription{
-						Category:  MapType,
-						KeyType:   "string",
-						ValueType: "int",
+						Description: "A named map type.",
+						Category:    MapType,
+						KeyType:     "string",
+						ValueType:   "int",
 					},
 				},
 			},
@@ -230,6 +239,7 @@ func TestDescribeTypeBase(test *testing.T) {
 			reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(),
 			FullTypeDescription{
 				BaseTypeDescription: BaseTypeDescription{
+					Description: "Wrapping a list in a named type!",
 					Category:    ArrayType,
 					ElementType: "bool",
 				},
@@ -237,6 +247,7 @@ func TestDescribeTypeBase(test *testing.T) {
 			map[string]FullTypeDescription{
 				mustGetTypeID(reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(), nil): FullTypeDescription{
 					BaseTypeDescription: BaseTypeDescription{
+						Description: "Wrapping a list in a named type!",
 						Category:    ArrayType,
 						ElementType: "bool",
 					},
@@ -565,15 +576,17 @@ func TestDescribeTypeBase(test *testing.T) {
 				},
 				mustGetTypeID(reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(), nil): FullTypeDescription{
 					BaseTypeDescription: BaseTypeDescription{
+						Description: "Wrapping a list in a named type!",
 						Category:    ArrayType,
 						ElementType: "bool",
 					},
 				},
 				mustGetTypeID(reflect.TypeOf((*simpleMapWrapper)(nil)).Elem(), nil): FullTypeDescription{
 					BaseTypeDescription: BaseTypeDescription{
-						Category:  MapType,
-						KeyType:   "string",
-						ValueType: "int",
+						Description: "A named map type.",
+						Category:    MapType,
+						KeyType:     "string",
+						ValueType:   "int",
 					},
 				},
 			},
@@ -716,15 +729,17 @@ func TestDescribeTypeBase(test *testing.T) {
 				},
 				mustGetTypeID(reflect.TypeOf((*simpleArrayWrapper)(nil)).Elem(), nil): FullTypeDescription{
 					BaseTypeDescription: BaseTypeDescription{
+						Description: "Wrapping a list in a named type!",
 						Category:    ArrayType,
 						ElementType: "bool",
 					},
 				},
 				mustGetTypeID(reflect.TypeOf((*simpleMapWrapper)(nil)).Elem(), nil): FullTypeDescription{
 					BaseTypeDescription: BaseTypeDescription{
-						Category:  MapType,
-						KeyType:   "string",
-						ValueType: "int",
+						Description: "A named map type.",
+						Category:    MapType,
+						KeyType:     "string",
+						ValueType:   "int",
 					},
 				},
 			},

--- a/resources/api.json
+++ b/resources/api.json
@@ -1814,6 +1814,7 @@
         },
         "core.NonEmptyString": {
             "category": "alias",
+            "description": "The type for a named field that must have a non-empty string value.",
             "alias-type": "string"
         },
         "core.ServerUserInfo": {
@@ -2062,10 +2063,12 @@
         },
         "model.CourseUserReference": {
             "category": "alias",
+            "description": "Course user references can represent the following:\n- An email address.\n- A literal \"*\" (which includes all users in the course).\n- A course role (which will include all course users with that role).\n- Any of the above options preceded by a dash (\"-\") (which indicates that the user or group will NOT be included in the final results).",
             "alias-type": "string"
         },
         "model.CourseUserRole": {
             "category": "alias",
+            "description": "Course user roles represent a user's role within a single course.",
             "alias-type": "int"
         },
         "model.ExternalLocatableError": {
@@ -2601,6 +2604,7 @@
         },
         "model.PairwiseKey": {
             "category": "array",
+            "description": "A key for pairwise analysis.\nShould always be an ordered (lexicographically) pair of full submissions IDs.",
             "element-type": "string"
         },
         "model.RawCourseUserData": {
@@ -2661,10 +2665,12 @@
         },
         "model.ServerUserReference": {
             "category": "alias",
+            "description": "Server user references can represent the following:\n- An email address.\n- A literal \"*\" (which includes all users on the server).\n- A server role (which will include all server users with that role).\n- \u003ccourse-id\u003e::\u003ccourse-role\u003e (which will include all users in the target course with that role).\n- *::\u003ccourse-role\u003e (which will include all users with the course role in any course).\n- \u003ccourse-id\u003e::* (which will include all users in the target course).\n- *::* (which includes all users enrolled in at least one course).\n- Any of the above options preceded by a dash (\"-\") (which indicates that the user or group will NOT be included in the final results).",
             "alias-type": "string"
         },
         "model.ServerUserRole": {
             "category": "alias",
+            "description": "Server user roles represent a user's role within an autograder server instance.",
             "alias-type": "int"
         },
         "model.SubmissionHistoryItem": {
@@ -2811,6 +2817,7 @@
         },
         "timestamp.Timestamp": {
             "category": "alias",
+            "description": "A safe (always valid) time representation.\nA timestamp is the number of milliseconds (int64) since the UNIX epoch (which is in UTC).",
             "alias-type": "int64"
         },
         "upload.RowEntry": {
@@ -2904,6 +2911,7 @@
         },
         "util.FileOperation": {
             "category": "array",
+            "description": "File operations represent simple file operations.\nAny represented file paths must be POSIX, relative, and not point to any parent directories.\nNote that this code will only work properly on POSIX systems because of the lexical analysis on paths.",
             "element-type": "string"
         },
         "util.FileSpec": {


### PR DESCRIPTION
This PR fixes an issue where type descriptions of non-struct types (alias types, named list / slice types, and named map types) would not be included in the API description.

These changes allow better documentation of our types, which improve the usability of the API documentation for outside users.