### PR TITLE
Corrected API error types to give back bad requests when appropriate.

### DIFF
--- a/internal/api/courses/assignments/submissions/proxy/regrade.go
+++ b/internal/api/courses/assignments/submissions/proxy/regrade.go
@@ -40,7 +40,7 @@ func HandleRegrade(request *RegradeRequest) (*RegradeResponse, *core.APIError) {
 	}
 
 	if userErr != nil {
-		return nil, core.NewBadRequestError("-639", request, "Failed to regrade the assignment for the target users.").Err(userErr)
+		return nil, core.NewBadRequestError("-640", request, "Failed to regrade the assignment for the target users.").Err(userErr)
 	}
 
 	response := RegradeResponse{

--- a/internal/api/courses/assignments/submissions/proxy/regrade.go
+++ b/internal/api/courses/assignments/submissions/proxy/regrade.go
@@ -34,9 +34,13 @@ func HandleRegrade(request *RegradeRequest) (*RegradeResponse, *core.APIError) {
 	request.RegradeOptions.GradeOptions = gradeOptions
 	request.RegradeOptions.Context = request.APIRequestUserContext.Context
 
-	result, numRemaining, err := grader.Regrade(request.Assignment, request.RegradeOptions)
-	if err != nil {
-		return nil, core.NewInternalError("-638", request, "Failed to regrade the assignment for the target users.").Err(err)
+	result, numRemaining, userErr, internalErr := grader.Regrade(request.Assignment, request.RegradeOptions)
+	if internalErr != nil {
+		return nil, core.NewInternalError("-638", request, "Failed to regrade the assignment for the target users.").Err(internalErr)
+	}
+
+	if userErr != nil {
+		return nil, core.NewBadRequestError("-639", request, "Failed to regrade the assignment for the target users.").Err(userErr)
 	}
 
 	response := RegradeResponse{

--- a/internal/api/courses/assignments/submissions/proxy/regrade_test.go
+++ b/internal/api/courses/assignments/submissions/proxy/regrade_test.go
@@ -223,7 +223,7 @@ func TestRegradeBase(test *testing.T) {
 				RawReferences: []model.CourseUserReference{"ZZZ"},
 			},
 			"course-admin",
-			"-638",
+			"-639",
 			RegradeResponse{},
 		},
 		{
@@ -234,7 +234,7 @@ func TestRegradeBase(test *testing.T) {
 				RawReferences: []model.CourseUserReference{"ZZZ"},
 			},
 			"course-admin",
-			"-638",
+			"-639",
 			RegradeResponse{},
 		},
 

--- a/internal/api/courses/assignments/submissions/proxy/regrade_test.go
+++ b/internal/api/courses/assignments/submissions/proxy/regrade_test.go
@@ -223,7 +223,7 @@ func TestRegradeBase(test *testing.T) {
 				RawReferences: []model.CourseUserReference{"ZZZ"},
 			},
 			"course-admin",
-			"-639",
+			"-640",
 			RegradeResponse{},
 		},
 		{
@@ -234,7 +234,7 @@ func TestRegradeBase(test *testing.T) {
 				RawReferences: []model.CourseUserReference{"ZZZ"},
 			},
 			"course-admin",
-			"-639",
+			"-640",
 			RegradeResponse{},
 		},
 

--- a/internal/api/users/list.go
+++ b/internal/api/users/list.go
@@ -31,7 +31,7 @@ func HandleList(request *ListRequest) (*ListResponse, *core.APIError) {
 
 	reference, err := model.ParseServerUserReferences(request.TargetUsers, courses)
 	if err != nil {
-		return nil, core.NewInternalError("-815", request, "Failed to parse target users.").Err(err)
+		return nil, core.NewBadRequestError("-815", request, "Failed to parse target users.").Err(err)
 	}
 
 	usersMap, err := db.GetServerUsers()

--- a/internal/grader/regrade_test.go
+++ b/internal/grader/regrade_test.go
@@ -255,9 +255,14 @@ func TestRegradeBase(test *testing.T) {
 			RetainOriginalContext: false,
 		}
 
-		result, numLeft, err := Regrade(assignment, options)
-		if err != nil {
-			test.Errorf("Case %d: Failed to regrade submissions: '%v'.", i, err)
+		result, numLeft, userErr, internalErr := Regrade(assignment, options)
+		if internalErr != nil {
+			test.Errorf("Case %d: Failed internally to regrade submissions: '%v'.", i, internalErr)
+			continue
+		}
+
+		if userErr != nil {
+			test.Errorf("Case %d: Failed to regrade submissions: '%v'.", i, userErr)
 			continue
 		}
 
@@ -290,9 +295,14 @@ func TestRegradeBase(test *testing.T) {
 			options.RegradeCutoff = result.Options.RegradeCutoff
 			options.JobOptions.WaitForCompletion = true
 
-			_, numLeft, err = Regrade(assignment, options)
-			if err != nil {
-				test.Errorf("Case %d: Failed to complete cleanup regrade: '%v'.", i, err)
+			_, numLeft, userErr, internalErr = Regrade(assignment, options)
+			if internalErr != nil {
+				test.Errorf("Case %d: Failed to complete cleanup regrade: '%v'.", i, internalErr)
+				continue
+			}
+
+			if userErr != nil {
+				test.Errorf("Case %d: Failed to complete cleanup regrade: '%v'.", i, userErr)
 				continue
 			}
 


### PR DESCRIPTION
This PR corrects some API error types to be bad request errors. This helps users get a better understanding of their issue without having to contact the server administrator.