### PR TITLE
Added an API endpoint to make proxy regrades.

### DIFF
--- a/internal/analysis/individual.go
+++ b/internal/analysis/individual.go
@@ -73,7 +73,6 @@ func IndividualAnalysis(options AnalysisOptions) (map[string]*model.IndividualAn
 	}
 
 	workErrors := make(map[string]string, len(output.WorkErrors))
-
 	for fullSubmissionID, err := range output.WorkErrors {
 		workErrors[fullSubmissionID] = err.Error()
 

--- a/internal/analysis/individual.go
+++ b/internal/analysis/individual.go
@@ -74,15 +74,13 @@ func IndividualAnalysis(options AnalysisOptions) (map[string]*model.IndividualAn
 
 	workErrors := make(map[string]string, len(output.WorkErrors))
 
-	if len(output.WorkErrors) != 0 {
-		for fullSubmissionID, err := range output.WorkErrors {
-			workErrors[fullSubmissionID] = err.Error()
+	for fullSubmissionID, err := range output.WorkErrors {
+		workErrors[fullSubmissionID] = err.Error()
 
-			logAttributes := submissionIDToLogValues(fullSubmissionID)
-			logAttributes = append([]any{err}, logAttributes...)
-			logAttributes = append(logAttributes, log.NewAttr("job-id", output.ID))
-			log.Error("Failed to run individual analysis.", logAttributes...)
-		}
+		logAttributes := submissionIDToLogValues(fullSubmissionID)
+		logAttributes = append([]any{err}, logAttributes...)
+		logAttributes = append(logAttributes, log.NewAttr("job-id", output.ID))
+		log.Error("Failed to run individual analysis.", logAttributes...)
 	}
 
 	return output.ResultItems, len(output.RemainingItems), workErrors, nil

--- a/internal/analysis/pairwise.go
+++ b/internal/analysis/pairwise.go
@@ -105,7 +105,6 @@ func PairwiseAnalysis(options AnalysisOptions) (map[model.PairwiseKey]*model.Pai
 	}
 
 	workErrors := make(map[string]string, len(output.WorkErrors))
-
 	for pairwiseKey, err := range output.WorkErrors {
 		workErrors[pairwiseKey.String()] = err.Error()
 

--- a/internal/analysis/pairwise.go
+++ b/internal/analysis/pairwise.go
@@ -106,12 +106,10 @@ func PairwiseAnalysis(options AnalysisOptions) (map[model.PairwiseKey]*model.Pai
 
 	workErrors := make(map[string]string, len(output.WorkErrors))
 
-	if len(output.WorkErrors) != 0 {
-		for pairwiseKey, err := range output.WorkErrors {
-			workErrors[pairwiseKey.String()] = err.Error()
+	for pairwiseKey, err := range output.WorkErrors {
+		workErrors[pairwiseKey.String()] = err.Error()
 
-			log.Error("Failed to run pairwise analysis.", err, pairwiseKey, log.NewAttr("job-id", output.ID))
-		}
+		log.Error("Failed to run pairwise analysis.", err, pairwiseKey, log.NewAttr("job-id", output.ID))
 	}
 
 	return output.ResultItems, len(output.RemainingItems), workErrors, nil

--- a/internal/api/courses/assignments/submissions/proxy/regrade.go
+++ b/internal/api/courses/assignments/submissions/proxy/regrade.go
@@ -1,0 +1,50 @@
+package proxy
+
+import (
+	"github.com/edulinq/autograder/internal/api/core"
+	"github.com/edulinq/autograder/internal/grader"
+	"github.com/edulinq/autograder/internal/model"
+	"github.com/edulinq/autograder/internal/timestamp"
+)
+
+type RegradeRequest struct {
+	core.APIRequestAssignmentContext
+	core.MinCourseRoleGrader
+
+	grader.RegradeOptions
+}
+
+type RegradeResponse struct {
+	Complete      bool                                    `json:"complete"`
+	Options       grader.RegradeOptions                   `json:"options"`
+	ResolvedUsers []string                                `json:"resolved-users"`
+	RegradeAfter  timestamp.Timestamp                     `json:"regrade-after"`
+	Results       map[string]*model.SubmissionHistoryItem `json:"results"`
+	WorkErrors    map[string]string                       `json:"work-errors"`
+}
+
+func HandleRegrade(request *RegradeRequest) (*RegradeResponse, *core.APIError) {
+	gradeOptions := grader.GetDefaultGradeOptions()
+	// Proxy submissions are not subject to submission restrictions.
+	gradeOptions.CheckRejection = false
+	gradeOptions.ProxyUser = request.User.Email
+
+	request.RegradeOptions.GradeOptions = gradeOptions
+
+	results, regradeAfter, numRemaining, workErrors, err := grader.Regrade(request.Assignment, request.RegradeOptions)
+	if err != nil {
+		return nil, core.NewInternalError("-638", request, "Failed to get courses from database.").Err(err)
+	}
+
+	response := RegradeResponse{
+		// TODO: Resolved users may have users from outside the course (so it will never be complete).
+		Complete:      (numRemaining == len(request.RegradeOptions.ResolvedUsers)),
+		Options:       request.RegradeOptions,
+		ResolvedUsers: request.RegradeOptions.ResolvedUsers,
+		RegradeAfter:  regradeAfter,
+		Results:       results,
+		WorkErrors:    workErrors,
+	}
+
+	return &response, nil
+}

--- a/internal/api/courses/assignments/submissions/proxy/regrade.go
+++ b/internal/api/courses/assignments/submissions/proxy/regrade.go
@@ -3,8 +3,6 @@ package proxy
 import (
 	"github.com/edulinq/autograder/internal/api/core"
 	"github.com/edulinq/autograder/internal/grader"
-	"github.com/edulinq/autograder/internal/model"
-	"github.com/edulinq/autograder/internal/timestamp"
 )
 
 type RegradeRequest struct {
@@ -15,14 +13,13 @@ type RegradeRequest struct {
 }
 
 type RegradeResponse struct {
-	Complete      bool                                    `json:"complete"`
-	Options       grader.RegradeOptions                   `json:"options"`
-	ResolvedUsers []string                                `json:"resolved-users"`
-	RegradeAfter  timestamp.Timestamp                     `json:"regrade-after"`
-	Results       map[string]*model.SubmissionHistoryItem `json:"results"`
-	WorkErrors    map[string]string                       `json:"work-errors"`
+	grader.RegradeResult
+
+	Complete      bool     `json:"complete"`
+	ResolvedUsers []string `json:"resolved-users"`
 }
 
+// Proxy regrade an assignment for all target users using their most recent submission.
 func HandleRegrade(request *RegradeRequest) (*RegradeResponse, *core.APIError) {
 	gradeOptions := grader.GetDefaultGradeOptions()
 	// Proxy submissions are not subject to submission restrictions.
@@ -30,20 +27,17 @@ func HandleRegrade(request *RegradeRequest) (*RegradeResponse, *core.APIError) {
 	gradeOptions.ProxyUser = request.User.Email
 
 	request.RegradeOptions.GradeOptions = gradeOptions
+	request.RegradeOptions.Context = request.APIRequestUserContext.Context
 
-	results, regradeAfter, numRemaining, workErrors, err := grader.Regrade(request.Assignment, request.RegradeOptions)
+	result, numRemaining, err := grader.Regrade(request.Assignment, request.RegradeOptions)
 	if err != nil {
 		return nil, core.NewInternalError("-638", request, "Failed to get courses from database.").Err(err)
 	}
 
 	response := RegradeResponse{
-		// TODO: Resolved users may have users from outside the course (so it will never be complete).
-		Complete:      (numRemaining == len(request.RegradeOptions.ResolvedUsers)),
-		Options:       request.RegradeOptions,
-		ResolvedUsers: request.RegradeOptions.ResolvedUsers,
-		RegradeAfter:  regradeAfter,
-		Results:       results,
-		WorkErrors:    workErrors,
+		RegradeResult: *result,
+		Complete:      (numRemaining == 0),
+		ResolvedUsers: result.Options.ResolvedUsers,
 	}
 
 	return &response, nil

--- a/internal/api/courses/assignments/submissions/proxy/regrade.go
+++ b/internal/api/courses/assignments/submissions/proxy/regrade.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"github.com/edulinq/autograder/internal/api/core"
 	"github.com/edulinq/autograder/internal/grader"
+	"github.com/edulinq/autograder/internal/model"
 )
 
 type RegradeRequest struct {
@@ -21,6 +22,10 @@ type RegradeResponse struct {
 
 // Proxy regrade an assignment for all target users using their most recent submission.
 func HandleRegrade(request *RegradeRequest) (*RegradeResponse, *core.APIError) {
+	if len(request.RegradeOptions.RawReferences) == 0 {
+		request.RegradeOptions.RawReferences = model.NewAllCourseUserReference()
+	}
+
 	gradeOptions := grader.GetDefaultGradeOptions()
 	// Proxy submissions are not subject to submission restrictions.
 	gradeOptions.CheckRejection = false

--- a/internal/api/courses/assignments/submissions/proxy/regrade.go
+++ b/internal/api/courses/assignments/submissions/proxy/regrade.go
@@ -36,7 +36,7 @@ func HandleRegrade(request *RegradeRequest) (*RegradeResponse, *core.APIError) {
 
 	result, numRemaining, err := grader.Regrade(request.Assignment, request.RegradeOptions)
 	if err != nil {
-		return nil, core.NewInternalError("-638", request, "Failed to get courses from database.").Err(err)
+		return nil, core.NewInternalError("-638", request, "Failed to regrade the assignment for the target users.").Err(err)
 	}
 
 	response := RegradeResponse{

--- a/internal/api/courses/assignments/submissions/proxy/regrade_test.go
+++ b/internal/api/courses/assignments/submissions/proxy/regrade_test.go
@@ -25,6 +25,9 @@ func TestRegradeBase(test *testing.T) {
 		"1697406272": model.MustLoadGradingResult(getTestSubmissionResultPath("1697406272")),
 	}
 
+	// A time in the year 3003 which can be used for regrade tests that want a future RegradeAfter time.
+	farFutureTime := timestamp.FromMSecs(32614181465000)
+
 	testCases := []struct {
 		options         grader.RegradeOptions
 		proxyUser       string
@@ -75,6 +78,115 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
+		// Empty Users, Wait For Completion
+		{
+			grader.RegradeOptions{
+				JobOptions: jobmanager.JobOptions{
+					WaitForCompletion: true,
+				},
+			},
+			"course-grader",
+			"",
+			RegradeResponse{
+				RegradeResult: grader.RegradeResult{
+					Results: map[string]*model.SubmissionHistoryItem{
+						"course-admin@test.edulinq.org":   nil,
+						"course-grader@test.edulinq.org":  nil,
+						"course-other@test.edulinq.org":   nil,
+						"course-owner@test.edulinq.org":   nil,
+						"course-student@test.edulinq.org": studentGradingResults["1697406272"].Info.ToHistoryItem(),
+					},
+					WorkErrors: map[string]string{},
+				},
+				Complete: true,
+				ResolvedUsers: []string{
+					"course-admin@test.edulinq.org",
+					"course-grader@test.edulinq.org",
+					"course-other@test.edulinq.org",
+					"course-owner@test.edulinq.org",
+					"course-student@test.edulinq.org",
+				},
+			},
+		},
+
+		// All Users, Wait For Completion
+		{
+			grader.RegradeOptions{
+				JobOptions: jobmanager.JobOptions{
+					WaitForCompletion: true,
+				},
+				RawReferences: []model.CourseUserReference{"*"},
+			},
+			"course-grader",
+			"",
+			RegradeResponse{
+				RegradeResult: grader.RegradeResult{
+					Results: map[string]*model.SubmissionHistoryItem{
+						"course-admin@test.edulinq.org":   nil,
+						"course-grader@test.edulinq.org":  nil,
+						"course-other@test.edulinq.org":   nil,
+						"course-owner@test.edulinq.org":   nil,
+						"course-student@test.edulinq.org": studentGradingResults["1697406272"].Info.ToHistoryItem(),
+					},
+					WorkErrors: map[string]string{},
+				},
+				Complete: true,
+				ResolvedUsers: []string{
+					"course-admin@test.edulinq.org",
+					"course-grader@test.edulinq.org",
+					"course-other@test.edulinq.org",
+					"course-owner@test.edulinq.org",
+					"course-student@test.edulinq.org",
+				},
+			},
+		},
+
+		// Early Regrade After, Wait For Completion
+		{
+			grader.RegradeOptions{
+				JobOptions: jobmanager.JobOptions{
+					WaitForCompletion: true,
+				},
+				RawReferences: []model.CourseUserReference{"student"},
+				RegradeAfter:  timestamp.ZeroPointer(),
+			},
+			"course-grader",
+			"",
+			RegradeResponse{
+				RegradeResult: grader.RegradeResult{
+					Results: map[string]*model.SubmissionHistoryItem{
+						"course-student@test.edulinq.org": studentGradingResults["1697406272"].Info.ToHistoryItem(),
+					},
+					WorkErrors: map[string]string{},
+				},
+				Complete:      true,
+				ResolvedUsers: []string{"course-student@test.edulinq.org"},
+			},
+		},
+
+		// Late Regrade After, Wait For Completion
+		{
+			grader.RegradeOptions{
+				JobOptions: jobmanager.JobOptions{
+					WaitForCompletion: true,
+				},
+				RawReferences: []model.CourseUserReference{"student"},
+				RegradeAfter:  &farFutureTime,
+			},
+			"course-grader",
+			"",
+			RegradeResponse{
+				RegradeResult: grader.RegradeResult{
+					Results: map[string]*model.SubmissionHistoryItem{
+						"course-student@test.edulinq.org": studentGradingResults["1697406272"].Info.ToHistoryItem(),
+					},
+					WorkErrors: map[string]string{},
+				},
+				Complete:      true,
+				ResolvedUsers: []string{"course-student@test.edulinq.org"},
+			},
+		},
+
 		// Student, No Wait
 		{
 			grader.RegradeOptions{
@@ -115,6 +227,103 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
+		// Empty Users, No Wait
+		{
+			grader.RegradeOptions{
+				JobOptions: jobmanager.JobOptions{
+					WaitForCompletion: false,
+				},
+			},
+			"course-grader",
+			"",
+			RegradeResponse{
+				RegradeResult: grader.RegradeResult{
+					Results:    map[string]*model.SubmissionHistoryItem{},
+					WorkErrors: map[string]string{},
+				},
+				Complete: false,
+				ResolvedUsers: []string{
+					"course-admin@test.edulinq.org",
+					"course-grader@test.edulinq.org",
+					"course-other@test.edulinq.org",
+					"course-owner@test.edulinq.org",
+					"course-student@test.edulinq.org",
+				},
+			},
+		},
+
+		// All Users, No Wait
+		{
+			grader.RegradeOptions{
+				JobOptions: jobmanager.JobOptions{
+					WaitForCompletion: false,
+				},
+				RawReferences: []model.CourseUserReference{"*"},
+			},
+			"course-grader",
+			"",
+			RegradeResponse{
+				RegradeResult: grader.RegradeResult{
+					Results:    map[string]*model.SubmissionHistoryItem{},
+					WorkErrors: map[string]string{},
+				},
+				Complete: false,
+				ResolvedUsers: []string{
+					"course-admin@test.edulinq.org",
+					"course-grader@test.edulinq.org",
+					"course-other@test.edulinq.org",
+					"course-owner@test.edulinq.org",
+					"course-student@test.edulinq.org",
+				},
+			},
+		},
+
+		// Early Regrade After, No Wait
+		{
+			grader.RegradeOptions{
+				JobOptions: jobmanager.JobOptions{
+					WaitForCompletion: true,
+				},
+				RawReferences: []model.CourseUserReference{"student"},
+				RegradeAfter:  timestamp.ZeroPointer(),
+			},
+			"course-grader",
+			"",
+			RegradeResponse{
+				RegradeResult: grader.RegradeResult{
+					Results: map[string]*model.SubmissionHistoryItem{
+						"course-student@test.edulinq.org": studentGradingResults["1697406272"].Info.ToHistoryItem(),
+					},
+					WorkErrors: map[string]string{},
+				},
+				Complete:      true,
+				ResolvedUsers: []string{"course-student@test.edulinq.org"},
+			},
+		},
+
+		// Late Regrade After, No Wait
+		{
+			grader.RegradeOptions{
+				JobOptions: jobmanager.JobOptions{
+					WaitForCompletion: true,
+				},
+				RawReferences: []model.CourseUserReference{"student"},
+				RegradeAfter:  &farFutureTime,
+			},
+			"course-grader",
+			"",
+			RegradeResponse{
+				RegradeResult: grader.RegradeResult{
+					Results: map[string]*model.SubmissionHistoryItem{
+						"course-student@test.edulinq.org": studentGradingResults["1697406272"].Info.ToHistoryItem(),
+					},
+					WorkErrors: map[string]string{},
+				},
+				Complete:      true,
+				ResolvedUsers: []string{"course-student@test.edulinq.org"},
+			},
+		},
+
 		// Errors
 		// Invalid Target Users
 		{
@@ -140,7 +349,7 @@ func TestRegradeBase(test *testing.T) {
 			RegradeResponse{},
 		},
 
-		// Perm errors
+		// Perm Errors
 		{
 			grader.RegradeOptions{
 				JobOptions: jobmanager.JobOptions{
@@ -169,6 +378,12 @@ func TestRegradeBase(test *testing.T) {
 		fields := map[string]any{
 			"target-users":        testCase.options.RawReferences,
 			"wait-for-completion": testCase.options.JobOptions.WaitForCompletion,
+			"regrade-after":       testCase.options.RegradeAfter,
+		}
+
+		// Update empty raw references to be the "*" to pass equality check.
+		if len(testCase.options.RawReferences) == 0 {
+			testCase.options.RawReferences = model.NewAllCourseUserReference()
 		}
 
 		var minRegradeAfter timestamp.Timestamp = 0

--- a/internal/api/courses/assignments/submissions/proxy/regrade_test.go
+++ b/internal/api/courses/assignments/submissions/proxy/regrade_test.go
@@ -212,27 +212,6 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
-		// Late Regrade After
-		{
-			grader.RegradeOptions{
-				JobOptions: jobmanager.JobOptions{
-					WaitForCompletion: false,
-				},
-				RawReferences: []model.CourseUserReference{"student"},
-				RegradeAfter:  &farFutureTime,
-			},
-			"course-grader",
-			"",
-			RegradeResponse{
-				RegradeResult: grader.RegradeResult{
-					Results:    map[string]*model.SubmissionHistoryItem{},
-					WorkErrors: map[string]string{},
-				},
-				Complete:      false,
-				ResolvedUsers: []string{"course-student@test.edulinq.org"},
-			},
-		},
-
 		// Errors
 
 		// Invalid Target Users

--- a/internal/api/courses/assignments/submissions/proxy/regrade_test.go
+++ b/internal/api/courses/assignments/submissions/proxy/regrade_test.go
@@ -25,7 +25,7 @@ func TestRegradeBase(test *testing.T) {
 		"1697406272": model.MustLoadGradingResult(getTestSubmissionResultPath("1697406272")),
 	}
 
-	// A time in the year 3003 which can be used for regrade tests that want a future RegradeAfter time.
+	// A time in the year 3003.
 	farFutureTime := timestamp.FromMSecs(32614181465000)
 
 	testCases := []struct {

--- a/internal/api/courses/assignments/submissions/proxy/regrade_test.go
+++ b/internal/api/courses/assignments/submissions/proxy/regrade_test.go
@@ -34,7 +34,9 @@ func TestRegradeBase(test *testing.T) {
 		expectedLocator string
 		expected        RegradeResponse
 	}{
-		// Student, Wait For Completion
+		// Wait For Completion
+
+		// Student
 		{
 			grader.RegradeOptions{
 				JobOptions: jobmanager.JobOptions{
@@ -56,7 +58,7 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
-		// Admin, Wait For Completion
+		// Admin
 		{
 			grader.RegradeOptions{
 				JobOptions: jobmanager.JobOptions{
@@ -78,7 +80,7 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
-		// Empty Users, Wait For Completion
+		// Empty Users
 		{
 			grader.RegradeOptions{
 				JobOptions: jobmanager.JobOptions{
@@ -109,7 +111,7 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
-		// All Users, Wait For Completion
+		// All Users
 		{
 			grader.RegradeOptions{
 				JobOptions: jobmanager.JobOptions{
@@ -141,7 +143,7 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
-		// Early Regrade After, Wait For Completion
+		// Early Regrade After
 		{
 			grader.RegradeOptions{
 				JobOptions: jobmanager.JobOptions{
@@ -164,7 +166,7 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
-		// Late Regrade After, Wait For Completion
+		// Late Regrade After
 		{
 			grader.RegradeOptions{
 				JobOptions: jobmanager.JobOptions{
@@ -187,7 +189,9 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
-		// Student, No Wait
+		// No Wait
+
+		// Student
 		{
 			grader.RegradeOptions{
 				JobOptions: jobmanager.JobOptions{
@@ -207,7 +211,7 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
-		// Grader, No Wait
+		// Grader
 		{
 			grader.RegradeOptions{
 				JobOptions: jobmanager.JobOptions{
@@ -227,7 +231,7 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
-		// Empty Users, No Wait
+		// Empty Users
 		{
 			grader.RegradeOptions{
 				JobOptions: jobmanager.JobOptions{
@@ -252,7 +256,7 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
-		// All Users, No Wait
+		// All Users
 		{
 			grader.RegradeOptions{
 				JobOptions: jobmanager.JobOptions{
@@ -278,11 +282,11 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
-		// Early Regrade After, No Wait
+		// Early Regrade After
 		{
 			grader.RegradeOptions{
 				JobOptions: jobmanager.JobOptions{
-					WaitForCompletion: true,
+					WaitForCompletion: false,
 				},
 				RawReferences: []model.CourseUserReference{"student"},
 				RegradeAfter:  timestamp.ZeroPointer(),
@@ -301,11 +305,11 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
-		// Late Regrade After, No Wait
+		// Late Regrade After
 		{
 			grader.RegradeOptions{
 				JobOptions: jobmanager.JobOptions{
-					WaitForCompletion: true,
+					WaitForCompletion: false,
 				},
 				RawReferences: []model.CourseUserReference{"student"},
 				RegradeAfter:  &farFutureTime,
@@ -314,17 +318,16 @@ func TestRegradeBase(test *testing.T) {
 			"",
 			RegradeResponse{
 				RegradeResult: grader.RegradeResult{
-					Results: map[string]*model.SubmissionHistoryItem{
-						"course-student@test.edulinq.org": studentGradingResults["1697406272"].Info.ToHistoryItem(),
-					},
+					Results:    map[string]*model.SubmissionHistoryItem{},
 					WorkErrors: map[string]string{},
 				},
-				Complete:      true,
+				Complete:      false,
 				ResolvedUsers: []string{"course-student@test.edulinq.org"},
 			},
 		},
 
 		// Errors
+
 		// Invalid Target Users
 		{
 			grader.RegradeOptions{
@@ -398,7 +401,7 @@ func TestRegradeBase(test *testing.T) {
 		if !response.Success {
 			if testCase.expectedLocator != "" {
 				if response.Locator != testCase.expectedLocator {
-					test.Errorf("Case %d: Incorrect error returned. Expected '%s', found '%s'.",
+					test.Errorf("Case %d: Incorrect error returned. Expected: '%s', Actual: '%s'.",
 						i, testCase.expectedLocator, response.Locator)
 				}
 			} else {
@@ -430,7 +433,7 @@ func TestRegradeBase(test *testing.T) {
 		}
 
 		if !((minRegradeAfter <= responseContent.RegradeAfter) && (responseContent.RegradeAfter <= maxRegradeAfter)) {
-			test.Errorf("Case %d: Unexpected regrade after time. Expected a time between '%d' and '%d', Actual: '%d'.",
+			test.Errorf("Case %d: Unexpected regrade after time. Expected a time within the range ['%d', '%d'], Actual: '%d'.",
 				i, minRegradeAfter, maxRegradeAfter, responseContent.RegradeAfter)
 			continue
 		}
@@ -438,7 +441,9 @@ func TestRegradeBase(test *testing.T) {
 		// Clear regrade after time for equality check.
 		responseContent.RegradeAfter = 0
 
+		// Copy the test case options to the expected output to pass the equality check.
 		testCase.expected.Options = testCase.options
+
 		if !reflect.DeepEqual(testCase.expected, responseContent) {
 			test.Errorf("Case %d: Unexpected regrade result. Expected: '%s', actual: '%s'.",
 				i, util.MustToJSONIndent(testCase.expected), util.MustToJSONIndent(responseContent))

--- a/internal/api/courses/assignments/submissions/proxy/regrade_test.go
+++ b/internal/api/courses/assignments/submissions/proxy/regrade_test.go
@@ -1,0 +1,233 @@
+package proxy
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/edulinq/autograder/internal/api/core"
+	"github.com/edulinq/autograder/internal/db"
+	"github.com/edulinq/autograder/internal/docker"
+	"github.com/edulinq/autograder/internal/grader"
+	"github.com/edulinq/autograder/internal/jobmanager"
+	"github.com/edulinq/autograder/internal/model"
+	"github.com/edulinq/autograder/internal/timestamp"
+	"github.com/edulinq/autograder/internal/util"
+)
+
+func TestRegradeBase(test *testing.T) {
+	docker.EnsureOrSkipForTest(test)
+
+	db.ResetForTesting()
+	defer db.ResetForTesting()
+
+	// Note that computation of these paths are deferred until test time.
+	studentGradingResults := map[string]*model.GradingResult{
+		"1697406272": model.MustLoadGradingResult(getTestSubmissionResultPath("1697406272")),
+	}
+
+	testCases := []struct {
+		options         grader.RegradeOptions
+		proxyUser       string
+		expectedLocator string
+		expected        RegradeResponse
+	}{
+		// Student, Wait For Completion
+		{
+			grader.RegradeOptions{
+				JobOptions: jobmanager.JobOptions{
+					WaitForCompletion: true,
+				},
+				RawReferences: []model.CourseUserReference{"student"},
+			},
+			"course-grader",
+			"",
+			RegradeResponse{
+				RegradeResult: grader.RegradeResult{
+					Results: map[string]*model.SubmissionHistoryItem{
+						"course-student@test.edulinq.org": studentGradingResults["1697406272"].Info.ToHistoryItem(),
+					},
+					WorkErrors: map[string]string{},
+				},
+				Complete:      true,
+				ResolvedUsers: []string{"course-student@test.edulinq.org"},
+			},
+		},
+
+		// Admin, Wait For Completion
+		{
+			grader.RegradeOptions{
+				JobOptions: jobmanager.JobOptions{
+					WaitForCompletion: true,
+				},
+				RawReferences: []model.CourseUserReference{"admin"},
+			},
+			"course-grader",
+			"",
+			RegradeResponse{
+				RegradeResult: grader.RegradeResult{
+					Results: map[string]*model.SubmissionHistoryItem{
+						"course-admin@test.edulinq.org": nil,
+					},
+					WorkErrors: map[string]string{},
+				},
+				Complete:      true,
+				ResolvedUsers: []string{"course-admin@test.edulinq.org"},
+			},
+		},
+
+		// Student, No Wait
+		{
+			grader.RegradeOptions{
+				JobOptions: jobmanager.JobOptions{
+					WaitForCompletion: false,
+				},
+				RawReferences: []model.CourseUserReference{"student"},
+			},
+			"course-grader",
+			"",
+			RegradeResponse{
+				RegradeResult: grader.RegradeResult{
+					Results:    map[string]*model.SubmissionHistoryItem{},
+					WorkErrors: map[string]string{},
+				},
+				Complete:      false,
+				ResolvedUsers: []string{"course-student@test.edulinq.org"},
+			},
+		},
+
+		// Grader, No Wait
+		{
+			grader.RegradeOptions{
+				JobOptions: jobmanager.JobOptions{
+					WaitForCompletion: false,
+				},
+				RawReferences: []model.CourseUserReference{"grader"},
+			},
+			"course-grader",
+			"",
+			RegradeResponse{
+				RegradeResult: grader.RegradeResult{
+					Results:    map[string]*model.SubmissionHistoryItem{},
+					WorkErrors: map[string]string{},
+				},
+				Complete:      false,
+				ResolvedUsers: []string{"course-grader@test.edulinq.org"},
+			},
+		},
+
+		// Errors
+		// Invalid Target Users
+		{
+			grader.RegradeOptions{
+				JobOptions: jobmanager.JobOptions{
+					WaitForCompletion: true,
+				},
+				RawReferences: []model.CourseUserReference{"ZZZ"},
+			},
+			"course-admin",
+			"-638",
+			RegradeResponse{},
+		},
+		{
+			grader.RegradeOptions{
+				JobOptions: jobmanager.JobOptions{
+					WaitForCompletion: false,
+				},
+				RawReferences: []model.CourseUserReference{"ZZZ"},
+			},
+			"course-admin",
+			"-638",
+			RegradeResponse{},
+		},
+
+		// Perm errors
+		{
+			grader.RegradeOptions{
+				JobOptions: jobmanager.JobOptions{
+					WaitForCompletion: true,
+				},
+				RawReferences: []model.CourseUserReference{"student"},
+			},
+			"course-student",
+			"-020",
+			RegradeResponse{},
+		},
+		{
+			grader.RegradeOptions{
+				JobOptions: jobmanager.JobOptions{
+					WaitForCompletion: false,
+				},
+				RawReferences: []model.CourseUserReference{"student"},
+			},
+			"course-other",
+			"-020",
+			RegradeResponse{},
+		},
+	}
+
+	for i, testCase := range testCases {
+		fields := map[string]any{
+			"target-users":        testCase.options.RawReferences,
+			"wait-for-completion": testCase.options.JobOptions.WaitForCompletion,
+		}
+
+		var minRegradeAfter timestamp.Timestamp = 0
+		if testCase.options.RegradeAfter == nil {
+			// Create a window for the regrade after check.
+			minRegradeAfter = timestamp.Now()
+		} else {
+			minRegradeAfter = *testCase.options.RegradeAfter
+		}
+
+		response := core.SendTestAPIRequestFull(test, `courses/assignments/submissions/proxy/regrade`, fields, nil, testCase.proxyUser)
+		if !response.Success {
+			if testCase.expectedLocator != "" {
+				if response.Locator != testCase.expectedLocator {
+					test.Errorf("Case %d: Incorrect error returned. Expected '%s', found '%s'.",
+						i, testCase.expectedLocator, response.Locator)
+				}
+			} else {
+				test.Errorf("Case %d: Response is not a success when it should be: '%v'.", i, response)
+			}
+
+			continue
+		}
+
+		if testCase.expectedLocator != "" {
+			test.Errorf("Case %d: Did not get an expected error.", i)
+			continue
+		}
+
+		var responseContent RegradeResponse
+		util.MustJSONFromString(util.MustToJSON(response.Content), &responseContent)
+
+		failed := grader.CheckAndClearIDs(test, i, testCase.expected.Results, responseContent.Results)
+		if failed {
+			continue
+		}
+
+		var maxRegradeAfter timestamp.Timestamp = 0
+		if testCase.options.RegradeAfter == nil {
+			// Create a window for the regrade after check.
+			maxRegradeAfter = timestamp.Now()
+		} else {
+			maxRegradeAfter = *testCase.options.RegradeAfter
+		}
+
+		if !((minRegradeAfter <= responseContent.RegradeAfter) && (responseContent.RegradeAfter <= maxRegradeAfter)) {
+			test.Errorf("Case %d: Unexpected regrade after time. Expected a time between '%d' and '%d', Actual: '%d'.",
+				i, minRegradeAfter, maxRegradeAfter, responseContent.RegradeAfter)
+			continue
+		}
+
+		// Clear regrade after time for equality check.
+		responseContent.RegradeAfter = 0
+
+		testCase.expected.Options = testCase.options
+		if !reflect.DeepEqual(testCase.expected, responseContent) {
+			test.Errorf("Case %d: Unexpected regrade result. Expected: '%s', actual: '%s'.",
+				i, util.MustToJSONIndent(testCase.expected), util.MustToJSONIndent(responseContent))
+			continue
+		}
+	}
+}

--- a/internal/api/courses/assignments/submissions/proxy/regrade_test.go
+++ b/internal/api/courses/assignments/submissions/proxy/regrade_test.go
@@ -128,7 +128,7 @@ func TestRegradeBase(test *testing.T) {
 					WaitForCompletion: true,
 				},
 				RawReferences: []model.CourseUserReference{"student"},
-				RegradeAfter:  timestamp.ZeroPointer(),
+				RegradeCutoff: timestamp.ZeroPointer(),
 			},
 			"course-grader",
 			"",
@@ -151,7 +151,7 @@ func TestRegradeBase(test *testing.T) {
 					WaitForCompletion: true,
 				},
 				RawReferences: []model.CourseUserReference{"student"},
-				RegradeAfter:  &farFutureTime,
+				RegradeCutoff: &farFutureTime,
 			},
 			"course-grader",
 			"",
@@ -196,7 +196,7 @@ func TestRegradeBase(test *testing.T) {
 					WaitForCompletion: false,
 				},
 				RawReferences: []model.CourseUserReference{"student"},
-				RegradeAfter:  timestamp.ZeroPointer(),
+				RegradeCutoff: timestamp.ZeroPointer(),
 			},
 			"course-grader",
 			"",
@@ -267,7 +267,7 @@ func TestRegradeBase(test *testing.T) {
 		fields := map[string]any{
 			"target-users":        testCase.options.RawReferences,
 			"wait-for-completion": testCase.options.JobOptions.WaitForCompletion,
-			"regrade-after":       testCase.options.RegradeAfter,
+			"regrade-cutoff":      testCase.options.RegradeCutoff,
 		}
 
 		// Update empty raw references to be the "*" to pass equality check.
@@ -301,9 +301,8 @@ func TestRegradeBase(test *testing.T) {
 		testCase.expected.Options = testCase.options
 
 		// Clear variable regrade after times for equality check.
-		responseContent.RegradeAfter = 0
-		if testCase.options.RegradeAfter == nil {
-			testCase.expected.Options.RegradeAfter = responseContent.Options.RegradeAfter
+		if testCase.options.RegradeCutoff == nil {
+			testCase.expected.Options.RegradeCutoff = responseContent.Options.RegradeCutoff
 		}
 
 		// Clear the submission IDs to pass the equality check.

--- a/internal/api/courses/assignments/submissions/proxy/routes.go
+++ b/internal/api/courses/assignments/submissions/proxy/routes.go
@@ -7,6 +7,7 @@ import (
 )
 
 var baseRoutes []core.Route = []core.Route{
+	core.MustNewAPIRoute(`courses/assignments/submissions/proxy/regrade`, HandleRegrade),
 	core.MustNewAPIRoute(`courses/assignments/submissions/proxy/resubmit`, HandleResubmit),
 	core.MustNewAPIRoute(`courses/assignments/submissions/proxy/submit`, HandleSubmit),
 }

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -66,5 +66,8 @@ var (
 	ANALYSIS_INDIVIDUAL_COURSE_POOL_SIZE = MustNewIntOption("analysis.individual.poolsize", 1, "The number of parallel workers per course when computing individual analysis.")
 	ANALYSIS_PAIRWISE_COURSE_POOL_SIZE   = MustNewIntOption("analysis.pairwise.poolsize", 1, "The number of parallel workers per course when computing pairwise analysis.")
 
+	// Regrades
+	REGRADE_COURSE_POOL_SIZE = MustNewIntOption("regrade.poolsize", 4, "The number of parallel workers per course when regrading an assignment.")
+
 	STALELOCK_DURATION_SECS = MustNewIntOption("lockmanager.staleduration", 2*60*60, "Number of seconds a lock can be unused before getting removed.")
 )

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -62,12 +62,10 @@ var (
 	DB_TYPE   = MustNewStringOption("db.type", "disk", "The type of database to use.")
 	DB_PG_URI = MustNewStringOption("db.pg.uri", "", "Connection string to connect to a Postgres Database. Empty if not using Postgres.")
 
-	// Code Analysis
+	// Job Management
 	ANALYSIS_INDIVIDUAL_COURSE_POOL_SIZE = MustNewIntOption("analysis.individual.poolsize", 1, "The number of parallel workers per course when computing individual analysis.")
 	ANALYSIS_PAIRWISE_COURSE_POOL_SIZE   = MustNewIntOption("analysis.pairwise.poolsize", 1, "The number of parallel workers per course when computing pairwise analysis.")
-
-	// Regrades
-	REGRADE_COURSE_POOL_SIZE = MustNewIntOption("regrade.poolsize", 4, "The number of parallel workers per course when regrading an assignment.")
+	REGRADE_COURSE_POOL_SIZE             = MustNewIntOption("regrade.poolsize", 4, "The number of parallel workers per course when regrading an assignment.")
 
 	STALELOCK_DURATION_SECS = MustNewIntOption("lockmanager.staleduration", 2*60*60, "Number of seconds a lock can be unused before getting removed.")
 )

--- a/internal/docker/model.go
+++ b/internal/docker/model.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	DEFAULT_IMAGE = "edulinq/autograder/internal.base"
+	DEFAULT_IMAGE = "ghcr.io/edulinq/grader.base:0.1.0-alpine"
 )
 
 type ImageInfo struct {

--- a/internal/grader/grade_test.go
+++ b/internal/grader/grade_test.go
@@ -97,7 +97,7 @@ func runSubmissionTests(test *testing.T, parallel bool, useDocker bool) {
 
 			if !result.Info.Equals(*testSubmission.TestSubmission.GradingInfo, !testSubmission.TestSubmission.IgnoreMessages) {
 				test.Fatalf("Actual output:\n---\n%v\n---\ndoes not match expected output:\n---\n%v\n---\n.",
-					result.Info, testSubmission.TestSubmission.GradingInfo)
+					util.MustToJSONIndent(result.Info), util.MustToJSONIndent(testSubmission.TestSubmission.GradingInfo))
 			}
 
 		})

--- a/internal/grader/regrade.go
+++ b/internal/grader/regrade.go
@@ -17,7 +17,7 @@ type RegradeOptions struct {
 	jobmanager.JobOptions
 	GradeOptions `json:"-"`
 
-	// The raw references of users to regrade.
+	// The raw course user references to regrade.
 	RawReferences []model.CourseUserReference `json:"target-users" required:""`
 
 	// Ensure every user has made a new submission after this time.

--- a/internal/grader/regrade.go
+++ b/internal/grader/regrade.go
@@ -1,8 +1,15 @@
 package grader
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/edulinq/autograder/internal/config"
 	"github.com/edulinq/autograder/internal/db"
 	"github.com/edulinq/autograder/internal/jobmanager"
+	"github.com/edulinq/autograder/internal/log"
+	"github.com/edulinq/autograder/internal/model"
+	"github.com/edulinq/autograder/internal/timestamp"
 )
 
 type RegradeOptions struct {
@@ -10,7 +17,7 @@ type RegradeOptions struct {
 	GradeOptions
 
 	// The raw references of users to regrade.
-	RawReferences []CourseUserReferences `json:"target-users" required:""`
+	RawReferences []model.CourseUserReference `json:"target-users" required:""`
 
 	// If true, do not swap the context to the background context when running.
 	// By default (when this is false), the context will be swapped to the background context when !WaitForCompletion.
@@ -24,39 +31,46 @@ type RegradeOptions struct {
 }
 
 func Regrade(options RegradeOptions) (map[string]*model.SubmissionHistoryItem, int, map[string]string, error) {
-	reference, err := ParseCourseUserReferences(options.RawReferences)
+	reference, err := model.ParseCourseUserReferences(options.RawReferences)
 	if err != nil {
 		return nil, 0, nil, fmt.Errorf("Failed to parse course user references: '%w'.", err)
 	}
 
-	fullUsers := model.ResolveCourseUserEmails(db.GetCourseUsers(options.Assignment.GetCourse().GetID(), reference))
+	courseUsers, err := db.GetCourseUsers(options.Assignment.GetCourse())
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("Failed to get course users: '%w'.", err)
+	}
+
+	fullUsers := model.ResolveCourseUserEmails(courseUsers, reference)
 
 	if !options.RetainOriginalContext && !options.WaitForCompletion {
 		options.Context = context.Background()
 	}
 
-	job := jobmanager.Job[string, *model.IndividualAnalysis]{
+	// TODO: We may want to return the proxy time!
+	var proxyTime timestamp.Timestamp = 0
+	if options.ProxyTime == nil {
+		proxyTime = timestamp.Now()
+	} else {
+		proxyTime = *options.ProxyTime
+	}
+
+	lockKey := fmt.Sprintf("regrade-course-%s", options.Assignment.GetCourse().GetID())
+
+	job := jobmanager.Job[string, *model.SubmissionHistoryItem]{
 		JobOptions:              &options.JobOptions,
-		LockKey:                 fmt.Sprintf("regrade-course-%s", options.Assignment.GetCourse().GetID()),
+		LockKey:                 lockKey,
 		PoolSize:                config.REGRADE_COURSE_POOL_SIZE.Get(),
 		ReturnIncompleteResults: !options.WaitForCompletion,
 		WorkItems:               fullUsers,
-		// TODO: Does this need to be modified to not include nil results? Guess: probably
-		RetrieveFunc: db.GetRecentSubmissionSurvey(options.Assignment, reference),
-		StoreFunc:    db.StoreIndividualAnalysis,
-		RemoveFunc:   db.RemoveIndividualAnalysis,
-		WorkFunc: func(fullSubmissionID string) (*model.IndividualAnalysis, error) {
-			return computeSingleIndividualAnalysis(options, fullSubmissionID, true)
+		RetrieveFunc: func(resolvedEmails []string) (map[string]*model.SubmissionHistoryItem, error) {
+			return retrieveRegradedSubmissions(options.Assignment, proxyTime, resolvedEmails)
 		},
-		WorkItemKeyFunc: func(fullSubmissionID string) string {
-			return fmt.Sprintf("analysis-individual-%s", fullSubmissionID)
+		WorkFunc: func(email string) (*model.SubmissionHistoryItem, error) {
+			return computeSingleRegrade(options, email)
 		},
-		OnComplete: func(result *jobmanager.JobOutput[string, *model.IndividualAnalysis]) {
-			if result == nil {
-				return
-			}
-
-			collectIndividualStats(fullSubmissionIDs, result.RunTime, options.InitiatorEmail)
+		WorkItemKeyFunc: func(email string) string {
+			return fmt.Sprintf("%s-%s", lockKey, email)
 		},
 	}
 
@@ -82,4 +96,41 @@ func Regrade(options RegradeOptions) (map[string]*model.SubmissionHistoryItem, i
 	}
 
 	return output.ResultItems, len(output.RemainingItems), workErrors, nil
+}
+
+func computeSingleRegrade(options RegradeOptions, email string) (*model.SubmissionHistoryItem, error) {
+	return nil, nil
+}
+
+func retrieveRegradedSubmissions(assignment *model.Assignment, proxyTime timestamp.Timestamp, emails []string) (map[string]*model.SubmissionHistoryItem, error) {
+	emailSet := make(map[string]any, len(emails))
+	for _, email := range emails {
+		emailSet[email] = nil
+	}
+
+	reference := &model.ParsedCourseUserReference{
+		Emails: emailSet,
+	}
+
+	results, err := db.GetRecentSubmissionSurvey(assignment, reference)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get recent submissions from db: '%w'.", err)
+	}
+
+	finalResults := make(map[string]*model.SubmissionHistoryItem, len(results))
+
+	for email, result := range results {
+		if result == nil {
+			continue
+		}
+
+		// The submission was made before the regrade threshold.
+		if result.GradingStartTime < proxyTime {
+			continue
+		}
+
+		finalResults[email] = result
+	}
+
+	return finalResults, nil
 }

--- a/internal/grader/regrade.go
+++ b/internal/grader/regrade.go
@@ -96,7 +96,7 @@ func Regrade(assignment *model.Assignment, options RegradeOptions) (*RegradeResu
 	for email, err := range output.WorkErrors {
 		workErrors[email] = err.Error()
 
-		logAttributes := make([]any, 3)
+		logAttributes := make([]any, 0, 3)
 		logAttributes = append([]any{err}, log.NewUserAttr(email))
 		logAttributes = append(logAttributes, log.NewAttr("job-id", output.ID))
 		log.Error("Failed to run regrade.", logAttributes...)
@@ -118,7 +118,7 @@ func performSingleRegrade(courseUsers map[string]*model.CourseUser, assignment *
 		return nil, fmt.Errorf("Cannot regrade an unknown user: '%s'.", email)
 	}
 
-	// Get the students most recent submission.
+	// Get the student's most recent submission.
 	previousResult, err := db.GetSubmissionContents(assignment, email, "")
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get most recent grading result for '%s': '%w'.", email, err)

--- a/internal/grader/regrade.go
+++ b/internal/grader/regrade.go
@@ -1,0 +1,85 @@
+package grader
+
+import (
+	"github.com/edulinq/autograder/internal/db"
+	"github.com/edulinq/autograder/internal/jobmanager"
+)
+
+type RegradeOptions struct {
+	jobmanager.JobOptions
+	GradeOptions
+
+	// The raw references of users to regrade.
+	RawReferences []CourseUserReferences `json:"target-users" required:""`
+
+	// If true, do not swap the context to the background context when running.
+	// By default (when this is false), the context will be swapped to the background context when !WaitForCompletion.
+	// The swap is so that regrade does not get canceled when an HTTP request is complete.
+	// Setting this true is useful for testing (as one round of analysis tests can be wrapped up).
+	RetainOriginalContext bool `json:"-"`
+
+	Assignment *model.Assignment `json:"-"`
+
+	ResolvedUsers []string `json:"-"`
+}
+
+func Regrade(options RegradeOptions) (map[string]*model.SubmissionHistoryItem, int, map[string]string, error) {
+	reference, err := ParseCourseUserReferences(options.RawReferences)
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("Failed to parse course user references: '%w'.", err)
+	}
+
+	fullUsers := model.ResolveCourseUserEmails(db.GetCourseUsers(options.Assignment.GetCourse().GetID(), reference))
+
+	if !options.RetainOriginalContext && !options.WaitForCompletion {
+		options.Context = context.Background()
+	}
+
+	job := jobmanager.Job[string, *model.IndividualAnalysis]{
+		JobOptions:              &options.JobOptions,
+		LockKey:                 fmt.Sprintf("regrade-course-%s", options.Assignment.GetCourse().GetID()),
+		PoolSize:                config.REGRADE_COURSE_POOL_SIZE.Get(),
+		ReturnIncompleteResults: !options.WaitForCompletion,
+		WorkItems:               fullUsers,
+		// TODO: Does this need to be modified to not include nil results? Guess: probably
+		RetrieveFunc: db.GetRecentSubmissionSurvey(options.Assignment, reference),
+		StoreFunc:    db.StoreIndividualAnalysis,
+		RemoveFunc:   db.RemoveIndividualAnalysis,
+		WorkFunc: func(fullSubmissionID string) (*model.IndividualAnalysis, error) {
+			return computeSingleIndividualAnalysis(options, fullSubmissionID, true)
+		},
+		WorkItemKeyFunc: func(fullSubmissionID string) string {
+			return fmt.Sprintf("analysis-individual-%s", fullSubmissionID)
+		},
+		OnComplete: func(result *jobmanager.JobOutput[string, *model.IndividualAnalysis]) {
+			if result == nil {
+				return
+			}
+
+			collectIndividualStats(fullSubmissionIDs, result.RunTime, options.InitiatorEmail)
+		},
+	}
+
+	err = job.Validate()
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("Failed to validate job: '%w'.", err)
+	}
+
+	output := job.Run()
+	if output.Error != nil {
+		return nil, 0, nil, fmt.Errorf("Failed to run regrade job '%s': '%w'.", output.ID, output.Error)
+	}
+
+	workErrors := make(map[string]string, len(output.WorkErrors))
+
+	for email, err := range output.WorkErrors {
+		workErrors[email] = err.Error()
+
+		logAttributes := make([]any, 3)
+		logAttributes = append([]any{err}, log.NewUserAttr(email))
+		logAttributes = append(logAttributes, log.NewAttr("job-id", output.ID))
+		log.Error("Failed to run regrade.", logAttributes...)
+	}
+
+	return output.ResultItems, len(output.RemainingItems), workErrors, nil
+}

--- a/internal/grader/regrade.go
+++ b/internal/grader/regrade.go
@@ -24,13 +24,13 @@ type RegradeOptions struct {
 	// If nil, the current time will be used.
 	RegradeAfter *timestamp.Timestamp `json:"regrade-after"`
 
+	Assignment *model.Assignment `json:"-"`
+
 	// If true, do not swap the context to the background context when running.
 	// By default (when this is false), the context will be swapped to the background context when !WaitForCompletion.
 	// The swap is so that regrade does not get canceled when an HTTP request is complete.
 	// Setting this true is useful for testing (as one round of analysis tests can be wrapped up).
 	RetainOriginalContext bool `json:"-"`
-
-	Assignment *model.Assignment `json:"-"`
 
 	ResolvedUsers []string `json:"-"`
 }
@@ -144,20 +144,14 @@ func computeSingleRegrade(options RegradeOptions, email string) (*model.Submissi
 			stderr = gradingResult.Stderr
 		}
 
-		log.Warn("Regrade submission failed internally.", err, log.NewAttr("stdout", stdout), log.NewAttr("stderr", stderr))
-
-		return nil, fmt.Errorf("Regrade submission failed internally.")
+		return nil, fmt.Errorf("Regrade submission failed internally: '%w'. Stdout: '%s', Stderr: '%s'.", err, stdout, stderr)
 	}
 
 	if reject != nil {
-		log.Debug("Regrade submission rejected.", log.NewAttr("reason", reject.String()))
-
 		return nil, fmt.Errorf("Regrade submission rejected: '%s'.", reject.String())
 	}
 
 	if failureMessage != "" {
-		log.Debug("Regrade submission got a soft error.", log.NewAttr("message", failureMessage))
-
 		return nil, fmt.Errorf("Regrade submission got a soft error: '%s'.", failureMessage)
 	}
 

--- a/internal/grader/regrade.go
+++ b/internal/grader/regrade.go
@@ -57,10 +57,6 @@ func Regrade(assignment *model.Assignment, options RegradeOptions) (*RegradeResu
 		options.Context = context.Background()
 	}
 
-	// TODO: We may want to return the regrade time!
-	// TODO: Think about what happens if they put a proxy time < regrade after.
-	// We will duplicate work on subsequent calls because the proxy time will be the submission time
-	// (so we will think work needs to be done again).
 	var regradeAfter timestamp.Timestamp = 0
 	if options.RegradeAfter == nil {
 		regradeAfter = timestamp.Now()

--- a/internal/grader/regrade_test.go
+++ b/internal/grader/regrade_test.go
@@ -108,35 +108,32 @@ func TestRegradeBase(test *testing.T) {
 			RetainOriginalContext: false,
 		}
 
-		results, regradeAfter, numLeft, workErrors, err := Regrade(assignment, options)
+		result, numLeft, err := Regrade(assignment, options)
 		if err != nil {
 			test.Errorf("Case %d: Failed to regrade submissions: '%v'.", i, err)
 			continue
 		}
 
-		if len(workErrors) != 0 {
-			test.Errorf("Case %d: Unexpected work errors during regrade: '%s'.", i, util.MustToJSONIndent(workErrors))
+		if len(result.WorkErrors) != 0 {
+			test.Errorf("Case %d: Unexpected work errors during regrade: '%s'.", i, util.MustToJSONIndent(result.WorkErrors))
 			continue
 		}
 
-		// TODO: Add a check for regradeAfter.
-		if regradeAfter == 0 {
-			continue
-		}
+		// TODO: Add a check for result.RegradeAfter.
 
 		if testCase.numLeft != numLeft {
 			test.Errorf("Case %d: Unexpected number of regrades remaining. Expected: '%d', actual: '%d'.", i, testCase.numLeft, numLeft)
 			continue
 		}
 
-		failed := CheckAndClearIDs(test, i, testCase.results, results)
+		failed := CheckAndClearIDs(test, i, testCase.results, result.Results)
 		if failed {
 			continue
 		}
 
-		if !reflect.DeepEqual(testCase.results, results) {
+		if !reflect.DeepEqual(testCase.results, result.Results) {
 			test.Errorf("Case %d: Unexpected regrade result. Expected: '%s', actual: '%s'.",
-				i, util.MustToJSONIndent(testCase.results), util.MustToJSONIndent(results))
+				i, util.MustToJSONIndent(testCase.results), util.MustToJSONIndent(result.Results))
 			continue
 		}
 	}

--- a/internal/grader/regrade_test.go
+++ b/internal/grader/regrade_test.go
@@ -22,7 +22,7 @@ const FAULTY_GRADER = `[[ $result -ne $expected ]]`
 func TestRegradeBase(test *testing.T) {
 	defer db.ResetForTesting()
 
-	// A time in the year 3003 which can be used for regrade tests that want a future RegradeAfter time.
+	// A time in the year 3003.
 	farFutureTime := timestamp.FromMSecs(32614181465000)
 
 	testCases := []struct {
@@ -277,12 +277,12 @@ func TestRegradeBase(test *testing.T) {
 
 		testSubmissions, err := GetTestSubmissions(bashSolutionDir, false)
 		if err != nil {
-			test.Errorf("Case %d: Error getting test submissions in '%s': '%v'.", i, baseDir, err)
+			test.Errorf("Case %d: Error getting test submissions in '%s': '%v'.", i, bashSolutionDir, err)
 			continue
 		}
 
 		if len(testSubmissions) != 1 {
-			test.Errorf("Case %d: Unexpected number of test submissions. Expected: '1', Actual: '%d' in '%s'.", i, len(testSubmissions), baseDir)
+			test.Errorf("Case %d: Unexpected number of test submissions in '%s'. Expected: '1', Actual: '%d'.", i, bashSolutionDir, len(testSubmissions))
 			continue
 		}
 
@@ -309,6 +309,7 @@ func TestRegradeBase(test *testing.T) {
 
 		// Insert a buggy line in the grader that will cause incorrect scoring.
 		bashGrader = strings.Replace(bashGrader, GOOD_GRADER, FAULTY_GRADER, 1)
+
 		err = util.WriteFile(bashGrader, bashGraderPath)
 		if err != nil {
 			test.Errorf("Case %d: Failed to write faulty grader: '%v'.", i, err)
@@ -355,7 +356,7 @@ func TestRegradeBase(test *testing.T) {
 
 		// Ensure there are not any more regrades running in the background.
 		if !testCase.waitForCompletion {
-			// Use the same regrade after time to continue the previous job.
+			// Use the same RegradeAfter time to continue the previous job.
 			options.RegradeAfter = &result.RegradeAfter
 			options.JobOptions.WaitForCompletion = true
 

--- a/internal/grader/regrade_test.go
+++ b/internal/grader/regrade_test.go
@@ -33,7 +33,9 @@ func TestRegradeBase(test *testing.T) {
 		regradeAfter       *timestamp.Timestamp
 		results            map[string]*model.SubmissionHistoryItem
 	}{
-		// User With Submission, Wait
+		// Wait For Completion
+
+		// User With Submission
 		{
 			[]model.CourseUserReference{"course-student@test.edulinq.org"},
 			[]string{"course-student@test.edulinq.org"},
@@ -51,17 +53,7 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
-		// User With Submission, No Wait
-		{
-			[]model.CourseUserReference{"course-student@test.edulinq.org"},
-			[]string{"course-student@test.edulinq.org"},
-			false,
-			1,
-			nil,
-			map[string]*model.SubmissionHistoryItem{},
-		},
-
-		// User Without Submission, Wait
+		// User Without Submission
 		{
 			[]model.CourseUserReference{"course-admin@test.edulinq.org"},
 			nil,
@@ -73,17 +65,7 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
-		// User Without Submission, No Wait
-		{
-			[]model.CourseUserReference{"course-admin@test.edulinq.org"},
-			nil,
-			false,
-			1,
-			nil,
-			map[string]*model.SubmissionHistoryItem{},
-		},
-
-		// Empty Users, Wait
+		// Empty Users
 		{
 			nil,
 			nil,
@@ -101,25 +83,7 @@ func TestRegradeBase(test *testing.T) {
 			map[string]*model.SubmissionHistoryItem{},
 		},
 
-		// Empty Users, No Wait
-		{
-			nil,
-			nil,
-			false,
-			0,
-			nil,
-			map[string]*model.SubmissionHistoryItem{},
-		},
-		{
-			[]model.CourseUserReference{},
-			nil,
-			false,
-			0,
-			nil,
-			map[string]*model.SubmissionHistoryItem{},
-		},
-
-		// All Users, Multiple Submissions, Wait
+		// All Users, Multiple Submissions
 		{
 			model.NewAllCourseUserReference(),
 			[]string{"course-student@test.edulinq.org", "course-admin@test.edulinq.org"},
@@ -147,17 +111,7 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
-		// All Users, Multiple Submissions, No Wait
-		{
-			model.NewAllCourseUserReference(),
-			[]string{"course-student@test.edulinq.org", "course-admin@test.edulinq.org"},
-			false,
-			5,
-			nil,
-			map[string]*model.SubmissionHistoryItem{},
-		},
-
-		// Some Users, Multiple Submissions, Wait
+		// Some Users, Multiple Submissions
 		{
 			[]model.CourseUserReference{"*", "-other", "-owner"},
 			[]string{"course-student@test.edulinq.org", "course-grader@test.edulinq.org"},
@@ -183,17 +137,7 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
-		// Some Users, Multiple Submissions, No Wait
-		{
-			[]model.CourseUserReference{"*", "-other", "-owner"},
-			[]string{"course-student@test.edulinq.org", "course-grader@test.edulinq.org"},
-			false,
-			3,
-			nil,
-			map[string]*model.SubmissionHistoryItem{},
-		},
-
-		// Regrade Time Before Submission, Wait
+		// Regrade Time Before Submission
 		{
 			[]model.CourseUserReference{"course-student@test.edulinq.org"},
 			[]string{"course-student@test.edulinq.org"},
@@ -212,26 +156,7 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
-		// Regrade Time Before Submission, No Wait
-		{
-			[]model.CourseUserReference{"course-student@test.edulinq.org"},
-			[]string{"course-student@test.edulinq.org"},
-			false,
-			0,
-			timestamp.ZeroPointer(),
-			map[string]*model.SubmissionHistoryItem{
-				"course-student@test.edulinq.org": &model.SubmissionHistoryItem{
-					CourseID:     "course-languages",
-					AssignmentID: "bash",
-					User:         "course-student@test.edulinq.org",
-					MaxPoints:    10,
-					// Note the full credit came from the original submission with the good grader.
-					Score: 10,
-				},
-			},
-		},
-
-		// Regrade Time Before Submission, Wait
+		// Regrade Time After Submission
 		{
 			[]model.CourseUserReference{"course-student@test.edulinq.org"},
 			[]string{"course-student@test.edulinq.org"},
@@ -249,7 +174,86 @@ func TestRegradeBase(test *testing.T) {
 			},
 		},
 
-		// Regrade Time Before Submission, No Wait
+		// No Wait For Completion
+
+		// User With Submission
+		{
+			[]model.CourseUserReference{"course-student@test.edulinq.org"},
+			[]string{"course-student@test.edulinq.org"},
+			false,
+			1,
+			nil,
+			map[string]*model.SubmissionHistoryItem{},
+		},
+
+		// User Without Submission
+		{
+			[]model.CourseUserReference{"course-admin@test.edulinq.org"},
+			nil,
+			false,
+			1,
+			nil,
+			map[string]*model.SubmissionHistoryItem{},
+		},
+
+		// Empty Users
+		{
+			nil,
+			nil,
+			false,
+			0,
+			nil,
+			map[string]*model.SubmissionHistoryItem{},
+		},
+		{
+			[]model.CourseUserReference{},
+			nil,
+			false,
+			0,
+			nil,
+			map[string]*model.SubmissionHistoryItem{},
+		},
+
+		// All Users, Multiple Submissions
+		{
+			model.NewAllCourseUserReference(),
+			[]string{"course-student@test.edulinq.org", "course-admin@test.edulinq.org"},
+			false,
+			5,
+			nil,
+			map[string]*model.SubmissionHistoryItem{},
+		},
+
+		// Some Users, Multiple Submissions
+		{
+			[]model.CourseUserReference{"*", "-other", "-owner"},
+			[]string{"course-student@test.edulinq.org", "course-grader@test.edulinq.org"},
+			false,
+			3,
+			nil,
+			map[string]*model.SubmissionHistoryItem{},
+		},
+
+		// Regrade Time Before Submission
+		{
+			[]model.CourseUserReference{"course-student@test.edulinq.org"},
+			[]string{"course-student@test.edulinq.org"},
+			false,
+			0,
+			timestamp.ZeroPointer(),
+			map[string]*model.SubmissionHistoryItem{
+				"course-student@test.edulinq.org": &model.SubmissionHistoryItem{
+					CourseID:     "course-languages",
+					AssignmentID: "bash",
+					User:         "course-student@test.edulinq.org",
+					MaxPoints:    10,
+					// Note the full credit came from the original submission with the good grader.
+					Score: 10,
+				},
+			},
+		},
+
+		// Regrade Time After Submission
 		{
 			[]model.CourseUserReference{"course-student@test.edulinq.org"},
 			[]string{"course-student@test.edulinq.org"},

--- a/internal/grader/regrade_test.go
+++ b/internal/grader/regrade_test.go
@@ -158,52 +158,10 @@ func TestRegradeBase(test *testing.T) {
 
 		// No Wait For Completion
 
-		// User With Submission
-		{
-			[]model.CourseUserReference{"course-student@test.edulinq.org"},
-			[]string{"course-student@test.edulinq.org"},
-			false,
-			1,
-			nil,
-			false,
-			map[string]*model.SubmissionHistoryItem{},
-		},
-
-		// User Without Submission
-		{
-			[]model.CourseUserReference{"course-admin@test.edulinq.org"},
-			nil,
-			false,
-			1,
-			nil,
-			false,
-			map[string]*model.SubmissionHistoryItem{},
-		},
-
-		// Empty Users
-		{
-			nil,
-			nil,
-			false,
-			0,
-			nil,
-			false,
-			map[string]*model.SubmissionHistoryItem{},
-		},
-		{
-			[]model.CourseUserReference{},
-			nil,
-			false,
-			0,
-			nil,
-			false,
-			map[string]*model.SubmissionHistoryItem{},
-		},
-
-		// All Users, Multiple Submissions
+		// All Users
 		{
 			model.NewAllCourseUserReference(),
-			[]string{"course-student@test.edulinq.org", "course-admin@test.edulinq.org"},
+			nil,
 			false,
 			5,
 			nil,
@@ -229,17 +187,6 @@ func TestRegradeBase(test *testing.T) {
 					Score: 10,
 				},
 			},
-		},
-
-		// Regrade Time After Submission
-		{
-			[]model.CourseUserReference{"course-student@test.edulinq.org"},
-			[]string{"course-student@test.edulinq.org"},
-			false,
-			1,
-			&farFutureTime,
-			false,
-			map[string]*model.SubmissionHistoryItem{},
 		},
 	}
 

--- a/internal/grader/regrade_test.go
+++ b/internal/grader/regrade_test.go
@@ -30,7 +30,7 @@ func TestRegradeBase(test *testing.T) {
 		initialSubmissions []string
 		waitForCompletion  bool
 		numLeft            int
-		regradeAfter       *timestamp.Timestamp
+		regradeCutoff      *timestamp.Timestamp
 		isCached           bool
 		results            map[string]*model.SubmissionHistoryItem
 	}{
@@ -251,7 +251,7 @@ func TestRegradeBase(test *testing.T) {
 				WaitForCompletion: testCase.waitForCompletion,
 			},
 			RawReferences:         testCase.users,
-			RegradeAfter:          testCase.regradeAfter,
+			RegradeCutoff:         testCase.regradeCutoff,
 			RetainOriginalContext: false,
 		}
 
@@ -286,8 +286,8 @@ func TestRegradeBase(test *testing.T) {
 
 		// Ensure there are not any more regrades running in the background.
 		if !testCase.waitForCompletion {
-			// Use the same RegradeAfter time to continue the previous job.
-			options.RegradeAfter = &result.RegradeAfter
+			// Use the same RegradeCutoff time to continue the previous job.
+			options.RegradeCutoff = result.Options.RegradeCutoff
 			options.JobOptions.WaitForCompletion = true
 
 			_, numLeft, err = Regrade(assignment, options)
@@ -304,7 +304,7 @@ func TestRegradeBase(test *testing.T) {
 	}
 }
 
-func TestRegradeSubmissionTime(test *testing.T) {
+func TestRegradeSubmissionCutoff(test *testing.T) {
 	earlyTime := timestamp.Zero()
 	futureTime := earlyTime + 10
 	middleTime := (futureTime + earlyTime) / 2
@@ -312,7 +312,7 @@ func TestRegradeSubmissionTime(test *testing.T) {
 	testCases := []struct {
 		gradingStartTime timestamp.Timestamp
 		proxyStartTime   *timestamp.Timestamp
-		regradeAfter     timestamp.Timestamp
+		regradeCutoff    timestamp.Timestamp
 		expected         bool
 	}{
 		// Normal Submissions, Submitted After Regrade Threshold
@@ -339,7 +339,7 @@ func TestRegradeSubmissionTime(test *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		result := isSubmittedBeforeRegradeTime(testCase.gradingStartTime, testCase.proxyStartTime, testCase.regradeAfter)
+		result := isSubmittedBeforeRegradeCutoff(testCase.gradingStartTime, testCase.proxyStartTime, testCase.regradeCutoff)
 		if result != testCase.expected {
 			test.Errorf("Case %d: Unexpected result. Expected: '%t', Actual: '%t'.", i, testCase.expected, result)
 			continue

--- a/internal/grader/regrade_test.go
+++ b/internal/grader/regrade_test.go
@@ -105,11 +105,10 @@ func TestRegradeBase(test *testing.T) {
 			RawReferences: testCase.users,
 			// TODO: Make this a test case field.
 			RegradeAfter:          nil,
-			Assignment:            assignment,
 			RetainOriginalContext: false,
 		}
 
-		results, numLeft, workErrors, err := Regrade(options)
+		results, regradeAfter, numLeft, workErrors, err := Regrade(assignment, options)
 		if err != nil {
 			test.Errorf("Case %d: Failed to regrade submissions: '%v'.", i, err)
 			continue
@@ -117,6 +116,11 @@ func TestRegradeBase(test *testing.T) {
 
 		if len(workErrors) != 0 {
 			test.Errorf("Case %d: Unexpected work errors during regrade: '%s'.", i, util.MustToJSONIndent(workErrors))
+			continue
+		}
+
+		// TODO: Add a check for regradeAfter.
+		if regradeAfter == 0 {
 			continue
 		}
 

--- a/internal/grader/regrade_test.go
+++ b/internal/grader/regrade_test.go
@@ -391,24 +391,32 @@ func TestDummyPrep(test *testing.T) {
 	db.ResetForTesting()
 
 	// tempDir, err := util.MkDirTemp("regrade-grading-dir-")
-	tempDir, inputDir, _, workDir, err := common.PrepTempGradingDir("regrade-grading-dir-")
+	tempDir, inputDir, _, _, err := common.PrepTempGradingDir("regrade-grading-dir")
 	if err != nil {
 		test.Fatalf("Failed to create temp dir for grading: '%v'.", err)
 	}
 	defer util.RemoveDirent(tempDir)
 
-	dummyAssignment := loadDummyAssignment(tempDir, test)
-
-	err = util.WriteFile(DUMMY_ASSIGNMENT_CONFIG, filepath.Join(workDir, "assignment.json"))
-	if err != nil {
-		test.Fatalf("Failed to write dummy assignment.json: '%v'.", err)
-	}
-
 	faultyGrader := BASE_GRADER + FAULTY_GRADER
-	err = util.WriteFile(faultyGrader, filepath.Join(workDir, "grader.sh"))
+	err = util.WriteFile(faultyGrader, filepath.Join(tempDir, "grader.sh"))
 	if err != nil {
 		test.Fatalf("Failed to write faulty grader: '%v'.", err)
 	}
+
+	paths, err := util.GetAllDirents(tempDir, false, false)
+	if err != nil {
+		test.Fatalf("Failed to get dirents: '%v'.", err)
+	}
+	fmt.Fprintf(os.Stderr, "found the following paths: '%v'.", util.MustToJSONIndent(paths))
+
+	dummyAssignment := loadDummyAssignment(tempDir, test)
+
+	/*
+		err = util.WriteFile(DUMMY_ASSIGNMENT_CONFIG, filepath.Join(workDir, "assignment.json"))
+		if err != nil {
+			test.Fatalf("Failed to write dummy assignment.json: '%v'.", err)
+		}
+	*/
 
 	err = util.WriteFile(SUBMISSION, filepath.Join(inputDir, "assignment.sh"))
 	if err != nil {

--- a/internal/grader/regrade_test.go
+++ b/internal/grader/regrade_test.go
@@ -1,0 +1,139 @@
+package grader
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/edulinq/autograder/internal/db"
+	"github.com/edulinq/autograder/internal/docker"
+	"github.com/edulinq/autograder/internal/jobmanager"
+	"github.com/edulinq/autograder/internal/model"
+	"github.com/edulinq/autograder/internal/util"
+)
+
+func TestRegradeBase(test *testing.T) {
+	docker.EnsureOrSkipForTest(test)
+
+	defer db.ResetForTesting()
+
+	// Note that computation of these paths are deferred until test time.
+	studentGradingResults := map[string]*model.GradingResult{
+		"1697406272": model.MustLoadGradingResult(getTestSubmissionResultPath("1697406272")),
+	}
+
+	testCases := []struct {
+		users             []model.CourseUserReference
+		waitForCompletion bool
+		numLeft           int
+		results           map[string]*model.SubmissionHistoryItem
+	}{
+		// User With Submission, Wait
+		{
+			[]model.CourseUserReference{"course-student@test.edulinq.org"},
+			true,
+			0,
+			map[string]*model.SubmissionHistoryItem{
+				"course-student@test.edulinq.org": studentGradingResults["1697406272"].Info.ToHistoryItem(),
+			},
+		},
+
+		// Empty Users, Wait
+		{
+			[]model.CourseUserReference{},
+			true,
+			0,
+			map[string]*model.SubmissionHistoryItem{},
+		},
+
+		// Empty Submissions, Wait
+		{
+			[]model.CourseUserReference{"course-admin@test.edulinq.org"},
+			true,
+			0,
+			map[string]*model.SubmissionHistoryItem{
+				"course-admin@test.edulinq.org": nil,
+			},
+		},
+
+		// User With Submission, No Wait
+		{
+			[]model.CourseUserReference{"course-student@test.edulinq.org"},
+			false,
+			1,
+			map[string]*model.SubmissionHistoryItem{},
+		},
+
+		// Empty Users, No Wait
+		{
+			nil,
+			false,
+			0,
+			map[string]*model.SubmissionHistoryItem{},
+		},
+		{
+			[]model.CourseUserReference{},
+			false,
+			0,
+			map[string]*model.SubmissionHistoryItem{},
+		},
+		{
+			[]model.CourseUserReference{"-*"},
+			false,
+			0,
+			map[string]*model.SubmissionHistoryItem{},
+		},
+
+		// Empty Submission, No Wait
+		{
+			[]model.CourseUserReference{"course-admin@test.edulinq.org"},
+			false,
+			1,
+			map[string]*model.SubmissionHistoryItem{},
+		},
+	}
+
+	assignment := db.MustGetTestAssignment()
+
+	for i, testCase := range testCases {
+		db.ResetForTesting()
+
+		options := RegradeOptions{
+			GradeOptions: GetDefaultGradeOptions(),
+			JobOptions: jobmanager.JobOptions{
+				WaitForCompletion: testCase.waitForCompletion,
+			},
+			RawReferences: testCase.users,
+			// TODO: Make this a test case field.
+			RegradeAfter:          nil,
+			Assignment:            assignment,
+			RetainOriginalContext: false,
+		}
+
+		results, numLeft, workErrors, err := Regrade(options)
+		if err != nil {
+			test.Errorf("Case %d: Failed to regrade submissions: '%v'.", i, err)
+			continue
+		}
+
+		if len(workErrors) != 0 {
+			test.Errorf("Case %d: Unexpected work errors during regrade: '%s'.", i, util.MustToJSONIndent(workErrors))
+			continue
+		}
+
+		if testCase.numLeft != numLeft {
+			test.Errorf("Case %d: Unexpected number of regrades remaining. Expected: '%d', actual: '%d'.", i, testCase.numLeft, numLeft)
+			continue
+		}
+
+		failed := CheckAndClearIDs(test, i, testCase.results, results)
+		if failed {
+			continue
+		}
+
+		if !reflect.DeepEqual(testCase.results, results) {
+			test.Errorf("Case %d: Unexpected regrade result. Expected: '%s', actual: '%s'.",
+				i, util.MustToJSONIndent(testCase.results), util.MustToJSONIndent(results))
+			continue
+		}
+	}
+}

--- a/internal/grader/test.go
+++ b/internal/grader/test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"testing"
 
 	"github.com/edulinq/autograder/internal/config"
 	"github.com/edulinq/autograder/internal/db"
@@ -72,50 +71,6 @@ func GetTestSubmissions(baseDir string, useDocker bool) ([]*TestSubmissionInfo, 
 	}
 
 	return testSubmissions, nil
-}
-
-func CheckAndClearIDs(test *testing.T, i int, expectedResults map[string]*model.SubmissionHistoryItem, actualResults map[string]*model.SubmissionHistoryItem) bool {
-	for user, expected := range expectedResults {
-		actual, ok := actualResults[user]
-		if !ok {
-			test.Errorf("Case %d: Unable to find result for user '%s'. Expected: '%v'.",
-				i, user, util.MustToJSONIndent(expected))
-			return true
-		}
-
-		if (expected == nil) && (actual == nil) {
-			continue
-		}
-
-		if expected == nil {
-			test.Errorf("Case %d: Unexpected result for user '%s'. Expected: '<nil>', actual: '%s'.",
-				i, user, util.MustToJSONIndent(actual))
-			return true
-		}
-
-		if actual == nil {
-			test.Errorf("Case %d: Unexpected result for user '%s'. Expected: '%s', actual: '<nil>'.",
-				i, user, util.MustToJSONIndent(expected))
-			return true
-		}
-
-		if expected.ShortID == actual.ShortID {
-			test.Errorf("Case %d: Regrade submission has the same short ID as the previous submission: '%s'.", i, expected.ShortID)
-			return true
-		}
-
-		if expected.ID == actual.ID {
-			test.Errorf("Case %d: Regrade submission has the same ID as the previous submission: '%s'.", i, expected.ID)
-			return true
-		}
-
-		actual.ShortID = ""
-		expected.ShortID = ""
-		actual.ID = ""
-		expected.ID = ""
-	}
-
-	return false
 }
 
 // Test submission are within their assignment's directory,

--- a/resources/api.json
+++ b/resources/api.json
@@ -573,7 +573,7 @@
                     "description": "Remove any existing records before running the job."
                 },
                 {
-                    "name": "regrade-after",
+                    "name": "regrade-cutoff",
                     "type": "int64",
                     "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
                 },
@@ -609,10 +609,6 @@
                 {
                     "name": "options",
                     "type": "grader.RegradeOptions"
-                },
-                {
-                    "name": "regrade-after",
-                    "type": "int64"
                 },
                 {
                     "name": "resolved-users",
@@ -2032,7 +2028,7 @@
                     "description": "Remove any existing records before running the job."
                 },
                 {
-                    "name": "regrade-after",
+                    "name": "regrade-cutoff",
                     "type": "int64",
                     "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
                 },

--- a/resources/api.json
+++ b/resources/api.json
@@ -580,7 +580,7 @@
                 {
                     "name": "target-users",
                     "type": "[]model.CourseUserReference",
-                    "description": "The raw references of users to regrade.",
+                    "description": "The raw course user references to regrade.",
                     "required": true
                 },
                 {
@@ -2039,7 +2039,7 @@
                 {
                     "name": "target-users",
                     "type": "[]model.CourseUserReference",
-                    "description": "The raw references of users to regrade."
+                    "description": "The raw course user references to regrade."
                 },
                 {
                     "name": "wait-for-completion",

--- a/resources/api.json
+++ b/resources/api.json
@@ -547,6 +547,87 @@
                 }
             ]
         },
+        "courses/assignments/submissions/proxy/regrade": {
+            "description": "Proxy regrade an assignment for all target users using their most recent submission.",
+            "input": [
+                {
+                    "name": "assignment-id",
+                    "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
+                    "required": true
+                },
+                {
+                    "name": "course-id",
+                    "type": "string",
+                    "description": "The ID of the course to make this request to.",
+                    "required": true
+                },
+                {
+                    "name": "dry-run",
+                    "type": "bool",
+                    "description": "Don't save anything."
+                },
+                {
+                    "name": "overwrite-records",
+                    "type": "bool",
+                    "description": "Remove any existing records before running the job."
+                },
+                {
+                    "name": "regrade-after",
+                    "type": "int64",
+                    "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
+                },
+                {
+                    "name": "target-users",
+                    "type": "[]model.CourseUserReference",
+                    "description": "The raw references of users to regrade.",
+                    "required": true
+                },
+                {
+                    "name": "user-email",
+                    "type": "string",
+                    "description": "The email of the user making this request.",
+                    "required": true
+                },
+                {
+                    "name": "user-pass",
+                    "type": "string",
+                    "description": "The password of the user making this request.",
+                    "required": true
+                },
+                {
+                    "name": "wait-for-completion",
+                    "type": "bool",
+                    "description": "Wait for the entire job to complete and return all results."
+                }
+            ],
+            "output": [
+                {
+                    "name": "complete",
+                    "type": "bool"
+                },
+                {
+                    "name": "options",
+                    "type": "grader.RegradeOptions"
+                },
+                {
+                    "name": "regrade-after",
+                    "type": "int64"
+                },
+                {
+                    "name": "resolved-users",
+                    "type": "[]string"
+                },
+                {
+                    "name": "results",
+                    "type": "map[string]*model.SubmissionHistoryItem"
+                },
+                {
+                    "name": "work-errors",
+                    "type": "map[string]string"
+                }
+            ]
+        },
         "courses/assignments/submissions/proxy/resubmit": {
             "description": "Proxy resubmit an assignment submission to the autograder.",
             "input": [
@@ -1933,6 +2014,36 @@
                 {
                     "name": "updated",
                     "type": "bool"
+                }
+            ]
+        },
+        "grader.RegradeOptions": {
+            "category": "struct",
+            "fields": [
+                {
+                    "name": "dry-run",
+                    "type": "bool",
+                    "description": "Don't save anything."
+                },
+                {
+                    "name": "overwrite-records",
+                    "type": "bool",
+                    "description": "Remove any existing records before running the job."
+                },
+                {
+                    "name": "regrade-after",
+                    "type": "int64",
+                    "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
+                },
+                {
+                    "name": "target-users",
+                    "type": "[]model.CourseUserReference",
+                    "description": "The raw references of users to regrade."
+                },
+                {
+                    "name": "wait-for-completion",
+                    "type": "bool",
+                    "description": "Wait for the entire job to complete and return all results."
                 }
             ]
         },


### PR DESCRIPTION
This PR adds a new API endpoint `courses/assignment/submissions/proxy/regrade` that allows course graders (or above) to make mass proxy regrades based on a course user references.

Regrades take the most recent submission for every user with the raw references and resubmit with a proxy time that is the same time as the original submission. This features allows course staff to easily regrade every students (or another role's) submissions.

Users are given the option to specify a `regrade-after` time, which means all users must have a new submission made after the target time. If a time is not provided, the current time is used. This semantic allows for better regrade caching.

As regrades may take a long time (as there could be many students), the endpoint gives the option to wait for completion. If the requesting user does not wait for completion, the results will be available by looking at the submission history or calling regrade with the same `regrade-after` time.

Note that this PR is a new version #170. The old PR will remain open as a reference until this PR is merged.